### PR TITLE
Recipes.ENRT.BaseEnrtRecipe: fix BaseCPUMeasurement conditional

### DIFF
--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -447,7 +447,7 @@ class BaseEnrtRecipe(
             return []
 
         if isinstance(measurement, BaseCPUMeasurement):
-            if self.params.perf_evaluation_strategy is "nonzero" or "none":
+            if self.params.perf_evaluation_strategy in ["nonzero", "none"]:
                 evaluators = []
             else:
                 evaluators = self.cpu_perf_evaluators


### PR DESCRIPTION
Description:

With introduction of new parameter `perf_evaluation_strategy` there is a logical bug in the conditional 
of `BaseCPUMeasurement` evaluator registration. It is being evaluated as follows in default scenario:

```
parameter is "nonzero" = 0

OR

"none" = 1

which results into 1, removing the CPU perf evaluator
```

To fix this logical bug `self.params.perf_evaluation_strategy` is checking whether its string value exists in the given list instead.

Test: J:6280045

Reviews: @olichtne @jtluka 