### PR TITLE
Tests/Iperf: fix parsing of empty json output

### DIFF
--- a/lnst/Tests/Iperf.py
+++ b/lnst/Tests/Iperf.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 import json
+from json.decoder import JSONDecodeError
 from lnst.Common.Parameters import IntParam, IpParam, StrParam, BoolParam
 from lnst.Common.Parameters import HostnameOrIpParam
 from lnst.Common.Utils import is_installed
@@ -31,8 +32,12 @@ class IperfBase(BaseTestModule):
 
         try:
             self._res_data["data"] = json.loads(stdout)
-        except:
+        except JSONDecodeError:
+            self._res_data["msg"] = "Error while parsing the iperf json output"
             self._res_data["data"] = stdout
+            self._res_data["stderr"] = stderr
+            logging.error(self._res_data["msg"])
+            return False
 
         self._res_data["stderr"] = stderr
 

--- a/lnst/Tests/Iperf.py
+++ b/lnst/Tests/Iperf.py
@@ -39,6 +39,15 @@ class IperfBase(BaseTestModule):
             logging.error(self._res_data["msg"])
             return False
 
+        try:
+            self._check_json_sanity()
+        except:
+            self._res_data["msg"] = "Iperf provided incomplete json data"
+            self._res_data["data"] = stdout
+            self._res_data["stderr"] = stderr
+            logging.error(self._res_data["msg"])
+            return False
+
         self._res_data["stderr"] = stderr
 
         if stderr != "":
@@ -53,6 +62,21 @@ class IperfBase(BaseTestModule):
             return False
 
         return True
+
+    def _check_json_sanity(self):
+        data = self._res_data["data"]
+        if "start" not in data:
+            raise Exception()
+
+        if "end" not in data:
+            raise Exception()
+
+        if len(data["intervals"]) == 0:
+            raise Exception()
+
+        if "streams" not in data["end"]:
+            raise Exception
+
 
 class IperfServer(IperfBase):
     bind = IpParam()


### PR DESCRIPTION
Iperf running as server may exit with return code 0 and return an empty json.
This usually happens when the iperf running as client cannot complete
the test, for example when running a UDP stream test with multiple
streams on debug kernel.

If the server's json output cannot be parsed the test module should
return False status.

Signed-off-by: Jan Tluka <jtluka@redhat.com>