### PR TITLE
Add performance testing to functional tunnel recipes

### DIFF
--- a/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
@@ -174,6 +174,17 @@ class GeneveLwtTunnelRecipe(
         """
         return [PingEndpoints(self.matched.host1.lo, self.matched.host2.lo)]
 
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for this recipe are the loopback devices that
+        are configured with IP addresses of the tunnelled networks.
+
+        Returned as::
+
+            [(self.matched.host1.lo, self.matched.host2.lo)]
+        """
+        return [(self.matched.host1.lo, self.matched.host2.lo)]
+
     def get_packet_assert_config(self, ping_config):
         """
         The packet assert test configuration contains filter for ip or ip6

--- a/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
@@ -175,6 +175,17 @@ class VxlanLwtTunnelRecipe(
         """
         return [PingEndpoints(self.matched.host1.lo, self.matched.host2.lo)]
 
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for this recipe are the loopback devices that
+        are configured with IP addresses of the tunnelled networks.
+
+        Returned as::
+
+            [(self.matched.host1.lo, self.matched.host2.lo)]
+        """
+        return [(self.matched.host1.lo, self.matched.host2.lo)]
+
     def get_packet_assert_config(self, ping_config):
         """
         The packet assert test configuration contains filter for source


### PR DESCRIPTION
Description:

Internal need requires us to run performance tests through VXLAN and GENEVE tunnels.
To achieve this `generate_perf_endpouints` methods has been added which triggers the whole hierarchy of performance benchmarks.

Just a note to keep in mind is that when user wants to run pure functional test he has to specify empty `perf_tests` list, instead of being null. If the list would not exist in parameters default value of all `perf_tests` would be used, which results in running all available streams to us. 

Tests: 

J:6377886

The first test-runner has `perf_tests=[]`

While second one has `perf_tests=['tcp_stream']`

Reviews: @olichtne @jtluka 