### PR TITLE
Recipes/BaremetalEnrtRecipe: avoid duplication of perf profiled cpus

### DIFF
--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -7,12 +7,19 @@ from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import (
 from lnst.RecipeCommon.Perf.Measurements.LinuxPerfMeasurement import (
     LinuxPerfMeasurement,
 )
-from lnst.Common.Parameters import BoolParam
+from lnst.Common.Parameters import (
+    BoolParam,
+    IntParam,
+    ListParam,
+)
+from lnst.Common.LnstError import LnstError
 
 import os
 
+
 class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
     do_linuxperf_measurement = BoolParam(default=False)
+    linuxperf_cpus_override = ListParam(type=ListParam(type=IntParam()), mandatory=False)
 
     def generate_perf_measurements_combinations(self, config):
         combinations = super().generate_perf_measurements_combinations(config)
@@ -27,12 +34,27 @@ class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
             except FileExistsError:
                 pass
 
+        profiled_cpu_groups: list[list[int]] = []
+        if self.params.get("linuxperf_cpus_override"):
+            profiled_cpu_groups = self.params.linuxperf_cpus_override
+        else:
+            profiled_cpu_groups = getattr(self, "linuxperf_cpus", [])
+
+        # TODO: in case no group of cpus is in the list, we may simply run
+        # profiler without the cpu specified, however this requires additional
+        # changes in the LinuxPerfMeasurement class; for now, let's just
+        # disallow this by raising an exception
+        if self.params.do_linuxperf_measurement and not profiled_cpu_groups:
+            raise LnstError(
+                "Cannot profile empty list of cpus when do_linuxperf_measurement parameter is specified"
+            )
+
         for combination in combinations:
             res: list[BaseMeasurement]
             if self.params.do_linuxperf_measurement:
                 measurement: BaseMeasurement = LinuxPerfMeasurement(
                     self.matched,
-                    self.linuxperf_cpus,
+                    profiled_cpu_groups,
                     data_folder=linuxperf_data_folder,
                     recipe_conf=config,
                 )


### PR DESCRIPTION
Description:  

If dev_intr_cpu and perf_tool_cpu contain the same cpus the LinuxPerf measurement would run perf profiler on these cpus twice, also writing to the same file at the same time, corrupting the data.

The two lists need to be aggregated and remove duplicates to avoid the conflict.

Fixes #255
  
Tests:  

RH internal job ids: ~~J:7083780~~ ~~J:7083775~~ J:7108529 (no override) J:7108533 (override)

Reviews:  

@olichtne @Kuba314 

Closes: #255 
