### PR TITLE
lnst: add pkgutil style namespace packages

### DIFF
--- a/install/lnst-slave.service
+++ b/install/lnst-slave.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/lnst-slave
+ExecStart=/usr/local/bin/lnst-slave
 StandardOutput=null
 
 [Install]

--- a/lnst/__init__.py
+++ b/lnst/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lnst"
-version = "15.8.0"
+version = "16.0.0"
 homepage = "http://lnst-project.org"
 license = "GPL-2.0-or-later"
 readme = "README.md"
@@ -17,7 +17,7 @@ packages = [
 include = ["lnst_slave_cli.py", "schema-sm.rng", "install/*", "lnst-ctl.conf", "lnst-slave.conf"]
 
 [tool.poetry.dependencies]
-python = "*"
+python = "^3.6"
 
 pyroute2 = "*"
 pyyaml = "*"


### PR DESCRIPTION
Description:
Removing top level init that was redundant and not used.

Updating the pyproject.toml, bumping project
version to 16 and python version to 3.6 and higher
to speed up installation.

Whenever LNST was installed as a dependent project
poetry was unable to stitch together multiple
packages and their modules.
Easiest solution is to update paths accordingly [0].

[0] - https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages

Tests:
J:5614799

Reviews: 
@olichtne @jtluka 