### PR TITLE
Include an exception in RecipeRun overall_result evaluation

### DIFF
--- a/lnst/Controller/Controller.py
+++ b/lnst/Controller/Controller.py
@@ -160,6 +160,7 @@ class Controller(object):
                                            log_list=self._log_ctl.get_recipe_log_list()))
                 recipe.test()
             except Exception as exc:
+                recipe.current_run.exception = exc
                 logging.error("Recipe execution terminated by unexpected exception")
                 log_exc_traceback()
                 raise

--- a/lnst/Controller/Recipe.py
+++ b/lnst/Controller/Recipe.py
@@ -215,7 +215,7 @@ class RecipeRun(object):
 
     @property
     def overall_result(self):
-        return all([i.success for i in self.results])
+        return all([i.success for i in self.results] + [self.exception is None])
 
     @property
     def recipe(self) -> BaseRecipe:

--- a/lnst/Controller/Recipe.py
+++ b/lnst/Controller/Recipe.py
@@ -172,6 +172,7 @@ class RecipeRun(object):
         self._recipe = recipe
         self._datetime = datetime.datetime.now()
         self._environ = os.environ.copy()
+        self._exception = None
 
     def add_result(self, result):
         if not isinstance(result, BaseResult):
@@ -228,6 +229,13 @@ class RecipeRun(object):
     def environ(self):
         return self._environ
 
+    @property
+    def exception(self):
+        return self._exception
+
+    @exception.setter
+    def exception(self, exception):
+        self._exception = exception
 
 def export_recipe_run(run: RecipeRun, export_dir: str = None, name: str = None) -> str:
     """


### PR DESCRIPTION
I noticed that the `overall_result` property is `True` even if an exception is raised during recipe run.