### PR TITLE
Perf.BaselineFlowAverageEvaluator: fix result text formatting

### DIFF
--- a/lnst/RecipeCommon/Perf/Evaluators/BaselineFlowAverageEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/BaselineFlowAverageEvaluator.py
@@ -92,6 +92,9 @@ class BaselineFlowAverageEvaluator(BaselineEvaluator):
         else:
             comparison = ResultType.FAIL
 
-        result_text = "IMPROVEMENT: " if comparison == ResultType.WARNING else f"{comparison}: " + result_text
+        if comparison == ResultType.WARNING:
+            result_text = f"IMPROVEMENT: {result_text}"
+        else:
+            result_text = f"{comparison}: {result_text}"
 
         return comparison, result_text


### PR DESCRIPTION
Description:  

When an improvement is detected, the formatting simply overwrote the
comparison line completely with "IMPROVEMENT:" instead of prepending
this to the line text like for the other cases.
  
Tests:  

standard automated tests suffice for this. Will proceed in a hotfix manner for this - if tests pass i'll continue with merge.

Reviews:  

not necessary if tests pass.

Closes: #  
