### PR TITLE
RecipeCommon.Perf.BaselineEvaluator: add data to result object

### DIFF
--- a/lnst/Controller/Recipe.py
+++ b/lnst/Controller/Recipe.py
@@ -160,6 +160,9 @@ class BaseRecipe(object):
         self.current_run.add_result(Result(result, description, data,
                                            level, data_level))
 
+    def add_custom_result(self, result: BaseResult):
+        self.current_run.add_result(result)
+
     def __getstate__(self):
         state = self.__dict__.copy()
         state['_ctl'] = None

--- a/lnst/RecipeCommon/Perf/Evaluators/BaselineEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/BaselineEvaluator.py
@@ -1,11 +1,15 @@
 from typing import List, Tuple
 from lnst.Controller.Recipe import BaseRecipe
-from lnst.Controller.RecipeResults import ResultType
+from lnst.Controller.RecipeResults import ResultType, Result
 from lnst.RecipeCommon.BaseResultEvaluator import BaseResultEvaluator
 from lnst.RecipeCommon.Perf.Recipe import RecipeConf as PerfRecipeConf
 from lnst.RecipeCommon.Perf.Measurements.Results import (
     BaseMeasurementResults as PerfMeasurementResults,
 )
+
+
+class BaselineEvaluationResult(Result):
+    pass
 
 
 class BaselineEvaluator(BaseResultEvaluator):
@@ -68,10 +72,12 @@ class BaselineEvaluator(BaseResultEvaluator):
                 }
             )
 
-        recipe.add_result(
-            cumulative_result,
-            "\n".join(result_text),
-            data={"comparisons": comparisons},
+        recipe.add_custom_result(
+            BaselineEvaluationResult(
+                cumulative_result,
+                "\n".join(result_text),
+                data={"comparisons": comparisons},
+            )
         )
 
     def describe_group_results(

--- a/lnst/Recipes/ENRT/ConfigMixins/DevInterruptHWConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/DevInterruptHWConfigMixin.py
@@ -119,7 +119,11 @@ class DevInterruptHWConfigMixin(BaseHWConfigMixin):
         else:
             set_down = False
 
-        dev_id_regex = r"({})|({})".format(dev.name, dev.bus_info)
+        if dev.bus_info:
+            dev_id_regex = r"({})|({})".format(dev.name, dev.bus_info)
+        else:
+            dev_id_regex = r"{}".format(dev.name)
+
         res = dev.netns.run(
             "grep -P \"{}\" /proc/interrupts | cut -f1 -d: | sed 's/ //'".format(
                 dev_id_regex
@@ -131,4 +135,8 @@ class DevInterruptHWConfigMixin(BaseHWConfigMixin):
             # set device back down if we set it up
             dev.down()
 
-        return [int(intr.strip()) for intr in res.stdout.strip().split('\n')]
+        return [
+            int(intr.strip())
+            for intr in res.stdout.strip().split("\n")
+            if intr != ""
+        ]


### PR DESCRIPTION
Description:  

Having access to the evaluation data as part of the created final Result object can be very helpful for post run analysis and is difficult to find without this direct link.

As the data is already present somewhere in the lrc file this shouldn't add any overhead except a simple object link to one additional place.

I am also considering defining a custom `class BaselineComparisonResult(Result)` which would be used here instead which could make the filtering in analysis tools even easier because we could simply do:

`comparison_results = [i for i in lrc.results if isinstance(i, BaselineComparisonResult)]`

What do you guys think?

I've had this prepared for quite a while but I think I really require this now to implement the inclusion of analysis data into dashboard - some of the data fields that we want to send are difficult to retrieve without this.
  
Tests:  

beaker job: `J:7102548`

Reviews: 

@jtluka @enhaut @Axonis 

Closes: #  
