### PR TITLE
Tests.TestPMD: change -w to -a argument

### DIFF
--- a/lnst/Tests/TestPMD.py
+++ b/lnst/Tests/TestPMD.py
@@ -36,7 +36,7 @@ class TestPMD(BaseTestModule):
 
         for i, nic in enumerate(self.params.nics):
             if self.params.forward_mode == "mac":
-                testpmd_args.extend(["-w", nic])
+                testpmd_args.extend(["-a", nic])
             elif self.params.forward_mode == "macswap":
                 testpmd_args.extend([f"--vdev=net_virtio_user{i+1},path=/var/run/openvswitch/{nic}"])
             else:


### PR DESCRIPTION
The -w (whitelist) argument has been deprecated and removed since DPDK
version 21.11 [1] and is instead replaced by the -a (allowlist)
argument.

[1] https://doc.dpdk.org/guides/rel_notes/release_21_11.html?highlight=whitelist

Signed-off-by: Ondrej Lichtner <olichtne@redhat.com>