### PR TITLE
Per metric thresholds

### DIFF
--- a/lnst/Controller/RunSummaryFormatter.py
+++ b/lnst/Controller/RunSummaryFormatter.py
@@ -107,8 +107,9 @@ class RunSummaryFormatter(object):
             except IndexError:
                 pass
 
-            output_lines.append("{res} {src}{desc}".format(
+            output_lines.append("{res} {result_index}_{src}{desc}".format(
                 res = self._format_result(res.result),
+                result_index=run.results.index(res),
                 src = self._format_source(res),
                 desc = ("\t{}".format(res.description)
                     if res.description.count('\n') == 0

--- a/lnst/RecipeCommon/Perf/Evaluators/BaselineEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/BaselineEvaluator.py
@@ -47,9 +47,11 @@ class BaselineEvaluator(BaseResultEvaluator):
         result_text = self.describe_group_results(recipe, recipe_conf, results)
 
         baselines = self.get_baselines(recipe, recipe_conf, results)
-        for result, baseline in zip(results, baselines):
+        result_index = len(recipe.current_run.results)
+
+        for i, (result, baseline) in enumerate(zip(results, baselines)):
             comparison, text = self.compare_result_with_baseline(
-                recipe, recipe_conf, result, baseline
+                recipe, recipe_conf, result, baseline, result_index
             )
             comparison_result = ResultType.max_severity(comparison_result, comparison)
             result_text.extend(text)
@@ -86,5 +88,6 @@ class BaselineEvaluator(BaseResultEvaluator):
         recipe_conf: PerfRecipeConf,
         result: PerfMeasurementResults,
         baseline: PerfMeasurementResults,
+        result_index: int = 0
     ) -> Tuple[ResultType, List[str]]:
         return ResultType.FAIL, ["Result to baseline comparison not implemented"]


### PR DESCRIPTION
Description:  
Replaced "per type" thresholds support with "per metric" thresholds. BaselineEvaluators now requires `dict` in following format:
`{"[RESULT_INDEX]_[METRIC_NAME]"}`:
* `[RESULT_INDEX]` is index of measurement result in `BaseRecipe.current_run` list. This index is used to distinguish same type measurement because those measurements have same name.
* `[METRIC_NAME]` is name of metric, it usually comes from `Evaluator._metrics_to_evaluate`

For example:
`throughput_avg_threshold=18.05;cpu_avg_threshold=15.08` recipe parameters needs to be changed to:
```json
"thresholds": {
   "189_generator_results": 18.05,
   "189_generator_cpu_stats": 15.08,
   "189_receiver_results": 18.05,
   "189_receiver_cpu_stats": 15.08,
   "182_host1": 15.08,
   "183_host2": 15.08,
   "190_host1": 1.5
}
```
As replacing `throughput_avg_threshold` and `cpu_avg_threshold` by `thresholds` recipe parameter takes a place.
  
Tests:  
`J:7098330`

Reviews:  
@Axonis @olichtne @jtluka 
