### PR TITLE
Implement performance analysis with Linux Perf tool

### DIFF
--- a/container_files/Dockerfile
+++ b/container_files/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf install -y initscripts \
     libvirt-devel \
     libnl3 \
     git \
+    perf \
     libnl3-devel &&  \
     curl -sSL https://install.python-poetry.org |  \
     python3 - --version 1.1.13

--- a/lnst/Common/Parameters.py
+++ b/lnst/Common/Parameters.py
@@ -16,6 +16,8 @@ from lnst.Common.DeviceRef import DeviceRef
 from lnst.Common.IpAddress import BaseIpAddress, ipaddress
 from lnst.Common.LnstError import LnstError
 
+from typing import List
+
 class ParamError(LnstError):
     pass
 
@@ -144,14 +146,16 @@ class ListParam(Param):
         if not isinstance(value, list):
             raise ParamError("Value must be a List. Not {}".format(type(value)))
 
-        if self._type is not None:
-            for item in value:
-                try:
-                    self._type.type_check(item)
-                except ParamError as e:
-                    raise ParamError("Value '{}' failed type check:\n{}"
-                                     .format(item, str(e)))
-        return value
+        if self._type is None:
+            return value
+
+        new_value: List[str] = []
+        for item in value:
+            try:
+                new_value.append(self._type.type_check(item))
+            except ParamError as e:
+                raise ParamError(f"Value '{item}' failed type check:\n{e}")
+        return new_value
 
 
 class ChoiceParam(Param):

--- a/lnst/Common/Parameters.py
+++ b/lnst/Common/Parameters.py
@@ -16,8 +16,6 @@ from lnst.Common.DeviceRef import DeviceRef
 from lnst.Common.IpAddress import BaseIpAddress, ipaddress
 from lnst.Common.LnstError import LnstError
 
-from typing import List
-
 class ParamError(LnstError):
     pass
 
@@ -149,7 +147,7 @@ class ListParam(Param):
         if self._type is None:
             return value
 
-        new_value: List[str] = []
+        new_value: list[str] = []
         for item in value:
             try:
                 new_value.append(self._type.type_check(item))

--- a/lnst/Controller/Machine.py
+++ b/lnst/Controller/Machine.py
@@ -609,8 +609,8 @@ class Machine(object):
         f = open(local_path, "rb")
 
         while True:
-            data = f.read(1024*1024) # 1MB buffer
-            if len(data) == 0:
+            data: bytes = f.read(1024*1024) # 1MB buffer
+            if not data:
                 break
 
             self.rpc_call("copy_part_to", remote_path, data, netns=netns)
@@ -629,8 +629,8 @@ class Machine(object):
 
         buf_size = 1024*1024 # 1MB buffer
         while True:
-            data = self.rpc_call("copy_part_from", remote_path, buf_size)
-            if data == "":
+            data: bytes = self.rpc_call("copy_part_from", remote_path, buf_size)
+            if not data:
                 break
             local_file.write(data)
 

--- a/lnst/Controller/Namespace.py
+++ b/lnst/Controller/Namespace.py
@@ -15,6 +15,7 @@ olichtne@redhat.com (Ondrej Lichtner)
 """
 
 import logging
+from typing import Optional
 from abc import ABCMeta
 from lnst.Controller.Job import DEFAULT_TIMEOUT
 from lnst.Devices.Device import Device
@@ -84,6 +85,17 @@ class Namespace(object):
         returns None for the init namespace
         returns a string name for any other namespace"""
         return self._name
+
+    def copy_file_to_machine(
+        self,
+        local_path: str,
+        remote_path: Optional[str] = None,
+        netns: Optional['Namespace'] = None,
+    ) -> str:
+        return self._machine.copy_file_to_machine(local_path, remote_path, netns)
+
+    def copy_file_from_machine(self, remote_path: str, local_path: str):
+        self._machine.copy_file_from_machine(remote_path, local_path)
 
     def prepare_job(self, what, fail=False, json=False, desc=None,
                     job_level=ResultLevel.DEBUG):

--- a/lnst/Controller/Namespace.py
+++ b/lnst/Controller/Namespace.py
@@ -89,10 +89,9 @@ class Namespace(object):
     def copy_file_to_machine(
         self,
         local_path: str,
-        remote_path: Optional[str] = None,
-        netns: Optional['Namespace'] = None,
+        remote_path: Optional[str] = None
     ) -> str:
-        return self._machine.copy_file_to_machine(local_path, remote_path, netns)
+        return self._machine.copy_file_to_machine(local_path, remote_path, self)
 
     def copy_file_from_machine(self, remote_path: str, local_path: str):
         self._machine.copy_file_from_machine(remote_path, local_path)

--- a/lnst/RecipeCommon/Perf/Measurements/BaseMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseMeasurement.py
@@ -24,11 +24,11 @@ class BaseMeasurement(object):
         raise NotImplementedError()
 
     @classmethod
-    def report_results(recipe, results):
+    def report_results(cls, recipe, results):
         raise NotImplementedError()
 
     @classmethod
-    def aggregate_results(first, second):
+    def aggregate_results(cls, first, second):
         raise NotImplementedError()
 
     def __repr__(self):

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional
+from datetime import datetime
 import logging
 import signal
 import time
@@ -15,6 +16,8 @@ from lnst.Controller.Host import Host
 from lnst.Controller.Recipe import BaseRecipe
 from lnst.Controller.RecipeResults import ResultLevel
 
+def timestamp() -> str:
+    return datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
 
 class LinuxPerfMeasurementResults(BaseMeasurementResults):
     _host: Host
@@ -174,7 +177,7 @@ class LinuxPerfMeasurement(BaseMeasurement):
 
             # copy agent's perf.data file to a controller
             src_filepath: str = job.result["filename"]
-            new_filename: str = f"{filename}.{self._collection_index}"
+            new_filename: str = f"{filename}.{self._collection_index}.{timestamp()}"
             dst_filepath: str = os.path.join(self._data_folder, host.hostid, new_filename)
 
             host.copy_file_from_machine(src_filepath, dst_filepath)

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional
+from typing import Any, Optional
 import logging
 import signal
 import time
@@ -19,7 +19,7 @@ from lnst.Controller.RecipeResults import ResultLevel
 class LinuxPerfMeasurementResults(BaseMeasurementResults):
     _host: Host
     _filename: str
-    _cpus: List[int]
+    _cpus: list[int]
 
     _start_timestamp: float
     _end_timestamp: float
@@ -29,7 +29,7 @@ class LinuxPerfMeasurementResults(BaseMeasurementResults):
         measurement: "LinuxPerfMeasurement",
         host: Host,
         filename: str,
-        cpus: List[int],
+        cpus: list[int],
         start_timestamp: float,
         end_timestamp: float,
     ):
@@ -66,14 +66,14 @@ class LinuxPerfMeasurementResults(BaseMeasurementResults):
 
 class AggregatedLinuxPerfMeasurementResults(BaseMeasurementResults):
 
-    _individual_results: List[LinuxPerfMeasurementResults] = []
+    _individual_results: list[LinuxPerfMeasurementResults] = []
 
     def __init__(self, result: Optional[LinuxPerfMeasurementResults] = None):
         if result:
             self._individual_results = [result]
 
     @property
-    def individual_results(self) -> List[LinuxPerfMeasurementResults]:
+    def individual_results(self) -> list[LinuxPerfMeasurementResults]:
         return self._individual_results
 
     def add_results(self, result: LinuxPerfMeasurementResults):
@@ -83,26 +83,26 @@ class AggregatedLinuxPerfMeasurementResults(BaseMeasurementResults):
 class LinuxPerfMeasurement(BaseMeasurement):
     _MEASUREMENT_VERSION: int = 1
 
-    hosts: List[Host]
+    hosts: list[Host]
     intr_filename: str
-    intr_cpus: List[int]
+    intr_cpus: list[int]
     iperf_filename: str
-    iperf_cpus: List[int]
+    iperf_cpus: list[int]
     _start_timestamp: float
     _end_timestamp: float
     _data_folder: str
 
-    _version: Optional[Dict[str, Any]] = None
+    _version: Optional[dict[str, Any]] = None
     _collection_index: int = 0
-    _jobs: List[Job] = []
+    _jobs: list[Job] = []
 
     def __init__(
         self,
-        hosts: List[Host],
+        hosts: list[Host],
         intr_filename: str,
-        intr_cpus: List[int],
+        intr_cpus: list[int],
         iperf_filename: str,
-        iperf_cpus: List[int],
+        iperf_cpus: list[int],
         data_folder: str,
         recipe_conf: Any = None,
     ):
@@ -121,7 +121,7 @@ class LinuxPerfMeasurement(BaseMeasurement):
             os.mkdir(os.path.join(self._data_folder, host.hostid))
 
     @property
-    def version(self) -> Optional[Dict[str, Any]]:
+    def version(self) -> Optional[dict[str, Any]]:
         if self._version:
             return self._version
 
@@ -165,9 +165,9 @@ class LinuxPerfMeasurement(BaseMeasurement):
                 logging.error(f"timeout while waiting for linuxperf job to finish on host {host.hostid}")
         self._end_timestamp = time.time()
 
-    def collect_results(self) -> List[BaseMeasurementResults]:
+    def collect_results(self) -> list[BaseMeasurementResults]:
         self._collection_index += 1
-        results: List[BaseMeasurementResults] = []
+        results: list[BaseMeasurementResults] = []
         for job, (host, filename, cpus) in zip(self._jobs, self._generate_configurations()):
             if job.result is None:
                 continue
@@ -195,7 +195,7 @@ class LinuxPerfMeasurement(BaseMeasurement):
     def report_results(
         cls,
         recipe: BaseRecipe,
-        aggregated_results: List[AggregatedLinuxPerfMeasurementResults],
+        aggregated_results: list[AggregatedLinuxPerfMeasurementResults],
     ):
         for aggregated_result in aggregated_results:
             cpus: str = ",".join(map(str, aggregated_result.individual_results[0].cpus))
@@ -212,13 +212,13 @@ class LinuxPerfMeasurement(BaseMeasurement):
     @classmethod
     def aggregate_results(
         cls,
-        old: Optional[List[AggregatedLinuxPerfMeasurementResults]],
-        new: List[LinuxPerfMeasurementResults],
-    ) -> List[AggregatedLinuxPerfMeasurementResults]:
+        old: Optional[list[AggregatedLinuxPerfMeasurementResults]],
+        new: list[LinuxPerfMeasurementResults],
+    ) -> list[AggregatedLinuxPerfMeasurementResults]:
         if old is None:
             return [AggregatedLinuxPerfMeasurementResults(result) for result in new]
 
-        aggregated: List[AggregatedLinuxPerfMeasurementResults] = []
+        aggregated: list[AggregatedLinuxPerfMeasurementResults] = []
         for old_measurements, new_measurement in zip(old, new):
             aggregated.append(
                 cls._aggregate_linux_perf_results(old_measurements, new_measurement)

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -1,0 +1,234 @@
+from typing import List, Dict, Any, Optional
+import logging
+import signal
+import time
+import os
+import re
+
+from lnst.Tests.LinuxPerf import LinuxPerf
+from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import (
+    BaseMeasurement,
+    BaseMeasurementResults,
+)
+from lnst.Controller.Job import Job
+from lnst.Controller.Host import Host
+from lnst.Controller.Recipe import BaseRecipe
+from lnst.Controller.RecipeResults import ResultLevel
+
+
+class LinuxPerfMeasurementResults(BaseMeasurementResults):
+    _host: Host
+    _filename: str
+    _cpus: List[int]
+
+    _start_timestamp: float
+    _end_timestamp: float
+
+    def __init__(
+        self,
+        measurement: "LinuxPerfMeasurement",
+        host: Host,
+        filename: str,
+        cpus: List[int],
+        start_timestamp: float,
+        end_timestamp: float,
+    ):
+        super().__init__(measurement)
+        self._host = host
+        self._filename = filename
+        self._cpus = cpus
+        self._start_timestamp = start_timestamp
+        self._end_timestamp = end_timestamp
+
+    @property
+    def host(self):
+        return self._host
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @property
+    def cpus(self):
+        return self._cpus
+
+    @property
+    def start_timestamp(self):
+        return self._start_timestamp
+
+    @property
+    def end_timestamp(self):
+        return self._end_timestamp
+
+    def time_slice(self, start, end):
+        return self
+
+
+class AggregatedLinuxPerfMeasurementResults(BaseMeasurementResults):
+
+    _individual_results: List[LinuxPerfMeasurementResults] = []
+
+    def __init__(self, result: Optional[LinuxPerfMeasurementResults] = None):
+        if result:
+            self._individual_results = [result]
+
+    @property
+    def individual_results(self) -> List[LinuxPerfMeasurementResults]:
+        return self._individual_results
+
+    def add_results(self, result: LinuxPerfMeasurementResults):
+        self._individual_results.append(result)
+
+
+class LinuxPerfMeasurement(BaseMeasurement):
+    _MEASUREMENT_VERSION: int = 1
+
+    hosts: List[Host]
+    intr_filename: str
+    intr_cpus: List[int]
+    iperf_filename: str
+    iperf_cpus: List[int]
+    _start_timestamp: float
+    _end_timestamp: float
+    _data_folder: str
+
+    _version: Optional[Dict[str, Any]] = None
+    _collection_index: int = 0
+    _jobs: List[Job] = []
+
+    def __init__(
+        self,
+        hosts: List[Host],
+        intr_filename: str,
+        intr_cpus: List[int],
+        iperf_filename: str,
+        iperf_cpus: List[int],
+        data_folder: str,
+        recipe_conf: Any = None,
+    ):
+        super().__init__(recipe_conf)
+
+        self.hosts = hosts
+        self.intr_filename = intr_filename
+        self.intr_cpus = intr_cpus
+        self.iperf_filename = iperf_filename
+        self.iperf_cpus = iperf_cpus
+
+        self._data_folder = data_folder
+
+        # create output folders
+        for host in self.hosts:
+            os.mkdir(os.path.join(self._data_folder, host.hostid))
+
+    @property
+    def version(self) -> Optional[Dict[str, Any]]:
+        if self._version:
+            return self._version
+
+        perf_version: Optional[str] = self._get_host_perf_version()
+        if perf_version is None:
+            return None
+
+        self._version = {
+            "measurement_version": self._MEASUREMENT_VERSION,
+            "host_perf_version": perf_version,
+        }
+        return self._version
+
+    def _get_host_perf_version(self) -> Optional[str]:
+        if not len(self.hosts):
+            raise Exception(
+                "No hosts in LinuxPerfMeasurement while getting perf version"
+            )
+
+        version_job = self.hosts[0].run("perf --version", job_level=ResultLevel.DEBUG)
+        if version_job.passed:
+            match = re.match(r"perf version (.+?)", version_job.stdout)
+            if match:
+                return match.group(1)
+        return None
+
+    def _generate_configurations(self):
+        for host in self.hosts:
+            yield (host, self.intr_filename, self.intr_cpus)
+            yield (host, self.iperf_filename, self.iperf_cpus)
+
+    def start(self) -> None:
+        self._start_timestamp = time.time()
+        for host, filename, cpus in self._generate_configurations():
+            self._jobs.append(host.run(LinuxPerf(output_file=filename, cpus=cpus), bg=True))
+
+    def finish(self) -> None:
+        for job, (host, _, _) in zip(self._jobs, self._generate_configurations()):
+            job.kill(signal=signal.SIGINT)
+            if not job.wait(timeout=120):
+                logging.error(f"timeout while waiting for linuxperf job to finish on host {host.hostid}")
+        self._end_timestamp = time.time()
+
+    def collect_results(self) -> List[BaseMeasurementResults]:
+        self._collection_index += 1
+        results: List[BaseMeasurementResults] = []
+        for job, (host, filename, cpus) in zip(self._jobs, self._generate_configurations()):
+            if job.result is None:
+                continue
+
+            # copy agent's perf.data file to a controller
+            src_filepath: str = job.result["filename"]
+            new_filename: str = f"{filename}.{self._collection_index}"
+            dst_filepath: str = os.path.join(self._data_folder, host.hostid, new_filename)
+
+            host.copy_file_from_machine(src_filepath, dst_filepath)
+            logging.debug(f"perf-record data copied from slave to {dst_filepath}")
+            results.append(
+                LinuxPerfMeasurementResults(
+                    self,
+                    host,
+                    dst_filepath,
+                    cpus,
+                    self._start_timestamp,
+                    self._end_timestamp,
+                )
+            )
+        return results
+
+    @classmethod
+    def report_results(
+        cls,
+        recipe: BaseRecipe,
+        aggregated_results: List[AggregatedLinuxPerfMeasurementResults],
+    ):
+        for aggregated_result in aggregated_results:
+            cpus: str = ",".join(map(str, aggregated_result.individual_results[0].cpus))
+            hostid: str = aggregated_result.individual_results[0].host.hostid
+            files: str = "\n    ".join(
+                result.filename for result in aggregated_result.individual_results
+            )
+
+            recipe.add_result(
+                True,
+                f"perf-record recorded CPU(s) {cpus} on {hostid} to files:\n    {files}",
+            )
+
+    @classmethod
+    def aggregate_results(
+        cls,
+        old: Optional[List[AggregatedLinuxPerfMeasurementResults]],
+        new: List[LinuxPerfMeasurementResults],
+    ) -> List[AggregatedLinuxPerfMeasurementResults]:
+        if old is None:
+            return [AggregatedLinuxPerfMeasurementResults(result) for result in new]
+
+        aggregated: List[AggregatedLinuxPerfMeasurementResults] = []
+        for old_measurements, new_measurement in zip(old, new):
+            aggregated.append(
+                cls._aggregate_linux_perf_results(old_measurements, new_measurement)
+            )
+        return aggregated
+
+    @staticmethod
+    def _aggregate_linux_perf_results(
+        old: AggregatedLinuxPerfMeasurementResults,
+        new: LinuxPerfMeasurementResults,
+    ) -> AggregatedLinuxPerfMeasurementResults:
+        old.add_results(new)
+        return old

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -218,15 +218,6 @@ class LinuxPerfMeasurement(BaseMeasurement):
 
         aggregated: list[AggregatedLinuxPerfMeasurementResults] = []
         for old_measurements, new_measurement in zip(old, new):
-            aggregated.append(
-                cls._aggregate_linux_perf_results(old_measurements, new_measurement)
-            )
+            old_measurements.add_results(new_measurement)
+            aggregated.append(old_measurements)
         return aggregated
-
-    @staticmethod
-    def _aggregate_linux_perf_results(
-        old: AggregatedLinuxPerfMeasurementResults,
-        new: LinuxPerfMeasurementResults,
-    ) -> AggregatedLinuxPerfMeasurementResults:
-        old.add_results(new)
-        return old

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -178,7 +178,7 @@ class LinuxPerfMeasurement(BaseMeasurement):
             dst_filepath: str = os.path.join(self._data_folder, host.hostid, new_filename)
 
             host.copy_file_from_machine(src_filepath, dst_filepath)
-            logging.debug(f"perf-record data copied from slave to {dst_filepath}")
+            logging.debug(f"perf-record data copied from agent to {dst_filepath}")
             results.append(
                 LinuxPerfMeasurementResults(
                     self,

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -121,7 +121,10 @@ class LinuxPerfMeasurement(BaseMeasurement):
 
         # create output folders
         for host in self.hosts:
-            os.mkdir(os.path.join(self._data_folder, host.hostid))
+            try:
+                os.mkdir(os.path.join(self._data_folder, host.hostid))
+            except FileExistsError:
+                pass
 
     @property
     def version(self) -> Optional[dict[str, Any]]:

--- a/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
@@ -48,3 +48,7 @@ class BaremetalEnrtRecipe(
         :any:`DisableTurboboostMixin.disable_turboboost_host_list`.
         """
         return self.matched
+
+    @property
+    def linuxperf_cpus(self):
+        return [self.params.dev_intr_cpu, self.params.perf_tool_cpu]

--- a/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
@@ -13,6 +13,7 @@ from lnst.Recipes.ENRT.MeasurementGenerators.FlowMeasurementGenerator import (
 from lnst.Recipes.ENRT.MeasurementGenerators.FlowEndpointsStatCPUMeasurementGenerator import (
     FlowEndpointsStatCPUMeasurementGenerator,
 )
+from lnst.Recipes.ENRT.MeasurementGenerators.LinuxPerfMeasurementGenerator import LinuxPerfMeasurementGenerator
 
 
 class BaremetalEnrtRecipe(
@@ -20,6 +21,7 @@ class BaremetalEnrtRecipe(
     DisableTurboboostMixin,
     DisableIdleStatesMixin,
     FlowEndpointsStatCPUMeasurementGenerator,
+    LinuxPerfMeasurementGenerator,
     FlowMeasurementGenerator,
     BaseEnrtRecipe,
 ):

--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -443,7 +443,7 @@ class BaseEnrtRecipe(
         :rtype: List[:any:`BaseResultEvaluator`]
 
         """
-        if self.params.perf_evaluation_strategy is "none":
+        if self.params.perf_evaluation_strategy == "none":
             return []
 
         if isinstance(measurement, BaseCPUMeasurement):
@@ -452,7 +452,7 @@ class BaseEnrtRecipe(
             else:
                 evaluators = self.cpu_perf_evaluators
         elif isinstance(measurement, BaseFlowMeasurement):
-            if self.params.perf_evaluation_strategy is "nonzero":
+            if self.params.perf_evaluation_strategy == "nonzero":
                 evaluators = [NonzeroFlowEvaluator()]
             else:
                 evaluators = self.net_perf_evaluators

--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -1,0 +1,44 @@
+from lnst.Recipes.ENRT.MeasurementGenerators.BaseMeasurementGenerator import (
+    BaseMeasurementGenerator,
+)
+from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import (
+    BaseMeasurement,
+)
+from lnst.RecipeCommon.Perf.Measurements.LinuxPerfMeasurement import (
+    LinuxPerfMeasurement,
+)
+from lnst.Common.Parameters import BoolParam, StrParam
+from lnst.Controller.Host import Host
+
+from typing import List, Any
+import os
+
+class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
+    do_linuxperf_measurement = BoolParam(default=False)
+    linuxperf_intr_fname = StrParam(default="intr.data")
+    linuxperf_iperf_fname = StrParam(default="iperf.data")
+
+    def generate_perf_measurements_combinations(self, config: Any):
+        combinations = super().generate_perf_measurements_combinations(config)
+
+        if not self.params.do_linuxperf_measurement:
+            return combinations
+
+        # create linuxperf data folder
+        linuxperf_data_folder: str = os.path.abspath(
+            os.path.join(self.current_run.log_dir, "linuxperf-data")
+        )
+        os.mkdir(linuxperf_data_folder)
+
+        for combination in combinations:
+            measurement: BaseMeasurement = LinuxPerfMeasurement(
+                self.matched,
+                self.params.linuxperf_intr_fname,
+                self.params.dev_intr_cpu,
+                self.params.linuxperf_iperf_fname,
+                self.params.perf_tool_cpu,
+                data_folder=linuxperf_data_folder,
+                recipe_conf=config,
+            )
+
+            yield [measurement] + combination

--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -10,7 +10,6 @@ from lnst.RecipeCommon.Perf.Measurements.LinuxPerfMeasurement import (
 from lnst.Common.Parameters import BoolParam, StrParam
 from lnst.Controller.Host import Host
 
-from typing import List, Any
 import os
 
 class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
@@ -18,7 +17,7 @@ class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
     linuxperf_intr_fname = StrParam(default="intr.data")
     linuxperf_iperf_fname = StrParam(default="iperf.data")
 
-    def generate_perf_measurements_combinations(self, config: Any):
+    def generate_perf_measurements_combinations(self, config):
         combinations = super().generate_perf_measurements_combinations(config)
 
         if not self.params.do_linuxperf_measurement:

--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -14,8 +14,6 @@ import os
 
 class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
     do_linuxperf_measurement = BoolParam(default=False)
-    linuxperf_intr_fname = StrParam(default="intr.data")
-    linuxperf_iperf_fname = StrParam(default="iperf.data")
 
     def generate_perf_measurements_combinations(self, config):
         combinations = super().generate_perf_measurements_combinations(config)
@@ -35,10 +33,7 @@ class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
         for combination in combinations:
             measurement: BaseMeasurement = LinuxPerfMeasurement(
                 self.matched,
-                self.params.linuxperf_intr_fname,
-                self.params.dev_intr_cpu,
-                self.params.linuxperf_iperf_fname,
-                self.params.perf_tool_cpu,
+                self.linuxperf_cpus,
                 data_folder=linuxperf_data_folder,
                 recipe_conf=config,
             )

--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -27,7 +27,10 @@ class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
         linuxperf_data_folder: str = os.path.abspath(
             os.path.join(self.current_run.log_dir, "linuxperf-data")
         )
-        os.mkdir(linuxperf_data_folder)
+        try:
+            os.mkdir(linuxperf_data_folder)
+        except FileExistsError:
+            pass
 
         for combination in combinations:
             measurement: BaseMeasurement = LinuxPerfMeasurement(

--- a/lnst/Tests/LinuxPerf.py
+++ b/lnst/Tests/LinuxPerf.py
@@ -37,11 +37,11 @@ class LinuxPerf(BaseTestModule):
         if stderr:
             log_output(logging.debug, "Stderr", stderr.decode())
 
-        self._res_data["filename"] = os.path.abspath(self._parse_filename_from_output(stderr.decode()))
+        self._res_data["filename"] = os.path.abspath(self.params.output_file)
         return process.returncode == -2
 
     def _compose_cmd(self) -> str:
-        cmd: str = "perf record --timestamp-filename"
+        cmd: str = "perf record"
         cmd += f" --output={self.params.output_file}"
 
         if "cpus" in self.params:
@@ -51,12 +51,3 @@ class LinuxPerf(BaseTestModule):
             cmd += f" --event={','.join(self.params.events)}"
 
         return cmd
-
-    def _parse_filename_from_output(self, output: str) -> Optional[str]:
-        for line in output.split("\n"):
-            m = re.match(r"^\[ perf record: Dump (.*?) \]$", line)
-            if m:
-                return m.group(1)
-
-        logging.error("could not parse output filename from perf-record output")
-        return None

--- a/lnst/Tests/LinuxPerf.py
+++ b/lnst/Tests/LinuxPerf.py
@@ -1,0 +1,62 @@
+from typing import Optional
+import subprocess
+import logging
+import re
+import os
+
+from lnst.Tests.BaseTestModule import BaseTestModule
+from lnst.Common.Parameters import StrParam, IntParam, ListParam
+from lnst.Common.Utils import is_installed
+from lnst.Common.ExecCmd import log_output
+
+class LinuxPerf(BaseTestModule):
+    output_file = StrParam(mandatory=True)
+    cpus = ListParam(type=IntParam())
+    events = ListParam(type=StrParam())
+
+    def run(self) -> bool:
+        self._res_data = {}
+        if not is_installed("perf"):
+            self._res_data["msg"] = "perf is not installed on this machine!"
+            logging.error(self._res_data["msg"])
+            return False
+
+        # can't use lnst.Common.ExecCmd.exec_cmd directly, because expected returncode is not zero
+        cmd: str = self._compose_cmd()
+        logging.debug(f"Executing: \"{cmd}\"")
+        process = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
+        )
+
+        self.wait_for_interrupt()
+
+        stdout, stderr = process.communicate()
+
+        if stdout:
+            log_output(logging.debug, "Stdout", stdout.decode())
+        if stderr:
+            log_output(logging.debug, "Stderr", stderr.decode())
+
+        self._res_data["filename"] = os.path.abspath(self._parse_filename_from_output(stderr.decode()))
+        return process.returncode == -2
+
+    def _compose_cmd(self) -> str:
+        cmd: str = "perf record --timestamp-filename"
+        cmd += f" --output={self.params.output_file}"
+
+        if "cpus" in self.params:
+            cmd += f" --cpu={','.join(map(str, self.params.cpus))}"
+
+        if "events" in self.params:
+            cmd += f" --event={','.join(self.params.events)}"
+
+        return cmd
+
+    def _parse_filename_from_output(self, output: str) -> Optional[str]:
+        for line in output.split("\n"):
+            m = re.match(r"^\[ perf record: Dump (.*?) \]$", line)
+            if m:
+                return m.group(1)
+
+        logging.error("could not parse output filename from perf-record output")
+        return None


### PR DESCRIPTION
Runs `perf record` on all Agents on an interrupt-receiveing CPU and on a CPU where `iperf` is running. All collected data is then copied to Controller.

- [x] LinuxPerf test module
- [x] LinuxPerf measurement
- [x] LinuxPerf measurement generator
- [x] Copy `perf-record` result files from Agents to Controller