### PR TITLE
CI tests

### DIFF
--- a/.github/runner.py
+++ b/.github/runner.py
@@ -1,0 +1,38 @@
+from lnst.Controller import Controller, HostReq, DeviceReq, BaseRecipe
+from lnst.Controller.ContainerPoolManager import ContainerPoolManager
+from lnst.Controller.MachineMapper import ContainerMapper
+
+
+class HelloWorldRecipe(BaseRecipe):
+    machine1 = HostReq()
+    machine1.nic1 = DeviceReq(label="net1")
+
+    machine2 = HostReq()
+    machine2.nic1 = DeviceReq(label="net1")
+
+    def test(self):
+        self.matched.machine1.nic1.ip_add("192.168.1.1/24")
+        self.matched.machine1.nic1.up()
+        self.matched.machine2.nic1.ip_add("192.168.1.2/24")
+        self.matched.machine2.nic1.up()
+
+        self.matched.machine1.run("ping 192.168.1.2 -c 5")
+        self.matched.machine2.run("ping 192.168.1.1 -c 5")
+
+
+podman_uri = "unix:///run/podman/podman.sock"
+image_name = "lnst"
+ctl = Controller(
+    poolMgr=ContainerPoolManager,
+    mapper=ContainerMapper,
+    podman_uri=podman_uri,
+    image=image_name,
+    debug=1,
+)
+
+recipe_instance = HelloWorldRecipe()
+ctl.run(recipe_instance)
+
+overall_result = all([run.overall_result for run in recipe_instance.runs])
+
+exit(not overall_result)

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,63 @@
+name: CI test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  FunctionalTest:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.6"
+
+    - name: Source branch checkout
+      uses: actions/checkout@v2
+
+    - name: Set up system requirements
+      run: |
+        sudo apt-get install podman -y
+        sudo systemctl enable --now podman.socket
+        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3.6 -
+
+    - name: Set up Podman network requirements
+      run: |
+        sudo sysctl -w net.ipv4.ip_forward=1
+        sudo sysctl net.ipv4.conf.all.forwarding=1
+        sudo iptables -P FORWARD ACCEPT
+        sudo sysctl -p
+
+    - name: Install LNST
+      run: |
+        sudo apt-get install -y iputils-* \
+        ethtool \
+        gcc \
+        python-dev \
+        libxml2-dev \
+        libxslt-dev \
+        qemu-kvm \
+        libvirt-daemon-system \
+        libvirt-clients \
+        bridge-utils \
+        libvirt-dev \
+        libnl-3-200 \
+        libnl-route-3-dev \
+        git \
+        libnl-3-dev
+        $HOME/.poetry/bin/poetry install
+
+    - name: Build LNST agents image
+      run: |
+        sudo podman build . -t lnst -f container_files/Dockerfile
+
+    - name: SimpleNetworkRecipe ping test
+      run: |
+        export PATH=$PATH:$HOME/.poetry/bin
+        venv_path=$(poetry env info -p)
+        sudo "$venv_path"/bin/python .github/runner.py
+


### PR DESCRIPTION
Pushes and pull requests to `master` triggers Github action,
which tries to merge upstream `master` branch and pull request's
source branch and also runs `SimpleNetworkRecipe` using
2 containers whose try to ping eachother. `runner.py` is taken from
our [wiki](https://lnst.readthedocs.io/en/latest/installation.html#creating-an-executable-helloworld-test-script).


GitHub action [does not support Fedora](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), so I had to use Ubuntu instead,  
basically the requirements are the same but some of them have quite different name.
Actions have [limits](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits) but it's pretty generous so I don't think it would be problem in future.