### PR TITLE
External.TRex: fix * imports and globals export

### DIFF
--- a/lnst/External/TRex/TRexLib.py
+++ b/lnst/External/TRex/TRexLib.py
@@ -46,6 +46,7 @@ class TRexCli:
     def _import_optionals():
         try:
             from trex.stl import api as trex_api
+            global trex_api
         except ModuleNotFoundError as e:
             raise DependencyError(e)
 

--- a/lnst/External/TRex/UDPMultiflow.py
+++ b/lnst/External/TRex/UDPMultiflow.py
@@ -15,8 +15,10 @@ class UDPMultiflow(object):
     @staticmethod
     def _import_optionals():
         try:
-            from trex_stl_lib.api import *
-            from trex.stl.trex_stl_hltapi import *
+            from trex_stl_lib.api import Ether, IP, UDP, STLPktBuilder, STLStream, STLTXCont
+            from trex.stl.trex_stl_hltapi import STLVM
+            global Ether, IP, UDP, STLPktBuilder, STLStream, STLTXCont
+            global STLVM
         except ModuleNotFoundError as e:
             raise DependencyError(e)
 

--- a/lnst/External/TRex/UDPSimple.py
+++ b/lnst/External/TRex/UDPSimple.py
@@ -16,7 +16,8 @@ class UDPSimple(object):
     @staticmethod
     def _import_optionals():
         try:
-            from trex_stl_lib.api import *
+            from trex_stl_lib.api import Ether, IP, UDP, STLPktBuilder, STLStream, STLTXCont
+            global Ether, IP, UDP, STLPktBuilder, STLStream, STLTXCont
         except ModuleNotFoundError as e:
             raise DependencyError(e)
 


### PR DESCRIPTION
from x import * is only supported on the global level so we need to
specify the actual objects to import.

We also need to export them as globals for the rest of the modules to
work correctly.

Signed-off-by: Ondrej Lichtner <olichtne@redhat.com>