### PR TITLE
Exporting controller&slaves logs to .lrc files

### DIFF
--- a/lnst/Common/LoggingHandler.py
+++ b/lnst/Common/LoggingHandler.py
@@ -85,3 +85,15 @@ class TransmitHandler(logging.Handler):
 
     def close(self):
         logging.Handler.close(self)
+
+
+class ExportHandler(logging.Handler):
+    def __init__(self, logs):
+        logging.Handler.__init__(self)
+        self._log_list = logs
+
+    def emit(self, record):
+        self._log_list.append(record)
+
+    def close(self):
+        logging.Handler.close(self)

--- a/lnst/Common/Logs.py
+++ b/lnst/Common/Logs.py
@@ -13,7 +13,7 @@ import os, sys, shutil
 from logging import Formatter
 import logging.handlers
 import traceback
-from lnst.Common.LoggingHandler import TransmitHandler
+from lnst.Common.LoggingHandler import TransmitHandler, ExportHandler
 from lnst.Common.Colours import decorate_with_preset, strip_colours
 
 def log_exc_traceback():
@@ -95,11 +95,13 @@ class MultilineFormatter(Formatter): # addr:17 level:7
 class LoggingCtl:
     log_folder = ""
     display_handler = None
+    export_handler = None
     recipe_handlers = (None,None)
     recipe_log_path = ""
     slaves = {}
     transmit_handler = None
     _id_seq = 0
+    log_list = {}
 
     def __init__(self, debug=False, log_dir=None, log_subdir="", colours=True):
         #clear any previously set handlers
@@ -127,6 +129,12 @@ class LoggingCtl:
         #the display_handler will display logs in the terminal
         self.display_handler = logging.StreamHandler(sys.stdout)
         self.display_handler.setFormatter(MultilineFormatter(colours))
+
+        # the export_handler will add log messages to lists, so it could be exported to .lrc file
+        self.log_list["controller"] = []
+        self.export_handler = self._create_export_handler(self.log_list["controller"], colours)
+        self.export_handler.setLevel(logging.DEBUG)
+
         if not debug:
             self.display_handler.setLevel(logging.INFO)
         else:
@@ -138,9 +146,11 @@ class LoggingCtl:
         logger = logging.getLogger()
         logger.setLevel(logging.NOTSET)
         logger.addHandler(self.display_handler)
+        logger.addHandler(self.export_handler)
 
     def unset_formatter(self):
         self.display_handler.setFormatter(None)
+        self.export_handler.setFormatter(None)
 
     def _gen_index(self, increment=True):
         if increment:
@@ -190,7 +200,11 @@ class LoggingCtl:
         logger.addHandler(slave_info)
         logger.addHandler(slave_debug)
 
-        self.slaves[slave_id] = (slave_info, slave_debug)
+        self.log_list[slave_id] = []
+        export_handler = self._create_export_handler(self.log_list[slave_id])
+        logger.addHandler(export_handler)
+
+        self.slaves[slave_id] = (slave_info, slave_debug, export_handler)
 
     def remove_slave(self, slave_id):
         logger = logging.getLogger(slave_id)
@@ -198,6 +212,7 @@ class LoggingCtl:
 
         logger.removeHandler(self.slaves[slave_id][0])
         logger.removeHandler(self.slaves[slave_id][1])
+        logger.removeHandler(self.slaves[slave_id][2])
 
         del self.slaves[slave_id]
 
@@ -236,7 +251,9 @@ class LoggingCtl:
         self.unset_recipe()
         logger = logging.getLogger()
         logger.removeHandler(self.display_handler)
+        logger.removeHandler(self.export_handler)
         self.display_handler = None
+        self.export_handler = None
 
     def _clean_folder(self, path):
         try:
@@ -257,8 +274,17 @@ class LoggingCtl:
 
         return (file_debug, file_info)
 
+    def _create_export_handler(self, target: list, colours: bool = False):
+        export_handler = ExportHandler(target)
+        export_handler.setFormatter(MultilineFormatter(colours))
+
+        return export_handler
+
     def get_recipe_log_path(self):
         return self.recipe_log_path
+
+    def get_recipe_log_list(self):
+        return self.log_list
 
     def set_origin_name(self, name):
         self._origin_name = name

--- a/lnst/Controller/Controller.py
+++ b/lnst/Controller/Controller.py
@@ -156,7 +156,8 @@ class Controller(object):
                 logging.info(line)
             try:
                 self._map_match(match, req, recipe)
-                recipe._init_run(RecipeRun(recipe, match, log_dir=self._log_ctl.get_recipe_log_path()))
+                recipe._init_run(RecipeRun(recipe, match, log_dir=self._log_ctl.get_recipe_log_path(),
+                                           log_list=self._log_ctl.get_recipe_log_list()))
                 recipe.test()
             except Exception as exc:
                 logging.error("Recipe execution terminated by unexpected exception")

--- a/lnst/Controller/Recipe.py
+++ b/lnst/Controller/Recipe.py
@@ -163,11 +163,12 @@ class BaseRecipe(object):
 
 
 class RecipeRun(object):
-    def __init__(self, recipe: BaseRecipe, match, desc=None, log_dir=None):
+    def __init__(self, recipe: BaseRecipe, match, desc=None, log_dir=None, log_list=None):
         self._match = match
         self._desc = desc
         self._results = []
         self._log_dir = log_dir
+        self._log_list = log_list
         self._recipe = recipe
         self._datetime = datetime.datetime.now()
         self._environ = os.environ.copy()
@@ -194,6 +195,10 @@ class RecipeRun(object):
     @property
     def log_dir(self):
         return self._log_dir
+
+    @property
+    def log_list(self):
+        return self._log_list
 
     @property
     def match(self):


### PR DESCRIPTION
Description:
Added lists of log messages from controller and all the slaves to exported `.lrc` files.

Exported `.lrc` files could be imported using `lnst.Controller.Recipe.import_recipe_run()` function.
After that logs could be found in `RecipeRun.log_list["controller"]` and `RecipeRun.log_list[SLAVE_ID]` lists.

Example:
```
from lnst.Controller.Recipe import import_recipe_run
from runner import HelloWorldRecipe

run = import_recipe_run("HelloWorldRecipe-run-2021-06-23_22:07:23.lrc")
print(run.log_list)

>>> {"controller": [<LogRecord: root, 20, /home/sdobron/rh/forked/lnst/lnst/Controller/SlavePoolManager.py, 49, "Checking machine pool availability.">, ...]
"machine1": [<LogRecord: root, 20, /root/lnst/lnst/Slave/NetTestSlave.py, 410, "Performing machine cleanup.">, ...]}
```

Reviews: 
@olichtne @jtluka 