### PR TITLE
Optional libvirt

### DIFF
--- a/lnst/Controller/ContainerPoolManager.py
+++ b/lnst/Controller/ContainerPoolManager.py
@@ -99,7 +99,7 @@ class ContainerPoolManager(object):
     def _podman_connect(self, podman_uri: str):
         logging.debug("Connecting to Podman API")
         try:
-            client = PodmanClient(base_url=podman_uri)
+            client = PodmanClient(base_url=podman_uri, timeout=60)
             client.info()  # info() will try to connect to the API
         except APIError as e:
             raise PoolManagerError(f"Could not connect to Podman API: {e}")

--- a/lnst/Controller/VirtDomainCtl.py
+++ b/lnst/Controller/VirtDomainCtl.py
@@ -12,8 +12,6 @@ rpazdera@redhat.com (Radek Pazdera)
 """
 
 import logging
-import libvirt
-from libvirt import libvirtError
 from lnst.Controller.Common import ControllerError
 
 #this is a global object because opening the connection to libvirt in every
@@ -22,6 +20,14 @@ from lnst.Controller.Common import ControllerError
 _libvirt_conn = None
 
 def init_libvirt_con():
+    try:
+        import libvirt
+        from libvirt import libvirtError
+    except ModuleNotFoundError:
+        msg = "Failed to import libvirt, please install the dependency if you want to use the libvirt network management feature."
+        logging.error(msg)
+        raise ControllerError(msg)
+
     global _libvirt_conn
     if _libvirt_conn is None:
         _libvirt_conn = libvirt.open(None)

--- a/lnst/Devices/VirtNetCtl.py
+++ b/lnst/Devices/VirtNetCtl.py
@@ -12,8 +12,6 @@ olichtne@redhat.com (Ondrej Lichtner)
 """
 
 import logging
-import libvirt
-from libvirt import libvirtError
 from lnst.Common.LnstError import LnstError
 
 #this is a global object because opening the connection to libvirt in every
@@ -22,6 +20,14 @@ from lnst.Common.LnstError import LnstError
 _libvirt_conn = None
 
 def init_libvirt_con():
+    try:
+        import libvirt
+        from libvirt import libvirtError
+    except ModuleNotFoundError:
+        msg = "Failed to import libvirt, please install libvirt to use the libvirt network management features."
+        logging.error(msg)
+        raise LnstError(msg)
+
     global _libvirt_conn
     if _libvirt_conn is None:
         _libvirt_conn = libvirt.open(None)

--- a/lnst/RecipeCommon/LibvirtControl.py
+++ b/lnst/RecipeCommon/LibvirtControl.py
@@ -1,11 +1,17 @@
 import logging
-import libvirt
-from libvirt import libvirtError
 from lnst.Common.LnstError import LnstError
 from lnst.Common.Logs import log_exc_traceback
 
 class LibvirtControl(object):
     def __init__(self):
+        try:
+            import libvirt
+            from libvirt import libvirtError
+        except ModuleNotFoundError:
+            msg = "Failed to import libvirt, please install libvirt if you want to use the LibvirtControl class."
+            logging.error(msg)
+            raise LnstError(msg)
+
         self._libvirt_conn = libvirt.open(None)
 
     def createXML(self, xml, flags=0):


### PR DESCRIPTION
This is a proposal draft to make libvirt into an optional runtime dependency instead of a hard install dependency.

It is typically not used in many/most of our test recipes and having it as a hard dependency can make the experience of setting up lnst a little bothersome.

The draft status is because I haven't tested these changes yet.