### PR TITLE
Controller.Job: add passed setter

### DIFF
--- a/lnst/Controller/Job.py
+++ b/lnst/Controller/Job.py
@@ -144,6 +144,10 @@ class Job(object):
         except:
             return False
 
+    @passed.setter
+    def passed(self, result):
+        self._res["passed"] = result
+
     @property
     def finished(self):
         """Indicates whether or not the Job finished running


### PR DESCRIPTION
Description:

Some Controller jobs can fail, but they are not significant
enough to mark the whole run as a failure.
Thus, having a setter for passed property, allows us to
override failed job, not causing run failure.

Tests: J:6287992

Reviews: @olichtne @jtluka 