### PR TITLE
Simple SR-IOV Network namespace OvS and Linux bridge recipe

### DIFF
--- a/lnst/Agent/InterfaceManager.py
+++ b/lnst/Agent/InterfaceManager.py
@@ -239,6 +239,9 @@ class InterfaceManager(object):
         old_device = self.get_device(ifindex)
         kwargs["name"] = old_device.name
 
+        if devcls == old_device.__class__:
+            return
+
         try:
             remapped_device = devcls(self, *args, **kwargs)
         except KeyError as e:

--- a/lnst/Controller/Host.py
+++ b/lnst/Controller/Host.py
@@ -57,16 +57,21 @@ class Host(Namespace):
         return ret
 
     def map_device(self, dev_id, how):
-        #TODO if this is supposed to be public it should be better than dict["hwaddr"]!!!!
-        hwaddr = how["hwaddr"]
-        dev = self._machine.get_dev_by_hwaddr(hwaddr)
+        if "hwaddr" in how:
+            hwaddr = how["hwaddr"]
+            dev = self._machine.get_dev_by_hwaddr(hwaddr)
+        elif "ifname" in how:
+            ifname = how["ifname"]
+            dev = self._machine.get_dev_by_ifname(ifname)
+        else:
+            raise ControllerError(f"Unknown how ({how}) mapping method.")
+
         if dev:
             self._objects[dev_id] = dev
             dev._id = dev_id
             dev._enable()
         else:
-            raise ControllerError("Device with macaddr {} not found on {}."
-                                  .format(hwaddr, self.hostid))
+            raise ControllerError(f"Device not found on {self.hostid} when searching by {how}.")
 
     def _custom_setattr(self, name, value):
         if not super(Host, self)._custom_setattr(name, value):

--- a/lnst/Controller/Host.py
+++ b/lnst/Controller/Host.py
@@ -79,6 +79,7 @@ class Host(Namespace):
                 self._machine.add_netns(value)
                 self._objects[name] = value
                 value._machine = self._machine
+                value.params = self.params
                 return True
             else:
                 return False

--- a/lnst/Controller/Machine.py
+++ b/lnst/Controller/Machine.py
@@ -279,6 +279,13 @@ class Machine(object):
                 return dev
         return None
 
+    def get_dev_by_ifname(self, ifname, netns=None):
+        ns_instance = self._get_netns_by_name(netns)
+        for dev in self._device_database[ns_instance].values():
+            if dev.name == ifname:
+                return dev
+        return None
+
     def _find_device_in_any_namespace(self, ifindex, peer_ifindex=None):
         for ns in list(self._namespaces.keys()) + [None]:
             dev = self.dev_db_get_ifindex(ifindex, ns)

--- a/lnst/Controller/Namespace.py
+++ b/lnst/Controller/Namespace.py
@@ -171,6 +171,7 @@ class Namespace(object):
                 value.netns = self
                 self._objects[name] = value
                 self._update_device_id(value, name)
+                value._enable()
                 return True
             else:
                 value._id = name

--- a/lnst/Recipes/ENRT/SRIOVNetnsBridgeRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsBridgeRecipe.py
@@ -1,0 +1,203 @@
+import time
+
+from lnst.Common.Parameters import Param, StrParam
+from lnst.Common.IpAddress import ipaddress
+from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Controller.NetNamespace import NetNamespace
+from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
+from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
+    OffloadSubConfigMixin,
+)
+from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
+    CommonHWSubConfigMixin,
+)
+from lnst.Devices import BridgeDevice
+
+
+class SRIOVNetnsBridgeRecipe(
+    CommonHWSubConfigMixin, OffloadSubConfigMixin, BaremetalEnrtRecipe
+):
+    """
+    This recipe implements Enrt testing for a SRIOV network scenario
+    with VF located in the network namespace to mimic container network.
+    PF with VF representor is plugged into the Linux bridge
+    and setups looks following.
+
+    .. code-block:: none
+
+                      +--------+
+               +------+ switch +-------+
+               |      +--------+       |
+       +-------|------+        +-------|------+
+       |    +--|--+   |        |    +--|--+   |
+    +--|----|eth0|--- |--+  +--|----|eth0|--- |--+
+    |  |    +----+    |  |  |  |    +----+    |  |
+    |  |       |      |  |  |  |       |      |  |
+    |  |vf_representor|  |  |  |vf_representor|  |
+    |  |              |  |  |  |              |  |
+    |  +-Linux bridge-+  |  |  +-Linux bridge-+  |
+    |         |          |  |         |          |
+    |    +-namespace-+   |  |    +-namespace-+   |
+    |   |    vf0     |   |  |   |    vf0     |   |
+    |   +-----------+    |  |   +-----------+    |
+    |      host1         |  |       host2        |
+    +--------------------+  +--------------------+
+
+    All sub configurations are included via Mixin classes.
+
+    The actual test machinery is implemented in the :any:`BaseEnrtRecipe` class.
+    """
+    host1 = HostReq()
+    host1.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+
+    host2 = HostReq()
+    host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+
+    """
+    This parameter was created due to the difference between various kernel and distro
+    versions, not having consistent naming scheme of virtual function.
+    
+    Solution here is to expect deterministic VF name, which is derived from the PF name.
+    With specific kernel parameter `biosdevname=1` we can expect default suffix on 
+    VF to be created to be `_n`, where n is the index of VF created.
+    """
+    vf_suffix = StrParam(default="_0")
+
+    offload_combinations = Param(default=(
+        dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
+        dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
+        dict(gro="on", gso="off", tso="off", tx="on", rx="on"),
+        dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
+        dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
+
+    def test_wide_configuration(self):
+        """
+        Test wide configuration for this recipe involves switching the device to switchdev
+        mode, adding single VF and mapping the VF, as well as its representor.
+        New namespace is created to mimic container networking, where the VF is moved.
+        Next, VF is assigned an IPv4 and IPv6 address on both hosts.
+        Finally, new Linux bridge is created, where PF and VF representor are added, to
+        ensure correct switching of network traffic between the hosts.
+
+        host1.eth0 = 192.168.101.1/24 and fc00::1/64
+
+        host2.eth0 = 192.168.101.2/24 and fc00::2/64
+        """
+        host1, host2 = self.matched.host1, self.matched.host2
+        configuration = super().test_wide_configuration()
+        configuration.test_wide_devices = []
+
+        for i, host in enumerate([host1, host2]):
+            host.run(f"devlink dev eswitch set pci/{host.eth0.bus_info} mode switchdev")
+            time.sleep(2)
+            host.run(f"echo 1 > /sys/class/net/{host.eth0.name}/device/sriov_numvfs")
+            time.sleep(3)
+
+            vf_ifname = dict(ifname=f"{host.eth0.name}{self.params.vf_suffix}")
+            host.map_device("vf_eth0", vf_ifname)
+
+            host.newns = NetNamespace(f"lnst")
+            host.newns.vf_eth0 = host.vf_eth0
+
+            vf_representor_ifname = dict(ifname="eth0")
+            host.map_device("vf_representor_eth0", vf_representor_ifname)
+
+            host.br0 = BridgeDevice()
+            host.br0.slave_add(host.eth0)
+            host.br0.slave_add(host.vf_representor_eth0)
+
+            for dev in [host.eth0, host.newns.vf_eth0, host.vf_representor_eth0, host.br0]:
+                dev.up()
+
+            host.newns.vf_eth0.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+            host.newns.vf_eth0.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+
+            configuration.test_wide_devices.append(host.newns.vf_eth0)
+
+        self.wait_tentative_ips(configuration.test_wide_devices)
+
+        return configuration
+
+    def generate_test_wide_description(self, config):
+        desc = super().generate_test_wide_description(config)
+        host1, host2 = self.matched.host1, self.matched.host2
+        for i, host in enumerate([host1, host2]):
+            desc += [
+                f"Configured {host.hostid}.{host.eth0.name}.driver = switchdev\n"
+                f"Created virtual function on {host.hostid}.{host.eth0.name} = {host.newns.vf_eth0.name}\n"
+                f"Created network_namespace on {host.hostid} = {host.newns.name}\n"
+                f"Moved interface {host.newns.vf_eth0.name} from {host.hostid} root namespace to {host.hostid}.{host.newns.name} namespace\n"
+                f"Created Linux bridge on {host.hostid} = {host.br0.name}\n"
+                f"Configured {host.hostid}.{host.br0.name}.slaves = {host.eth0.name}, {host.vf_representor_eth0.name}"
+            ]
+        desc += [
+            f"Configured {dev.host.hostid}.{dev.name}.ips = {dev.ips}"
+                    for dev in config.test_wide_devices
+                 ]
+        return desc
+
+    def test_wide_deconfiguration(self, config):
+        """
+        Test wide deconfiguration means deleting the Linux bridge and returning the
+        control over the physical function to base driver.
+        Finally virtual function is deleted.
+        """
+        host1, host2 = self.matched.host1, self.matched.host2
+        for i, host in enumerate([host1, host2]):
+            host.run(f"echo 0 > /sys/class/net/{host.eth0.name}/device/sriov_numvfs")
+            time.sleep(2)
+            host.run(f"devlink dev eswitch set pci/{host.eth0.bus_info} mode legacy")
+            time.sleep(3)
+        del config.test_wide_devices
+
+        super().test_wide_deconfiguration(config)
+
+    def generate_ping_endpoints(self, config):
+        """
+        The ping endpoints for this recipe are simply the two matched NICs:
+
+        host1.newns.vf_eth0 and host2.newns.vf_eth0
+
+        Returned as::
+
+            [PingEndpoints(self.matched.host1.eth0, self.matched.host2.eth0)]
+        """
+        return [PingEndpoints(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
+
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for this recipe are simply the two matched NICs:
+
+        host1.newns.vf_eth0 and host2.newns.vf_eth0
+
+        Returned as::
+
+            [(self.matched.host1.eth0, self.matched.host2.eth0)]
+        """
+        return [(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
+
+    @property
+    def pause_frames_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def offload_nics(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def mtu_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def coalescing_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def dev_interrupt_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def parallel_stream_qdisc_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+

--- a/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
@@ -1,0 +1,205 @@
+import time
+
+from lnst.Common.Parameters import Param, StrParam
+from lnst.Common.IpAddress import ipaddress
+from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Controller.NetNamespace import NetNamespace
+from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
+from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
+    OffloadSubConfigMixin,
+)
+from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
+    CommonHWSubConfigMixin,
+)
+from lnst.Devices import OvsBridgeDevice
+
+
+class SRIOVNetnsOvSRecipe(
+    CommonHWSubConfigMixin, OffloadSubConfigMixin, BaremetalEnrtRecipe
+):
+    """
+    This recipe implements Enrt testing for a SRIOV network scenario
+    with VF located in the network namespace to mimic container network.
+    PF with VF representor is plugged into the OvS bridge with enabled
+    hardware offload capabilities and setups looks following.
+
+    .. code-block:: none
+
+                      +--------+
+               +------+ switch +-------+
+               |      +--------+       |
+       +-------|------+        +-------|------+
+       |    +--|--+   |        |    +--|--+   |
+    +--|----|eth0|--- |--+   +--|----|eth0|--- |--+
+    |  |    +----+    |  |   |  |    +----+    |  |
+    |  |       |      |  |   |  |       |      |  |
+    |  |vf_representor|  |   |  |vf_representor|  |
+    |  |              |  |   |  |              |  |
+    |  +--OvS bridge--+  |   |  +--OvS bridge--+  |
+    |         |          |   |         |          |
+    |    +-namespace-+   |   |    +-namespace-+   |
+    |   |    vf0     |   |   |   |    vf0     |   |
+    |   +-----------+    |   |   +-----------+    |
+    |      host1         |   |       host2        |
+    +--------------------+   +--------------------+
+
+    All sub configurations are included via Mixin classes.
+
+    The actual test machinery is implemented in the :any:`BaseEnrtRecipe` class.
+    """
+    host1 = HostReq()
+    host1.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+
+    host2 = HostReq()
+    host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+
+    """
+    This parameter was created due to the difference between various kernel and distro
+    versions, not having consistent naming scheme of virtual function.
+
+    Solution here is to expect deterministic VF name, which is derived from the PF name.
+    With specific kernel parameter `biosdevname=1` we can expect default suffix on 
+    VF to be created to be `_n`, where n is the index of VF created.
+    """
+    vf_suffix = StrParam(default="_0")
+
+    offload_combinations = Param(default=(
+        dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
+        dict(gro="off", gso="on", tso="on", tx="on", rx="on"),
+        dict(gro="on", gso="off", tso="off", tx="on", rx="on"),
+        dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
+        dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
+
+    def test_wide_configuration(self):
+        """
+        Test wide configuration for this recipe involves switching the device to switchdev
+        mode, adding single VF and mapping the VF, as well as its representor.
+        New namespace is created to mimic container networking, where the VF is moved.
+        Next, VF is assigned an IPv4 and IPv6 address on both hosts.
+        Finally, new OvS bridge is created, where PF and VF representor are added, to
+        ensure correct switching of network traffic between the hosts.
+
+        host1.eth0 = 192.168.101.1/24 and fc00::1/64
+
+        host2.eth0 = 192.168.101.2/24 and fc00::2/64
+        """
+        host1, host2 = self.matched.host1, self.matched.host2
+        configuration = super().test_wide_configuration()
+        configuration.test_wide_devices = []
+
+        for i, host in enumerate([host1, host2]):
+            host.run("systemctl enable openvswitch")
+            host.run("systemctl start openvswitch")
+            host.run("ovs-vsctl set Open_vSwitch . other_config:hw-offload=true")
+
+            host.run(f"devlink dev eswitch set pci/{host.eth0.bus_info} mode switchdev")
+            time.sleep(2)
+            host.run(f"echo 1 > /sys/class/net/{host.eth0.name}/device/sriov_numvfs")
+            time.sleep(3)
+
+            vf_ifname = dict(ifname=f"{host.eth0.name}{self.params.vf_suffix}")
+            host.map_device("vf_eth0", vf_ifname)
+
+            host.newns = NetNamespace(f"lnst")
+            host.newns.vf_eth0 = host.vf_eth0
+
+            vf_representor_ifname = dict(ifname="eth0")
+            host.map_device("vf_representor_eth0", vf_representor_ifname)
+
+            host.br0 = OvsBridgeDevice()
+            host.br0.port_add(host.eth0)
+            host.br0.port_add(host.vf_representor_eth0)
+
+            for dev in [host.eth0, host.newns.vf_eth0, host.vf_representor_eth0, host.br0]:
+                dev.up()
+
+            host.newns.vf_eth0.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+            host.newns.vf_eth0.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+
+            configuration.test_wide_devices.append(host.newns.vf_eth0)
+
+        self.wait_tentative_ips(configuration.test_wide_devices)
+
+        return configuration
+
+    def generate_test_wide_description(self, config):
+        desc = super().generate_test_wide_description(config)
+        host1, host2 = self.matched.host1, self.matched.host2
+        for i, host in enumerate([host1, host2]):
+            desc += [
+                f"Configured {host.hostid}.{host.eth0.name}.driver = switchdev\n"
+                f"Created virtual function on {host.hostid}.{host.eth0.name} = {host.newns.vf_eth0.name}\n"
+                f"Created network_namespace on {host.hostid} = {host.newns.name}\n"
+                f"Moved interface {host.newns.vf_eth0.name} from {host.hostid} root namespace to {host.hostid}.{host.newns.name} namespace\n"
+                f"Created OvS bridge on {host.hostid} = {host.br0.name}\n"
+                f"Configured {host.hostid}.{host.br0.name}.slaves = {host.eth0.name}, {host.vf_representor_eth0.name}"
+            ]
+        desc += [
+            f"Configured {dev.host.hostid}.{dev.name}.ips = {dev.ips}"
+            for dev in config.test_wide_devices
+        ]
+
+    def test_wide_deconfiguration(self, config):
+        """
+        Test wide deconfiguration means deleting the OvS bridge and returning the
+        control over the physical function to base driver.
+        Finally virtual function is deleted.
+        """
+        host1, host2 = self.matched.host1, self.matched.host2
+        for i, host in enumerate([host1, host2]):
+            host.run(f"echo 0 > /sys/class/net/{host.eth0.name}/device/sriov_numvfs")
+            time.sleep(2)
+            host.run(f"devlink dev eswitch set pci/{host.eth0.bus_info} mode legacy")
+            time.sleep(3)
+        del config.test_wide_devices
+
+        super().test_wide_deconfiguration(config)
+
+    def generate_ping_endpoints(self, config):
+        """
+        The ping endpoints for this recipe are simply the two matched NICs:
+
+        host1.newns.vf_eth0 and host2.newns.vf_eth0
+
+        Returned as::
+
+            [PingEndpoints(self.matched.host1.eth0, self.matched.host2.eth0)]
+        """
+        return [PingEndpoints(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
+
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for this recipe are simply the two matched NICs:
+
+        host1.newns.vf_eth0 and host2.newns.vf_eth0
+
+        Returned as::
+
+            [(self.matched.host1.eth0, self.matched.host2.eth0)]
+        """
+        return [(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
+
+    @property
+    def pause_frames_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def offload_nics(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def mtu_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def coalescing_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def dev_interrupt_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+
+    @property
+    def parallel_stream_qdisc_hw_config_dev_list(self):
+        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]

--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -100,6 +100,8 @@ from lnst.Recipes.ENRT.VxlanNetnsTunnelRecipe import VxlanNetnsTunnelRecipe
 from lnst.Recipes.ENRT.VxlanGpeTunnelRecipe import VxlanGpeTunnelRecipe
 from lnst.Recipes.ENRT.L2TPTunnelRecipe import L2TPTunnelRecipe
 from lnst.Recipes.ENRT.MPTCPRecipe import MPTCPRecipe
+from lnst.Recipes.ENRT.SRIOVNetnsOvSRecipe import SRIOVNetnsOvSRecipe
+from lnst.Recipes.ENRT.SRIOVNetnsBridgeRecipe import SRIOVNetnsBridgeRecipe
 
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe


### PR DESCRIPTION
Description:

Adding new SR-IOV recipe with a single VF placed in the network namespace to mimic the container behaviour. 

There are changes to Controller.Machine and Host, as well as Agent.InterfaceManager to handle the new scenario,
where we are remapping the device of the same class just with changed network namespace.

To actually remap the VF device, we cannot find it by the MAC address, as that is randomly generated, so there is a new method for Machine to locate the device by its interface name, which is consistent.

Test:

EL8 - 7284398
EL9 - 7284270

Reviews: @olichtne @jtluka 