### PR TITLE
ENRT.LinuxPerfMeasurementGenerator: fix generator return implementation

### DIFF
--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -29,6 +29,7 @@ class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
                 pass
 
         for combination in combinations:
+            res: list[BaseMeasurement]
             if self.params.do_linuxperf_measurement:
                 measurement: BaseMeasurement = LinuxPerfMeasurement(
                     self.matched,

--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -18,24 +18,26 @@ class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
     def generate_perf_measurements_combinations(self, config):
         combinations = super().generate_perf_measurements_combinations(config)
 
-        if not self.params.do_linuxperf_measurement:
-            return combinations
-
-        # create linuxperf data folder
-        linuxperf_data_folder: str = os.path.abspath(
-            os.path.join(self.current_run.log_dir, "linuxperf-data")
-        )
-        try:
-            os.mkdir(linuxperf_data_folder)
-        except FileExistsError:
-            pass
+        if self.params.do_linuxperf_measurement:
+            # create linuxperf data folder
+            linuxperf_data_folder: str = os.path.abspath(
+                os.path.join(self.current_run.log_dir, "linuxperf-data")
+            )
+            try:
+                os.mkdir(linuxperf_data_folder)
+            except FileExistsError:
+                pass
 
         for combination in combinations:
-            measurement: BaseMeasurement = LinuxPerfMeasurement(
-                self.matched,
-                self.linuxperf_cpus,
-                data_folder=linuxperf_data_folder,
-                recipe_conf=config,
-            )
+            if self.params.do_linuxperf_measurement:
+                measurement: BaseMeasurement = LinuxPerfMeasurement(
+                    self.matched,
+                    self.linuxperf_cpus,
+                    data_folder=linuxperf_data_folder,
+                    recipe_conf=config,
+                )
+                res = [measurement] + combination
+            else:
+                res = combination
 
-            yield [measurement] + combination
+            yield res


### PR DESCRIPTION
When 'yield' is used in python it automatically changes the
function/method into a generator. This is regardless of if the yield is
reached or not - this is decided when the function is parsed, not during
runtime.

At the same time, the 'return' statement works differently in a
generator. The return statement raises the 'StopIteration' exception
that is used by loops etc. to detect that the generation has stopped. If
'return' is used with a value, this value is provided to the exception
object:

`return val` is sort of equivalent to `raise StopIteration(val)`

However, when we write:

    for i in generator:

The `StopIteration(val)` simply exits the loop, the `val` itself isn't
assigned to `i` to start one more iteration of the loop.

Because of this the old code of the LinuxPerfMeasurementGenerator when
it simply called `return super().generate_perf_measurements_combinations`
the previous level of the collaborative mixin hierarchy stopped
iteration and didn't receive the previously generated list of
measurement combinations.

To fix this I restructured the method to avoid the use of the `return`
statement, and instead relied on the use of `yield` for the individual
previous values.

Signed-off-by: Ondrej Lichtner <olichtne@redhat.com>