### PR TITLE
Update LNST to use python 3.9

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.6"
+        python-version: "3.9"
 
     - name: Source branch checkout
       uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install podman -y
         sudo systemctl enable --now podman.socket
-        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3.6 -
+        curl -sSL https://install.python-poetry.org | python3 - --version 1.1.13
 
     - name: Set up Podman network requirements
       run: |
@@ -50,7 +50,8 @@ jobs:
         libnl-route-3-dev \
         git \
         libnl-3-dev
-        $HOME/.poetry/bin/poetry install
+        export PATH="/root/.local/bin:$PATH"
+        poetry install
 
     - name: Build LNST agents image
       run: |
@@ -58,7 +59,7 @@ jobs:
 
     - name: SimpleNetworkRecipe ping test
       run: |
-        export PATH=$PATH:$HOME/.poetry/bin
+        export PATH="/root/.local/bin:$PATH"
         venv_path=$(poetry env info -p)
-        sudo "$venv_path"/bin/python .github/runner.py
+        sudo "$venv_path"/bin/python3 .github/runner.py
 

--- a/container_files/Dockerfile
+++ b/container_files/Dockerfile
@@ -4,7 +4,7 @@ FROM fedora:34
 RUN dnf install -y initscripts \
     iputils \
     ethtool \
-    python3.6 \
+    python3.9 \
     python-pip \
     gcc \
     python-devel \
@@ -14,7 +14,9 @@ RUN dnf install -y initscripts \
     libvirt-devel \
     libnl3 \
     git \
-    libnl3-devel && pip install 'poetry==1.1.7'
+    libnl3-devel &&  \
+    curl -sSL https://install.python-poetry.org |  \
+    python3 - --version 1.1.13
 
 COPY . /lnst
 RUN cd /lnst/container_files && chmod +x install.sh && sh install.sh

--- a/container_files/install.sh
+++ b/container_files/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export PATH="/root/.local/bin:$PATH"
 poetry install
 
 venv_path=$(poetry env info -p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lnst"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "http://lnst-project.org"
 license = "GPL-2.0-or-later"
 readme = "README.md"
@@ -17,14 +17,13 @@ packages = [
 include = ["schema-am.rng", "install/*", "lnst-ctl.conf"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.9"
 
 pyroute2 = "*"
 pyyaml = "*"
 lxml = "*"
 libvirt-python = "*"
 ethtool = "*"
-dataclasses = "*"
 podman = "*"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Description:

Updating python version being used in LNST.

Decision to do so, was made based on the fact, that newer poetry installer requires python 3.7 and higher, thus giving us an opportunity to update the LNST version with it as well.

Test:

J:6443576

Reviews: @jtluka @olichtne 