### PR TITLE
Evaluating flows in BaseFlowMeasurement and fixed evaluating infinity in NonzeroFlowEvaluator

### DIFF
--- a/lnst/RecipeCommon/Perf/Evaluators/NonzeroFlowEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/NonzeroFlowEvaluator.py
@@ -34,7 +34,15 @@ class NonzeroFlowEvaluator(BaseResultEvaluator):
             for metric_name in self._metrics_to_evaluate:
                 metric = getattr(flow_results, metric_name, None)
                 if metric:
-                    if metric.average > 0:
+                    if metric.average == float("inf"):
+                        result = False
+                        result_text.append(
+                            "{} reported invalid value: {}".format(
+                                metric_name,
+                                metric.average
+                            )
+                        )
+                    elif metric.average > 0:
                         result_text.append(
                             "{} reported non-zero throughput".format(
                                 metric_name


### PR DESCRIPTION
Description:  
Replaced hardcoded result pass with evaluating in `BaseFlowMeasurement._report_flow_results()` to correctly evaluating flows with invalid duration.  
Fixed evaluating `inf` as valid passed result in `NonzeroFlowEvaluator.evaluate_results()`.

Reviews:  
@Axonis @olichtne @jtluka 