### PR TITLE
docs: specify python3.9 as requirement for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"


### PR DESCRIPTION
By merging the LinuxPerfMeasurement* bits the build of docs on readthedocs [broke](https://readthedocs.org/projects/lnst/builds/16801479/). This is due to python3.7 used for building the docs that is incompatible with type hinting that is present in the LinuxPerfMeasurement* bits.

This patch adds .readthedocs.yml that specifies python3.9 as requirement to build the docs.

I still need to test this as I'm not sure what other bits I need to include in the file.