### PR TITLE
External.TRexLib: move import_optionals to run method

### DIFF
--- a/lnst/External/TRex/TRexLib.py
+++ b/lnst/External/TRex/TRexLib.py
@@ -36,7 +36,6 @@ class TRexCli:
     trex_stl_path = 'trex_client/interactive'
 
     def __init__(self, params):
-        self._import_optionals()
         self.params = params
         self.results = {}
         for key in TREX_CLI_DEFAULT_PARAMS:
@@ -56,6 +55,7 @@ class TRexCli:
     def run(self):
         sys.path.insert(0, os.path.join(self.params.trex_dir,
                                         self.trex_stl_path))
+        self._import_optionals()
 
         try:
             return self._run(trex_api)


### PR DESCRIPTION
The optionals are runtime optionals that can be relevant to the specific
host where the trex is to be executed, and the import depends on the
sys.path variable being updated to include the specified parametrized
path.

Therefore the `_import_optionals` method should only be called in the
run method.

Signed-off-by: Ondrej Lichtner <olichtne@redhat.com>