### PR TITLE
Add optional parameters for VLAN IDs

### DIFF
--- a/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
@@ -5,7 +5,7 @@ from lnst.Common.IpAddress import (
     Ip4Address,
     Ip6Address,
 )
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import Param, IntParam
 from lnst.Devices import GreDevice, VlanDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
@@ -63,7 +63,7 @@ class GreTunnelOverVlanRecipe(
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
     host2.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(
         default=(

--- a/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
@@ -63,6 +63,8 @@ class GreTunnelOverVlanRecipe(
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
     host2.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(
         default=(
             dict(gro="on", gso="on", tso="on"),
@@ -80,22 +82,22 @@ class GreTunnelOverVlanRecipe(
         """
         host1, host2 = self.matched.host1, self.matched.host2
 
-        host1.vlan10 = VlanDevice(realdev=host1.eth0, vlan_id=10)
-        host2.vlan10 = VlanDevice(realdev=host2.eth0, vlan_id=10)
+        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_id)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
-        for i, device in enumerate([host1.vlan10, host2.vlan10]):
+        for i, device in enumerate([host1.vlan0, host2.vlan0]):
             device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
             configuration.test_wide_devices.append(device)
 
         for dev in [
             host1.eth0,
-            host1.vlan10,
+            host1.vlan0,
             host2.eth0,
-            host2.vlan10,
+            host2.vlan0,
         ]:
             dev.up()
 
-        configuration.tunnel_endpoints = (host1.vlan10, host2.vlan10)
+        configuration.tunnel_endpoints = (host1.vlan0, host2.vlan0)
 
     def create_tunnel(self, configuration):
         """
@@ -160,8 +162,8 @@ class GreTunnelOverVlanRecipe(
         and grep patterns to match the ICMP or ICMP6 echo requests.
         """
         ip_filter = {"family": AF_INET}
-        m1_carrier = self.matched.host1.vlan10
-        m2_carrier = self.matched.host2.vlan10
+        m1_carrier = self.matched.host1.vlan0
+        m2_carrier = self.matched.host2.vlan0
         m1_carrier_ip = m1_carrier.ips_filter(**ip_filter)[0]
         m2_carrier_ip = m2_carrier.ips_filter(**ip_filter)[0]
 

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
@@ -27,6 +27,8 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -47,8 +49,8 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         guest1.eth0.down()
         guest2.eth0.down()
 
-        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=10)
-        guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=10)
+        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
+        guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=self.params.vlan_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [guest1.vlan0, guest2.vlan0,

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
@@ -1,5 +1,5 @@
 import logging
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import Param, IntParam
 from lnst.Common.IpAddress import ipaddress
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
@@ -27,7 +27,7 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
@@ -24,7 +24,7 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
@@ -24,6 +24,8 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -43,8 +45,8 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         host2.eth0.down()
         guest1.eth0.down()
 
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=10)
-        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=10)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
+        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [guest1.vlan0, host1.br0,

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
@@ -1,5 +1,5 @@
 import logging
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import Param, IntParam
 from lnst.Common.IpAddress import ipaddress
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
@@ -27,7 +27,7 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
@@ -27,6 +27,8 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -47,9 +49,9 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         guest1.eth0.down()
         guest2.eth0.down()
 
-        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=10,
+        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_id,
             master=host1.br0)
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=10,
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id,
             master=host2.br0)
 
         configuration = super().test_wide_configuration()

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
@@ -22,6 +22,8 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -42,9 +44,9 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         guest1.eth0.down()
 
         host1_vlan_args0 = dict()
-        host2_vlan_args0 = dict(realdev=host2.eth0, vlan_id=10)
+        host2_vlan_args0 = dict(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
-        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=10,
+        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_id,
             master=host1.br0)
         host2.vlan0 = VlanDevice(**host2_vlan_args0)
 

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
@@ -22,7 +22,7 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
@@ -43,12 +43,9 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         host2.eth0.down()
         guest1.eth0.down()
 
-        host1_vlan_args0 = dict()
-        host2_vlan_args0 = dict(realdev=host2.eth0, vlan_id=self.params.vlan_id)
-
         host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_id,
             master=host1.br0)
-        host2.vlan0 = VlanDevice(**host2_vlan_args0)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [guest1.eth0, host2.vlan0,

--- a/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
@@ -40,6 +40,8 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
     guest4 = HostReq()
     guest4.eth0 = DeviceReq(label="to_guest4")
 
+    vlan_ids = Param(default=[10, 20])
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
         dict(gro="off", gso="on", tso="on", tx="on"),
@@ -69,13 +71,13 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         for guest in (guest1, guest2, guest3, guest4):
             guest.eth0.down()
 
-        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=10,
+        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[0],
             master=host1.br0)
-        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=20,
+        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[1],
             master=host1.br1)
-        host2.vlan0 = VlanDevice(realdev=host2.bond0, vlan_id=10,
+        host2.vlan0 = VlanDevice(realdev=host2.bond0, vlan_id=self.params.vlan_ids[0],
             master=host2.br0)
-        host2.vlan1 = VlanDevice(realdev=host2.bond0, vlan_id=20,
+        host2.vlan1 = VlanDevice(realdev=host2.bond0, vlan_id=self.params.vlan_ids[1],
             master=host2.br1)
 
         configuration = super().test_wide_configuration()

--- a/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
@@ -40,7 +40,8 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
     guest4 = HostReq()
     guest4.eth0 = DeviceReq(label="to_guest4")
 
-    vlan_ids = Param(default=[10, 20])
+    vlan0_id = IntParam(default=10)
+    vlan1_id = IntParam(default=20)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
@@ -71,13 +72,13 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         for guest in (guest1, guest2, guest3, guest4):
             guest.eth0.down()
 
-        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[0],
+        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan0_id,
             master=host1.br0)
-        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[1],
+        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan1_id,
             master=host1.br1)
-        host2.vlan0 = VlanDevice(realdev=host2.bond0, vlan_id=self.params.vlan_ids[0],
+        host2.vlan0 = VlanDevice(realdev=host2.bond0, vlan_id=self.params.vlan0_id,
             master=host2.br0)
-        host2.vlan1 = VlanDevice(realdev=host2.bond0, vlan_id=self.params.vlan_ids[1],
+        host2.vlan1 = VlanDevice(realdev=host2.bond0, vlan_id=self.params.vlan1_id,
             master=host2.br1)
 
         configuration = super().test_wide_configuration()

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
@@ -1,5 +1,5 @@
 import logging
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import Param, IntParam
 from lnst.Common.IpAddress import ipaddress
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
@@ -27,7 +27,7 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
@@ -27,6 +27,8 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -48,8 +50,8 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         guest1.eth0.down()
         guest2.eth0.down()
 
-        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=10)
-        guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=10)
+        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
+        guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=self.params.vlan_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [guest1.vlan0, guest2.vlan0]

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
@@ -43,8 +43,6 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         host2.eth0.down()
         guest1.eth0.down()
 
-        host2_vlan_args0 =  dict(realdev=host2.eth0, vlan_id=10)
-        guest1_vlan_args0 = dict(realdev=guest1.eth0, vlan_id=10)
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
 

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
@@ -22,6 +22,8 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -43,8 +45,8 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
 
         host2_vlan_args0 =  dict(realdev=host2.eth0, vlan_id=10)
         guest1_vlan_args0 = dict(realdev=guest1.eth0, vlan_id=10)
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=10)
-        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=10)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
+        guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [host2.vlan0, guest1.vlan0]

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
@@ -22,7 +22,7 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
@@ -1,5 +1,5 @@
 import logging
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import Param, IntParam
 from lnst.Common.IpAddress import ipaddress
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
@@ -26,7 +26,7 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
@@ -26,6 +26,8 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     guest2 = HostReq()
     guest2.eth0 = DeviceReq(label="to_guest2")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -42,7 +44,7 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
             host.eth0.down()
             host.tap0.down()
             host.br0.port_add(host.eth0)
-            host.br0.port_add(host.tap0, port_options={'tag': 10})
+            host.br0.port_add(host.tap0, port_options={'tag': self.params.vlan_id})
 
         guest1.eth0.down()
         guest2.eth0.down()

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
@@ -23,7 +23,7 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
-    vlan_id = Param(default=10)
+    vlan_id = IntParam(default=10)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
@@ -23,6 +23,8 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     guest1 = HostReq()
     guest1.eth0 = DeviceReq(label="to_guest")
 
+    vlan_id = Param(default=10)
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -38,12 +40,12 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         host1.tap0.down()
         host1.br0 = OvsBridgeDevice()
         host1.br0.port_add(host1.eth0)
-        host1.br0.port_add(host1.tap0, port_options={'tag': 10})
+        host1.br0.port_add(host1.tap0, port_options={'tag': self.params.vlan_id})
 
         host2.eth0.down()
         guest1.eth0.down()
 
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=10)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [guest1.eth0, host2.vlan0]

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
@@ -38,6 +38,8 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
     guest4 = HostReq()
     guest4.eth0 = DeviceReq(label="to_guest4")
 
+    vlan_ids = Param(default=[10, 20])
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
         dict(gro="off", gso="on", tso="on", tx="on"),
@@ -57,8 +59,8 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
             for dev in [host.eth0, host.eth1, host.tap0, host.tap1]:
                 dev.down()
             host.br0 = OvsBridgeDevice()
-            for dev, tag in [(host.tap0, "10"), (host.tap1, "20")]:
-                host.br0.port_add(device=dev, port_options={'tag': tag})
+            host.br0.port_add(device=host.tap0, port_options={'tag': self.params.vlan_ids[0]})
+            host.br0.port_add(device=host.tap1, port_options={'tag': self.params.vlan_ids[1]})
             #miimon cannot be set due to colon in argument name -->
             #other_config:bond-miimon-interval
             host.br0.bond_add(port_name, (host.eth0, host.eth1),

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
@@ -38,7 +38,8 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
     guest4 = HostReq()
     guest4.eth0 = DeviceReq(label="to_guest4")
 
-    vlan_ids = Param(default=[10, 20])
+    vlan0_id = IntParam(default=10)
+    vlan1_id = IntParam(default=20)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
@@ -59,8 +60,8 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
             for dev in [host.eth0, host.eth1, host.tap0, host.tap1]:
                 dev.down()
             host.br0 = OvsBridgeDevice()
-            host.br0.port_add(device=host.tap0, port_options={'tag': self.params.vlan_ids[0]})
-            host.br0.port_add(device=host.tap1, port_options={'tag': self.params.vlan_ids[1]})
+            host.br0.port_add(device=host.tap0, port_options={'tag': self.params.vlan0_id})
+            host.br0.port_add(device=host.tap1, port_options={'tag': self.params.vlan1_id})
             #miimon cannot be set due to colon in argument name -->
             #other_config:bond-miimon-interval
             host.br0.bond_add(port_name, (host.eth0, host.eth1),

--- a/lnst/Recipes/ENRT/VlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverBondRecipe.py
@@ -61,6 +61,8 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
+    vlan_ids = Param(default=[10, 20, 30])
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
         dict(gro="off", gso="on", tso="on", tx="on"),
@@ -78,7 +80,7 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         bonding device according to the recipe parameters. Then three
         VLAN (802.1Q) tunnels are created on top of the bonding device on the
         first host and on the matched NIC on the second host. The tunnels are
-        configured with ids 10, 20, 30.
+        configured with VLAN ids from vlan_ids param (by default: [10, 20, 30]).
 
         An IPv4 and IPv6 address is configured on each tunnel endpoint.
 
@@ -98,12 +100,12 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
             dev.down()
             host1.bond0.slave_add(dev)
 
-        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=10)
-        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=20)
-        host1.vlan2 = VlanDevice(realdev=host1.bond0, vlan_id=30)
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=10)
-        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=20)
-        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=30)
+        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[0])
+        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[1])
+        host1.vlan2 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[2])
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[0])
+        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[1])
+        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[2])
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []
@@ -203,7 +205,7 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
     def generate_perf_endpoints(self, config):
         """
         The perf endpoints for this recipe are the VLAN tunnel endpoints with
-        VLAN id 10:
+        VLAN id from parameter vlan_ids[0] (by default: 10):
 
         host1.vlan0 and host2.vlan0
 

--- a/lnst/Recipes/ENRT/VlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverBondRecipe.py
@@ -61,7 +61,9 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
-    vlan_ids = Param(default=[10, 20, 30])
+    vlan0_id = IntParam(default=10)
+    vlan1_id = IntParam(default=20)
+    vlan2_id = IntParam(default=30)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
@@ -80,7 +82,8 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         bonding device according to the recipe parameters. Then three
         VLAN (802.1Q) tunnels are created on top of the bonding device on the
         first host and on the matched NIC on the second host. The tunnels are
-        configured with VLAN ids from vlan_ids param (by default: [10, 20, 30]).
+        configured with VLAN ids from vlan0_id, vlan1_id and vlan2_id params (by
+        default: 10, 20, 30).
 
         An IPv4 and IPv6 address is configured on each tunnel endpoint.
 
@@ -100,12 +103,12 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
             dev.down()
             host1.bond0.slave_add(dev)
 
-        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[0])
-        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[1])
-        host1.vlan2 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan_ids[2])
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[0])
-        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[1])
-        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[2])
+        host1.vlan0 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan0_id)
+        host1.vlan1 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan1_id)
+        host1.vlan2 = VlanDevice(realdev=host1.bond0, vlan_id=self.params.vlan2_id)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan0_id)
+        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan1_id)
+        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan2_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []

--- a/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
@@ -1,4 +1,4 @@
-from lnst.Common.Parameters import Param, StrParam
+from lnst.Common.Parameters import Param, IntParam, StrParam
 from lnst.Common.IpAddress import ipaddress
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
@@ -25,7 +25,9 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="tnet", driver=RecipeParam("driver"))
 
-    vlan_ids = Param(default=[10, 20, 30])
+    vlan0_id = IntParam(default=10)
+    vlan1_id = IntParam(default=20)
+    vlan2_id = IntParam(default=30)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
@@ -43,12 +45,12 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
             dev.down()
             host1.team0.slave_add(dev)
 
-        host1.vlan0 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan_ids[0])
-        host1.vlan1 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan_ids[1])
-        host1.vlan2 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan_ids[2])
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[0])
-        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[1])
-        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[2])
+        host1.vlan0 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan0_id)
+        host1.vlan1 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan1_id)
+        host1.vlan2 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan2_id)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan0_id)
+        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan1_id)
+        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan2_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []

--- a/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
@@ -25,6 +25,8 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="tnet", driver=RecipeParam("driver"))
 
+    vlan_ids = Param(default=[10, 20, 30])
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on"),
         dict(gro="off", gso="on", tso="on", tx="on"),
@@ -41,12 +43,12 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
             dev.down()
             host1.team0.slave_add(dev)
 
-        host1.vlan0 = VlanDevice(realdev=host1.team0, vlan_id=10)
-        host1.vlan1 = VlanDevice(realdev=host1.team0, vlan_id=20)
-        host1.vlan2 = VlanDevice(realdev=host1.team0, vlan_id=30)
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=10)
-        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=20)
-        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=30)
+        host1.vlan0 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan_ids[0])
+        host1.vlan1 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan_ids[1])
+        host1.vlan2 = VlanDevice(realdev=host1.team0, vlan_id=self.params.vlan_ids[2])
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[0])
+        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[1])
+        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[2])
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []

--- a/lnst/Recipes/ENRT/VlansRecipe.py
+++ b/lnst/Recipes/ENRT/VlansRecipe.py
@@ -1,4 +1,4 @@
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import Param, IntParam
 from lnst.Common.IpAddress import ipaddress
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
@@ -42,7 +42,9 @@ class VlansRecipe(VlanPingEvaluatorMixin,
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
-    vlan_ids = Param(default=[10, 20, 30])
+    vlan0_id = IntParam(default=10)
+    vlan1_id = IntParam(default=20)
+    vlan2_id = IntParam(default=30)
 
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
@@ -55,8 +57,8 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         """
         Test wide configuration for this recipe involves creating three
         VLAN (802.1Q) tunnels on top of the matched host's NIC with vlan
-        ids from parameter vlan_id (by default: [10, 20, 30]). The same tunnels
-        are configured on the second host.
+        ids from parameters vlan0_id, vlan1_id and vlan2_id (by default: 10, 20,
+        30). The same tunnels are configured on the second host.
 
         An IPv4 and IPv6 address is configured on each tunnel endpoint.
 
@@ -74,12 +76,12 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         host1.eth0.down()
         host2.eth0.down()
 
-        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_ids[0])
-        host1.vlan1 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_ids[1])
-        host1.vlan2 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_ids[2])
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[0])
-        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[1])
-        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[2])
+        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan0_id)
+        host1.vlan1 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan1_id)
+        host1.vlan2 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan2_id)
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan0_id)
+        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan1_id)
+        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan2_id)
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []
@@ -160,7 +162,7 @@ class VlansRecipe(VlanPingEvaluatorMixin,
     def generate_perf_endpoints(self, config):
         """
         The perf endpoints for this recipe are the VLAN tunnel endpoints with
-        VLAN id from parameter vlan_ids[0] (by default: 10):
+        VLAN id from parameter vlan0_id (by default: 10):
 
         host1.vlan0 and host2.vlan0
 

--- a/lnst/Recipes/ENRT/VlansRecipe.py
+++ b/lnst/Recipes/ENRT/VlansRecipe.py
@@ -42,6 +42,8 @@ class VlansRecipe(VlanPingEvaluatorMixin,
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
+    vlan_ids = Param(default=[10, 20, 30])
+
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
@@ -53,7 +55,8 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         """
         Test wide configuration for this recipe involves creating three
         VLAN (802.1Q) tunnels on top of the matched host's NIC with vlan
-        ids 10, 20, 30. The same tunnels are configured on the second host.
+        ids from parameter vlan_id (by default: [10, 20, 30]). The same tunnels
+        are configured on the second host.
 
         An IPv4 and IPv6 address is configured on each tunnel endpoint.
 
@@ -71,12 +74,12 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         host1.eth0.down()
         host2.eth0.down()
 
-        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=10)
-        host1.vlan1 = VlanDevice(realdev=host1.eth0, vlan_id=20)
-        host1.vlan2 = VlanDevice(realdev=host1.eth0, vlan_id=30)
-        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=10)
-        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=20)
-        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=30)
+        host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_ids[0])
+        host1.vlan1 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_ids[1])
+        host1.vlan2 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_ids[2])
+        host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[0])
+        host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[1])
+        host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_ids[2])
 
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []
@@ -157,7 +160,7 @@ class VlansRecipe(VlanPingEvaluatorMixin,
     def generate_perf_endpoints(self, config):
         """
         The perf endpoints for this recipe are the VLAN tunnel endpoints with
-        VLAN id 10:
+        VLAN id from parameter vlan_ids[0] (by default: 10):
 
         host1.vlan0 and host2.vlan0
 


### PR DESCRIPTION
Some switches are configured to allow only a small number of VLAN IDs (such as in klab.bos lab).

Allow passing an optional argument vlan_id/vlan_ids to specify what VLAN tags to use in the tests.

Note: only tested VlansRecipe