### PR TITLE
lnst.Controller.SlaveObject: fix getattr inited check

### DIFF
--- a/lnst/Controller/SlaveObject.py
+++ b/lnst/Controller/SlaveObject.py
@@ -23,6 +23,9 @@ class SlaveObject(object):
         if name == "_inited":
             return super(SlaveObject, self).__getattribute__(name)
 
+        if not self._inited:
+            return super(SlaveObject, self).__getattr__(name)
+
         attr = getattr(self.__cls, name)
 
         if callable(attr):


### PR DESCRIPTION
The getattr method of SlaveObject will run into an infinite recursion
issue when unpickling lrc files that stored a reference to a slave
object.

This is due to attempting to access the "_inited" property which isn't
properly set up when unpickling. Adding an explicit override for this
property into the getattr method resolves the issue.

Original-Author: Perry Gagne <pgagne@redhat.com>

Need to deploy this as a hotfix so picking this up earlier out of the
MPTCP patchset.

Signed-off-by: Ondrej Lichtner <olichtne@redhat.com>