### PR TITLE
Trimming measurements results

### DIFF
--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -9,6 +9,33 @@ Requirements
 The first requirement is **Podman**, follow installation steps on
 `official Podman installation page <https://podman.io/getting-started/installation>`_.
 
+
+Configure Podman to use CNI
++++++++++++++++++++++++++++
+
+If you use Podman 4.0+ you need to change default network backend from `netavark` to `CNI` as LNST supports CNI
+only. If your Podman is already running, stop it.
+
+
+1. Remove all the LNST's leftovers from `/etc/cni/net.d/lnst_*.conflist` if you already tried to run LNST
+
+2. Set default network backend to `cni`, add following block to `containers.conf` -
+`documentation <https://github.com/containers/common/blob/main/docs/containers.conf.5.md>`_:
+
+  .. code-block:: toml
+
+    [network]
+    network_backend="cni"
+
+3. Install `CNI` plugins:
+
+  .. code-block:: bash
+
+    dnf install containernetworking-plugins
+
+4. Start your Podman instance
+
+
 Podman API is also required, follow the steps below:
 
 Enabling Podman API service:

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -141,8 +141,8 @@ class NetworkFlowTest(object):
         return self._client_job
 
 class FlowMeasurementResults(BaseMeasurementResults):
-    def __init__(self, measurement, flow):
-        super(FlowMeasurementResults, self).__init__(measurement)
+    def __init__(self, measurement, flow, warmup_duration=0):
+        super(FlowMeasurementResults, self).__init__(measurement, warmup_duration)
         self._flow = flow
         self._generator_results = None
         self._generator_cpu_stats = None
@@ -208,7 +208,7 @@ class FlowMeasurementResults(BaseMeasurementResults):
         )
 
     def time_slice(self, start, end):
-        result_copy = FlowMeasurementResults(self.measurement, self.flow)
+        result_copy = FlowMeasurementResults(self.measurement, self.flow, warmup_duration=0)
 
         result_copy.generator_cpu_stats = self.generator_cpu_stats.time_slice(start, end)
         result_copy.receiver_cpu_stats = self.receiver_cpu_stats.time_slice(start, end)
@@ -363,6 +363,7 @@ class BaseFlowMeasurement(BaseMeasurement):
              parallel_streams=sample_flow.parallel_streams,
              cpupin=None,
              aggregated_flow=True,
+             warmup_duration=sample_flow.warmup_duration
         )
 
         aggregated_result = AggregatedFlowMeasurementResults(
@@ -372,7 +373,9 @@ class BaseFlowMeasurement(BaseMeasurement):
         for i in range(nr_iterations):
             parallel_result = FlowMeasurementResults(
                     measurement=sample_result.measurement,
-                    flow=dummy_flow)
+                    flow=dummy_flow,
+                    warmup_duration=dummy_flow.warmup_duration
+            )
             parallel_result.generator_results = ParallelPerfResult()
             parallel_result.generator_cpu_stats = ParallelPerfResult()
             parallel_result.receiver_results = ParallelPerfResult()

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -19,7 +19,8 @@ class Flow(object):
                  receiver_port=None,
                  msg_size=None,
                  cpupin=None,
-                 aggregated_flow=False):
+                 aggregated_flow=False,
+                 warmup_duration=0):
         self._type = type
 
         self._generator = generator
@@ -35,6 +36,7 @@ class Flow(object):
         self._parallel_streams = parallel_streams
         self._cpupin = cpupin
         self._aggregated_flow=aggregated_flow
+        self._warmup_duration = warmup_duration
 
     @property
     def type(self):
@@ -88,6 +90,10 @@ class Flow(object):
     def aggregated_flow(self):
         return self._aggregated_flow
 
+    @property
+    def warmup_duration(self):
+        return self._warmup_duration
+
     def __repr__(self):
         string = """
         Flow(
@@ -103,7 +109,8 @@ class Flow(object):
             duration={duration},
             parallel_streams={parallel_streams},
             cpupin={cpupin},
-            aggregated_flow={aggregated_flow},
+            aggregated_flow={aggregated_flow}
+            warmup_duration={warmup_duration},
         )""".format(
             type=self.type,
             generator=str(self.generator),
@@ -118,6 +125,7 @@ class Flow(object):
             parallel_streams=self.parallel_streams,
             cpupin=self.cpupin,
             aggregated_flow=self._aggregated_flow,
+            warmup_duration=self._warmup_duration
         )
         string = textwrap.dedent(string).strip()
         return string
@@ -154,7 +162,7 @@ class FlowMeasurementResults(BaseMeasurementResults):
         return self._flow
 
     @property
-    def generator_results(self):
+    def generator_results(self) -> ParallelPerfResult:
         return self._generator_results
 
     @generator_results.setter
@@ -170,7 +178,7 @@ class FlowMeasurementResults(BaseMeasurementResults):
         self._generator_cpu_stats = value
 
     @property
-    def receiver_results(self):
+    def receiver_results(self) -> ParallelPerfResult:
         return self._receiver_results
 
     @receiver_results.setter

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -215,6 +215,30 @@ class FlowMeasurementResults(BaseMeasurementResults):
             ]
         )
 
+    @property
+    def warmup_end(self):
+        if self.warmup_duration == 0:
+            return self.start_timestamp
+
+        return max(
+            [
+                parallel[self.warmup_duration - 1].end_timestamp
+                for parallel in (*self.generator_results, *self.receiver_results)
+            ]
+        )
+
+    @property
+    def warmdown_start(self):
+        if self.warmup_duration == 0:
+            return self.end_timestamp
+
+        return min(
+            [
+                parallel[-self.warmup_duration].start_timestamp
+                for parallel in (*self.generator_results, *self.receiver_results)
+            ]
+        )
+
     def time_slice(self, start, end):
         result_copy = FlowMeasurementResults(self.measurement, self.flow, warmup_duration=0)
 

--- a/lnst/RecipeCommon/Perf/Measurements/BaseMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseMeasurement.py
@@ -39,12 +39,17 @@ class BaseMeasurement(object):
 
 
 class BaseMeasurementResults(object):
-    def __init__(self, measurement: BaseMeasurement):
+    def __init__(self, measurement: BaseMeasurement, warmup=0):
         self._measurement = measurement
+        self._warmup_duration = warmup
 
     @property
     def measurement(self) -> BaseMeasurement:
         return self._measurement
+
+    @property
+    def warmup_duration(self):
+        return self._warmup_duration
 
     def align_data(self, start, end):
         return self

--- a/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
@@ -90,7 +90,9 @@ class IperfFlowMeasurement(BaseFlowMeasurement):
         for test_flow in test_flows:
             flow_results = FlowMeasurementResults(
                     measurement=self,
-                    flow=test_flow.flow)
+                    flow=test_flow.flow,
+                    warmup_duration=test_flow.flow.warmup_duration
+            )
             flow_results.generator_results = self._parse_job_streams(
                     test_flow.client_job)
             flow_results.generator_cpu_stats = self._parse_job_cpu(

--- a/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
@@ -1,5 +1,6 @@
 import re
 import time
+from typing import List
 
 from lnst.Common.IpAddress import ipaddress
 
@@ -9,6 +10,7 @@ from lnst.Controller.RecipeResults import ResultLevel
 from lnst.RecipeCommon.Perf.Results import PerfInterval
 from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
 from lnst.RecipeCommon.Perf.Results import ParallelPerfResult
+from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import Flow
 from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import NetworkFlowTest
 from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import BaseFlowMeasurement
 from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import FlowMeasurementResults
@@ -20,7 +22,7 @@ from lnst.Tests.Iperf import IperfClient, IperfServer
 class IperfFlowMeasurement(BaseFlowMeasurement):
     _MEASUREMENT_VERSION = 1
 
-    def __init__(self, flows, recipe_conf=None):
+    def __init__(self, flows: List[Flow], recipe_conf=None):
         super(IperfFlowMeasurement, self).__init__(recipe_conf)
         self._flows = flows
         self._running_measurements = []
@@ -136,7 +138,8 @@ class IperfFlowMeasurement(BaseFlowMeasurement):
         host = flow.generator
         client_params = {
             "server": ipaddress(flow.receiver_bind),
-            "duration": flow.duration
+            "duration": flow.duration,
+            "warmup_duration": flow.warmup_duration
         }
 
         if flow.type == "tcp_stream":

--- a/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
@@ -132,8 +132,10 @@ class IperfFlowMeasurement(BaseFlowMeasurement):
 
     def _prepare_client(self, flow):
         host = flow.generator
-        client_params = dict(server = ipaddress(flow.receiver_bind),
-                             duration = flow.duration)
+        client_params = {
+            "server": ipaddress(flow.receiver_bind),
+            "duration": flow.duration
+        }
 
         if flow.type == "tcp_stream":
             #tcp stream is the default for iperf3

--- a/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
@@ -129,7 +129,9 @@ class NeperFlowMeasurement(BaseFlowMeasurement):
         for test_flow in test_flows:
             flow_results = FlowMeasurementResults(
                     measurement=self,
-                    flow=test_flow.flow)
+                    flow=test_flow.flow,
+                    warmup_duration=test_flow.flow.warmup_duration
+            )
             generator_stats = self._parse_job_samples(test_flow.client_job)
             flow_results.generator_results = generator_stats[0]
             flow_results.generator_cpu_stats = generator_stats[1]

--- a/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
@@ -73,7 +73,8 @@ class NeperFlowMeasurement(BaseFlowMeasurement):
         host = flow.receiver
         server_params = dict(workload = flow.type,
                              bind = ipaddress(flow.receiver_bind),
-                             test_length = flow.duration)
+                             test_length = flow.duration,
+                             warmup_duration = flow.warmup_duration)
 
         self._set_cpupin_params(server_params, flow.cpupin)
 
@@ -88,7 +89,8 @@ class NeperFlowMeasurement(BaseFlowMeasurement):
         host = flow.generator
         client_params = dict(workload = flow.type,
                              server = ipaddress(flow.receiver_bind),
-                             test_length = flow.duration)
+                             test_length = flow.duration,
+                             warmup_duration = flow.warmup_duration)
 
         self._set_cpupin_params(client_params, flow.cpupin)
 

--- a/lnst/RecipeCommon/Perf/Measurements/TRexFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TRexFlowMeasurement.py
@@ -137,7 +137,7 @@ class TRexFlowMeasurement(BaseFlowMeasurement):
         return result
 
     def _parse_results_by_port(self, job, port, flow):
-        results = FlowMeasurementResults(measurement=self, flow=flow)
+        results = FlowMeasurementResults(measurement=self, flow=flow, warmup_duration=flow.warmup_duration)
         results.generator_results = SequentialPerfResult()
         results.generator_cpu_stats = SequentialPerfResult()
 

--- a/lnst/RecipeCommon/Perf/Results.py
+++ b/lnst/RecipeCommon/Perf/Results.py
@@ -76,7 +76,7 @@ class PerfInterval(PerfResult):
                 float(self.value), self.unit, float(self.duration))
 
     def time_slice(self, start, end):
-        if end < self.start_timestamp or start > self.end_timestamp:
+        if end <= self.start_timestamp or start >= self.end_timestamp:
             raise EmptySlice(
                 "current start, end {} {}; request start, end {}, {}".format(
                     self.start_timestamp, self.end_timestamp, start, end,

--- a/lnst/Recipes/ENRT/MeasurementGenerators/FlowMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/FlowMeasurementGenerator.py
@@ -93,6 +93,7 @@ class FlowMeasurementGenerator(BaseMeasurementGenerator):
     perf_parallel_streams = IntParam(default=1)
     perf_parallel_processes = IntParam(default=1)
     perf_msg_sizes = ListParam(default=[123])
+    perf_warmup_duration = IntParam(default=0, mandatory=False)
 
     net_perf_tool = ChoiceParam(type=StrParam, choices=MEASUREMENT_LOOKUP.keys(), default='iperf')
 
@@ -230,6 +231,7 @@ class FlowMeasurementGenerator(BaseMeasurementGenerator):
             receiver_port=server_port,
             msg_size=msg_size,
             duration=self.params.perf_duration,
+            warmup_duration=self.params.perf_warmup_duration,
             parallel_streams=self.params.perf_parallel_streams,
             cpupin=cpupin,
         )

--- a/lnst/Tests/Neper.py
+++ b/lnst/Tests/Neper.py
@@ -25,6 +25,7 @@ class NeperBase(BaseTestModule):
     num_flows = IntParam()
     num_threads = IntParam()
     test_length = IntParam()
+    warmup_duration = IntParam(default=0, mandatory=False)
     request_size = IntParam()
     response_size = IntParam()
     opts = StrParam()
@@ -137,4 +138,4 @@ class NeperClient(NeperBase):
 
     def runtime_estimate(self):
         _overhead = 5
-        return self.params.test_length + _overhead
+        return self.params.test_length + self.params.warmup_duration * 2 + _overhead


### PR DESCRIPTION
* Fixed slicing intervals (`time_slice()`):
Condition used in slicing intervals allows to slice interval to interval with duration of 0. Interval may not be sliced also for cases, when `end` of new interval is equal to interval's start - it would create an interval [1, 1] instead of [1, 1).
* Added `perf_warmup_duration` parameter for recipes, that uses `Iperf`. It represents warmup and warmdown period, so iperf will measure for `perf_duration + perf_warmup_duration * 2 seconds`, the default value is `0`.
* Trimming results based on latest start of measurement and earliest end of measurements in SINGLE result has been replaced by trimming results by latest measurement. So for example, if there is a list of results `[StatCPUMeasurementResults, StatCPUMeasurementResults, FlowMeasurementResults]` the old version of trimming `StatCPUMeasurementResults`s did not respect the measurement times of `FlowMeasurementResults`. Now, these results are trimmed by latest measurement - `FlowMeasurementResults`. That results to all the results now starts at the same time.
* Added CNI configuration steps to docs

As these are breaking changes, i would like to do some analysis, how it affects testing results so feel free to review for now.

Closes https://github.com/LNST-project/lnst/issues/246