### PR TITLE
Test Network Address Parameters

### DIFF
--- a/lnst/Recipes/ENRT/DoubleBondRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleBondRecipe.py
@@ -1,5 +1,11 @@
-from lnst.Common.Parameters import Param, StrParam, IntParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    StrParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -25,23 +31,25 @@ class DoubleBondRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
         dict(gro="on", gso="off", tso="off", tx="on"),
         dict(gro="on", gso="on", tso="off", tx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
+
     bonding_mode = StrParam(mandatory=True)
     miimon_value = IntParam(mandatory=True)
 
     def test_wide_configuration(self):
         host1, host2 = self.matched.host1, self.matched.host2
 
-        net_addr = "192.168.101"
-        net_addr6 = "fc00:0:0:0"
-        for i, host in enumerate([host1, host2]):
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for host in [host1, host2]:
             host.bond0 = BondDevice(mode=self.params.bonding_mode,
                 miimon=self.params.miimon_value)
             for dev in [host.eth0, host.eth1]:
                 dev.down()
                 host.bond0.slave_add(dev)
-            host.bond0.ip_add(ipaddress(net_addr + "." + str(i+1) + "/24"))
-            host.bond0.ip_add(ipaddress(net_addr6 + "::" + str(i+1) +
-                "/64"))
+            host.bond0.ip_add(next(ipv4_addr))
+            host.bond0.ip_add(next(ipv6_addr))
             for dev in [host.eth0, host.eth1, host.bond0]:
                 dev.up()
 

--- a/lnst/Recipes/ENRT/DoubleTeamRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleTeamRecipe.py
@@ -1,5 +1,10 @@
-from lnst.Common.Parameters import Param, StrParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    StrParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -25,24 +30,25 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
         dict(gro="on", gso="off", tso="off", tx="on"),
         dict(gro="on", gso="on", tso="off", tx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    net_ipv6 = IPv6NetworkParam(default='fc00:0:0:1::/64')
+
     runner_name = StrParam(mandatory=True)
 
     def test_wide_configuration(self):
         host1, host2 = self.matched.host1, self.matched.host2
 
-        net_addr_1 = "192.168.10"
-        net_addr6_1 = "fc00:0:0:1"
-        for i, host in enumerate([host1, host2]):
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for host in [host1, host2]:
             host.team0 = TeamDevice(
                     config={'runner': {'name': self.params.runner_name}}
                     )
             for dev in [host.eth0, host.eth1]:
                 dev.down()
                 host.team0.slave_add(dev)
-            host.team0.ip_add(ipaddress(net_addr_1 + "." + str(i+1) +
-                "/24"))
-            host.team0.ip_add(ipaddress(net_addr6_1 + "::" + str(i+1) +
-                "/64"))
+            host.team0.ip_add(next(ipv4_addr))
+            host.team0.ip_add(next(ipv6_addr))
             for dev in [host.eth0, host.eth1, host.team0]:
                 dev.up()
 

--- a/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
@@ -1,9 +1,9 @@
 import signal
 import logging
 import copy
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Common.IpAddress import AF_INET, AF_INET6
-from lnst.Common.Parameters import StrParam
+from lnst.Common.Parameters import StrParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.LnstError import LnstError
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
@@ -51,6 +51,11 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="to_switch", driver=RecipeParam("driver"))
 
+    net1_ipv4 = IPv4NetworkParam(default="192.168.99.0/24")
+    net1_ipv6 = IPv6NetworkParam(default="fc00:1::/64")
+    net2_ipv4 = IPv4NetworkParam(default="192.168.100.0/24")
+    net2_ipv6 = IPv6NetworkParam(default="fc00:2::/64")
+
     algorithm = [('rfc4106(gcm(aes))', 160, 96)]
     spi_values = ["0x00001000", "0x00001001"]
     ipsec_mode = StrParam(default="transport")
@@ -69,12 +74,14 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [host1.eth0, host2.eth0]
 
-        net_addr = "192.168."
-        net_addr6 = "fc00:"
-        for i, host in enumerate([host1, host2]):
+        ipv4_addr = {host1: interface_addresses(self.params.net1_ipv4),
+                     host2: interface_addresses(self.params.net2_ipv4)}
+        ipv6_addr = {host1: interface_addresses(self.params.net1_ipv6),
+                     host2: interface_addresses(self.params.net2_ipv6)}
+        for host in [host1, host2]:
             host.eth0.down()
-            host.eth0.ip_add(ipaddress(net_addr + str(i + 99) + ".1/24"))
-            host.eth0.ip_add(ipaddress(net_addr6 + str(i + 1) + "::1/64"))
+            host.eth0.ip_add(next(ipv4_addr[host]))
+            host.eth0.ip_add(next(ipv6_addr[host]))
             host.eth0.up()
 
         self.wait_tentative_ips(configuration.test_wide_devices)

--- a/lnst/Recipes/ENRT/MPTCPRecipe.py
+++ b/lnst/Recipes/ENRT/MPTCPRecipe.py
@@ -1,8 +1,8 @@
 from socket import AF_INET, AF_INET6
 from typing import List
 
-from lnst.Common.Parameters import Param
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import Param, IPv4NetworkParam, IPv6NetworkParam
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.Host import Host
 from lnst.RecipeCommon.MPTCPManager import MPTCPManager, MPTCPFlags
@@ -35,7 +35,12 @@ class MPTCPRecipe(
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
-    #Only use mptcp
+    net1_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net1_ipv6 = IPv6NetworkParam(default="fc00::/64")
+    net2_ipv4 = IPv4NetworkParam(default="192.168.102.0/24")
+    net2_ipv6 = IPv6NetworkParam(default="fc01::/64")
+
+    # Only use mptcp
     perf_tests = Param(default=("mptcp_stream",))
 
     def init_mptcp_control(self, hosts: List[Host]):
@@ -68,12 +73,21 @@ class MPTCPRecipe(
 
         self.init_mptcp_control(hosts)
 
-        for i, host in enumerate(hosts):
+        ipv4_addr1 = interface_addresses(self.params.net1_ipv4)
+        ipv6_addr1 = interface_addresses(self.params.net1_ipv6)
+        ipv4_addr2 = interface_addresses(self.params.net2_ipv4)
+        ipv6_addr2 = interface_addresses(self.params.net2_ipv6)
+
+        save_addrs = {}
+
+        for host in hosts:
             host.run("sysctl -w /net/mptcp/enabled=1")
-            host.eth0.ip_add(ipaddress("192.168.101." + str(i+1) + "/24"))
-            host.eth1.ip_add(ipaddress("192.168.102." + str(i+1) + "/24"))
-            host.eth0.ip_add(ipaddress("fc00::" + str(i+1) + "/64"))
-            host.eth1.ip_add(ipaddress("fc01::" + str(i+1) + "/64"))
+            host.eth0.ip_add(next(ipv4_addr1))
+            host.eth0.ip_add(next(ipv6_addr1))
+            host.eth1.ip_add(save_addr4 := next(ipv4_addr2))
+            host.eth1.ip_add(save_addr6 := next(ipv6_addr2))
+            save_addrs[host.eth1] = {AF_INET: save_addr4, AF_INET6: save_addr6}
+
             host.eth0.up()
             host.eth1.up()
             config.test_wide_devices.append(host.eth0)
@@ -83,13 +97,19 @@ class MPTCPRecipe(
         if "ipv4" in self.params.ip_versions:
             host1.mptcp.add_endpoints(host1.eth1.ips_filter(family=AF_INET), flags=MPTCPFlags.MPTCP_PM_ADDR_FLAG_SUBFLOW)
             # Need route on client side to populate forwarding table
-            host1.run(f"ip route add 192.168.101.0/24 dev {host1.eth1.name} via 192.168.102.2 prio 10000")
+            host1.run(
+                f"ip route add {self.params.net1_ipv4} dev {host1.eth1.name}"
+                f" via {save_addrs[host2.eth1][AF_INET]} prio 10000"
+            )
             # Need to disable rp_filter on server side
             host2.run("sysctl -w net.ipv4.conf.all.rp_filter=0")
 
         if "ipv6" in self.params.ip_versions:
             host1.mptcp.add_endpoints(host1.eth1.ips_filter(family=AF_INET6), flags=MPTCPFlags.MPTCP_PM_ADDR_FLAG_SUBFLOW)
-            host1.run(f"ip route add fc00::/64 dev {host1.eth1.name} via fc01::2 prio 10000")
+            host1.run(
+                f"ip route add {self.params.net1_ipv6} dev {host1.eth1.name}"
+                f" via {save_addrs[host2.eth1][AF_INET6]} prio 10000"
+            )
             # ipv6 doesnt have rp_filter
 
         # Configure limits

--- a/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
+++ b/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
@@ -67,7 +67,6 @@ class OvSDPDKPvPRecipe(BasePvPRecipe):
     def test(self):
         self.check_dependencies()
         ping_config = self.gen_ping_config()
-        self.warmup(ping_config)
 
         config = OVSPvPTestConf()
         self.pvp_test(config)

--- a/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
@@ -1,7 +1,12 @@
 import time
 
-from lnst.Common.Parameters import Param, StrParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    StrParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.NetNamespace import NetNamespace
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
@@ -71,6 +76,10 @@ class SRIOVNetnsOvSRecipe(
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
+
+
     def test_wide_configuration(self):
         """
         Test wide configuration for this recipe involves switching the device to switchdev
@@ -87,6 +96,9 @@ class SRIOVNetnsOvSRecipe(
         host1, host2 = self.matched.host1, self.matched.host2
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []
+
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
 
         for i, host in enumerate([host1, host2]):
             host.run("systemctl enable openvswitch")
@@ -113,9 +125,8 @@ class SRIOVNetnsOvSRecipe(
 
             for dev in [host.eth0, host.newns.vf_eth0, host.vf_representor_eth0, host.br0]:
                 dev.up()
-
-            host.newns.vf_eth0.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
-            host.newns.vf_eth0.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+            host.newns.vf_eth0.ip_add(next(ipv4_addr))
+            host.newns.vf_eth0.ip_add(next(ipv6_addr))
 
             configuration.test_wide_devices.append(host.newns.vf_eth0)
 

--- a/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
@@ -1,5 +1,5 @@
-from lnst.Common.Parameters import Param
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import Param, IPv4NetworkParam, IPv6NetworkParam
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
@@ -46,6 +46,9 @@ class SimpleNetworkRecipe(
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
+
     def test_wide_configuration(self):
         """
         Test wide configuration for this recipe involves just adding an IPv4 and
@@ -59,9 +62,12 @@ class SimpleNetworkRecipe(
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []
 
-        for i, host in enumerate([host1, host2]):
-            host.eth0.ip_add(ipaddress("192.168.101." + str(i+1) + "/24"))
-            host.eth0.ip_add(ipaddress("fc00::" + str(i+1) + "/64"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+
+        for host in [host1, host2]:
+            host.eth0.ip_add(next(ipv4_addr))
+            host.eth0.ip_add(next(ipv6_addr))
             host.eth0.up()
             configuration.test_wide_devices.append(host.eth0)
 

--- a/lnst/Recipes/ENRT/VhostNetPvPRecipe.py
+++ b/lnst/Recipes/ENRT/VhostNetPvPRecipe.py
@@ -50,7 +50,6 @@ class VhostNetPvPRecipe(BasePvPRecipe):
 
     def test(self):
         self.check_params()
-        self.warmup(self.gen_ping_config())
 
         config = VhostPvPTestConf()
         self.pvp_test(config)

--- a/lnst/Recipes/ENRT/VhostNetPvPRecipe.py
+++ b/lnst/Recipes/ENRT/VhostNetPvPRecipe.py
@@ -5,8 +5,8 @@ from lnst.Recipes.ENRT.BasePvPRecipe import VirtioDevice, VirtioType
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 
 from lnst.Common.Logs import log_exc_traceback
-from lnst.Common.Parameters import Param, StrParam, ParamError
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import Param, StrParam, ParamError, IPv4NetworkParam
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Devices import BridgeDevice
 
 from lnst.RecipeCommon.Perf.Recipe import RecipeConf as PerfRecipeConf
@@ -30,6 +30,8 @@ class VhostNetPvPRecipe(BasePvPRecipe):
     host_req = HostReq(with_guest="yes")
     host_req.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
     host_req.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
 
     host1_dpdk_cores = StrParam(mandatory=True)
 
@@ -83,8 +85,9 @@ class VhostNetPvPRecipe(BasePvPRecipe):
         config.generator.nics.append(self.matched.generator_req.eth0)
         config.generator.nics.append(self.matched.generator_req.eth1)
 
-        self.matched.generator_req.eth0.ip_add(ipaddress("192.168.1.1/24"))
-        self.matched.generator_req.eth1.ip_add(ipaddress("192.168.1.2/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        self.matched.generator_req.eth0.ip_add(next(ipv4_addr))
+        self.matched.generator_req.eth1.ip_add(next(ipv4_addr))
         self.matched.generator_req.eth0.up()
         self.matched.generator_req.eth1.up()
 

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
@@ -1,6 +1,11 @@
 import logging
-from lnst.Common.Parameters import Param, IntParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -36,6 +41,9 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
     def test_wide_configuration(self):
         host1, host2, guest1, guest2 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2)
@@ -56,16 +64,14 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         configuration.test_wide_devices = [guest1.vlan0, guest2.vlan0,
             host1.br0, host2.br0]
 
-        net_addr_1 = "192.168.10"
-        net_addr6_1 = "fc00:0:0:1"
-        host1.br0.ip_add(ipaddress(net_addr_1 + ".1/24"))
-        host2.br0.ip_add(ipaddress(net_addr_1 + ".2/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")
+        host1.br0.ip_add(next(ipv4_addr))
+        host2.br0.ip_add(next(ipv4_addr))
 
         for i, guest in enumerate([guest1, guest2]):
-            guest.vlan0.ip_add(ipaddress(net_addr_1 + "." + str(i+3) +
-                "/24"))
-            guest.vlan0.ip_add(ipaddress(net_addr6_1 + "::" + str(i+3) +
-                "/64"))
+            guest.vlan0.ip_add(next(ipv4_addr))
+            guest.vlan0.ip_add(next(ipv6_addr))
 
         for host in [host1, host2]:
             for dev in [host.eth0, host.tap0, host.br0]:

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
@@ -1,5 +1,5 @@
-from lnst.Common.Parameters import Param, IntParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -32,6 +32,9 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
     def test_wide_configuration(self):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
@@ -51,15 +54,13 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         configuration.test_wide_devices = [guest1.vlan0, host1.br0,
             host2.vlan0]
 
-        net_addr_1 = "192.168.10"
-        net_addr6_1 = "fc00:0:0:1"
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")
 
-        host1.br0.ip_add(ipaddress(net_addr_1 + ".1/24"))
-        for i, machine in enumerate([host2, guest1]):
-            machine.vlan0.ip_add(ipaddress(net_addr_1 + "." + str(i+2) +
-                "/24"))
-            machine.vlan0.ip_add(ipaddress(net_addr6_1 + "::" + str(i+2) +
-                "/64"))
+        host1.br0.ip_add(next(ipv4_addr))
+        for machine in [host2, guest1]:
+            machine.vlan0.ip_add(next(ipv4_addr))
+            machine.vlan0.ip_add(next(ipv6_addr))
 
         for dev in [host1.eth0, host1.tap0, host1.br0, host2.eth0,
                     host2.vlan0, guest1.eth0, guest1.vlan0]:

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
@@ -1,6 +1,11 @@
 import logging
-from lnst.Common.Parameters import Param, IntParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -36,6 +41,9 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
     def test_wide_configuration(self):
         host1, host2, guest1, guest2 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2)
@@ -58,15 +66,14 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         configuration.test_wide_devices = [host1.vlan0, host2.vlan0,
             host1.br0, host2.br0]
 
-        net_addr_1 = "192.168.10"
-        net_addr6_1 = "fc00:0:0:1"
-        host1.br0.ip_add(ipaddress(net_addr_1 + ".1/24"))
-        host2.br0.ip_add(ipaddress(net_addr_1 + ".2/24"))
-        for i, guest in enumerate([guest1, guest2]):
-            guest.eth0.ip_add(ipaddress(net_addr_1 + "." + str(i+3) +
-                "/24"))
-            guest.eth0.ip_add(ipaddress(net_addr6_1 + "::" + str(i+3) +
-                "/64"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")
+
+        host1.br0.ip_add(next(ipv4_addr))
+        host2.br0.ip_add(next(ipv4_addr))
+        for guest in [guest1, guest2]:
+            guest.eth0.ip_add(next(ipv4_addr))
+            guest.eth0.ip_add(next(ipv6_addr))
 
         for host in [host1, host2]:
             for dev in [host.eth0, host.tap0, host.vlan0, host.br0]:

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
@@ -1,5 +1,5 @@
-from lnst.Common.Parameters import Param, IntParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -31,6 +31,9 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
     def test_wide_configuration(self):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
@@ -49,13 +52,11 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [host2.vlan0, guest1.vlan0]
 
-        net_addr_1 = "192.168.10"
-        net_addr6_1 = "fc00:0:0:1"
-        for i, machine in enumerate([host2, guest1]):
-            machine.vlan0.ip_add(ipaddress(net_addr_1 + "." + str(i+2) +
-                "/24"))
-            machine.vlan0.ip_add(ipaddress(net_addr6_1 + "::" + str(i+2) +
-                "/64"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.2/24")
+        ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")
+        for machine in [host2, guest1]:
+            machine.vlan0.ip_add(next(ipv4_addr))
+            machine.vlan0.ip_add(next(ipv6_addr))
 
         for dev in [host1.eth0, host1.tap0, host1.br0, host2.eth0,
             host2.vlan0, guest1.eth0, guest1.vlan0]:

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
@@ -1,5 +1,5 @@
-from lnst.Common.Parameters import Param, IntParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -31,6 +31,9 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
     def test_wide_configuration(self):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
@@ -49,11 +52,11 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [guest1.eth0, host2.vlan0]
 
-        net_addr_1 = "192.168.10"
-        net_addr6_1 = "fc00:0:0:1"
+        ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.2/24")
+        ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")
         for i, dev in enumerate([host2.vlan0, guest1.eth0]):
-            dev.ip_add(ipaddress(net_addr_1 + "." + str(i+2) + "/24"))
-            dev.ip_add(ipaddress(net_addr6_1 + "::" + str(i+2) + "/64"))
+            dev.ip_add(next(ipv4_addr))
+            dev.ip_add(next(ipv6_addr))
 
         for dev in [host1.eth0, host1.tap0, host1.br0, host2.eth0,
             host2.vlan0, guest1.eth0]:

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
@@ -1,7 +1,13 @@
 import logging
 from itertools import product
-from lnst.Common.Parameters import Param, IntParam, StrParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    StrParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -47,6 +53,12 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         dict(gro="on", gso="off", tso="off", tx="on"),
         dict(gro="on", gso="on", tso="off", tx="off")))
 
+    vlan0_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    vlan0_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
+    vlan1_ipv4 = IPv4NetworkParam(default="192.168.20.0/24")
+    vlan1_ipv6 = IPv6NetworkParam(default="fc00:0:0:2::/64")
+
     bonding_mode = StrParam(mandatory = True)
     miimon_value = IntParam(mandatory = True)
 
@@ -76,22 +88,18 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         configuration.test_wide_devices = [guest1.eth0, guest2.eth0,
             guest3.eth0, guest4.eth0]
 
-        net_addr_1 = "192.168.10"
-        net_addr6_1 = "fc00:0:0:1"
-        net_addr_2 = "192.168.20"
-        net_addr6_2 = "fc00:0:0:2"
+        vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
+        vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6)
+        vlan1_ipv4_addr = interface_addresses(self.params.vlan1_ipv4)
+        vlan1_ipv6_addr = interface_addresses(self.params.vlan1_ipv6)
 
-        for i, guest in enumerate([guest1, guest3]):
-            guest.eth0.ip_add(ipaddress(net_addr_1 + "." + str(i+1) +
-                "/24"))
-            guest.eth0.ip_add(ipaddress(net_addr6_1 + "::" + str(i+1) +
-                "/64"))
+        for guest in [guest1, guest3]:
+            guest.eth0.ip_add(next(vlan0_ipv4_addr))
+            guest.eth0.ip_add(next(vlan0_ipv6_addr))
 
-        for i, guest in enumerate([guest2, guest4]):
-            guest.eth0.ip_add(ipaddress(net_addr_2 + "." + str(i+1) +
-                "/24"))
-            guest.eth0.ip_add(ipaddress(net_addr6_2 + "::" + str(i+1) +
-                "/64"))
+        for guest in [guest2, guest4]:
+            guest.eth0.ip_add(next(vlan1_ipv4_addr))
+            guest.eth0.ip_add(next(vlan1_ipv6_addr))
 
         for host in [host1, host2]:
             for dev in [host.eth0, host.eth1, host.tap0, host.tap1,

--- a/lnst/Recipes/ENRT/VlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverBondRecipe.py
@@ -1,5 +1,11 @@
-from lnst.Common.Parameters import Param, IntParam, StrParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    StrParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -71,6 +77,15 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         dict(gro="on", gso="off", tso="off", tx="on"),
         dict(gro="on", gso="on", tso="off", tx="off")))
 
+    vlan0_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    vlan0_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
+    vlan1_ipv4 = IPv4NetworkParam(default="192.168.20.0/24")
+    vlan1_ipv6 = IPv6NetworkParam(default="fc00:0:0:2::/64")
+
+    vlan2_ipv4 = IPv4NetworkParam(default="192.168.30.0/24")
+    vlan2_ipv6 = IPv6NetworkParam(default="fc00:0:0:3::/64")
+
     bonding_mode = StrParam(mandatory=True)
     miimon_value = IntParam(mandatory=True)
 
@@ -117,16 +132,20 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
                 host.vlan1, host.vlan2])
         configuration.test_wide_devices.append(host1.bond0)
 
-        net_addr = "192.168"
-        net_addr6 = "fc00:0:0"
+        vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
+        vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6)
+        vlan1_ipv4_addr = interface_addresses(self.params.vlan1_ipv4)
+        vlan1_ipv6_addr = interface_addresses(self.params.vlan1_ipv6)
+        vlan2_ipv4_addr = interface_addresses(self.params.vlan2_ipv4)
+        vlan2_ipv6_addr = interface_addresses(self.params.vlan2_ipv6)
 
-        for i, host in enumerate([host1, host2]):
-            host.vlan0.ip_add(ipaddress('{}.10.{}/24'.format(net_addr, i+1)))
-            host.vlan1.ip_add(ipaddress('{}.20.{}/24'.format(net_addr, i+1)))
-            host.vlan2.ip_add(ipaddress('{}.30.{}/24'.format(net_addr, i+1)))
-            host.vlan0.ip_add(ipaddress('{}:1::{}/64'.format(net_addr6, i+1)))
-            host.vlan1.ip_add(ipaddress('{}:2::{}/64'.format(net_addr6, i+1)))
-            host.vlan2.ip_add(ipaddress('{}:3::{}/64'.format(net_addr6, i+1)))
+        for host in [host1, host2]:
+            host.vlan0.ip_add(next(vlan0_ipv4_addr))
+            host.vlan1.ip_add(next(vlan1_ipv4_addr))
+            host.vlan2.ip_add(next(vlan2_ipv4_addr))
+            host.vlan0.ip_add(next(vlan0_ipv6_addr))
+            host.vlan1.ip_add(next(vlan1_ipv6_addr))
+            host.vlan2.ip_add(next(vlan2_ipv6_addr))
 
         for dev in [host1.eth0, host1.eth1, host1.bond0, host1.vlan0,
             host1.vlan1, host1.vlan2, host2.eth0, host2.vlan0,

--- a/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
@@ -1,5 +1,11 @@
-from lnst.Common.Parameters import Param, IntParam, StrParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    StrParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -35,6 +41,15 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         dict(gro="on", gso="off", tso="off", tx="on"),
         dict(gro="on", gso="on", tso="off", tx="off")))
 
+    vlan0_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    vlan0_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
+    vlan1_ipv4 = IPv4NetworkParam(default="192.168.20.0/24")
+    vlan1_ipv6 = IPv6NetworkParam(default="fc00:0:0:2::/64")
+
+    vlan2_ipv4 = IPv4NetworkParam(default="192.168.30.0/24")
+    vlan2_ipv6 = IPv6NetworkParam(default="fc00:0:0:3::/64")
+
     runner_name = StrParam(mandatory = True)
 
     def test_wide_configuration(self):
@@ -59,16 +74,20 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
                 host.vlan1, host.vlan2])
         configuration.test_wide_devices.append(host1.team0)
 
-        net_addr = "192.168"
-        net_addr6 = "fc00:0:0"
+        vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
+        vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6)
+        vlan1_ipv4_addr = interface_addresses(self.params.vlan1_ipv4)
+        vlan1_ipv6_addr = interface_addresses(self.params.vlan1_ipv6)
+        vlan2_ipv4_addr = interface_addresses(self.params.vlan2_ipv4)
+        vlan2_ipv6_addr = interface_addresses(self.params.vlan2_ipv6)
 
-        for i, host in enumerate([host1, host2]):
-            host.vlan0.ip_add(ipaddress('{}.10.{}/24'.format(net_addr, i+1)))
-            host.vlan1.ip_add(ipaddress('{}.20.{}/24'.format(net_addr, i+1)))
-            host.vlan2.ip_add(ipaddress('{}.30.{}/24'.format(net_addr, i+1)))
-            host.vlan0.ip_add(ipaddress('{}:1::{}/64'.format(net_addr6, i+1)))
-            host.vlan1.ip_add(ipaddress('{}:2::{}/64'.format(net_addr6, i+1)))
-            host.vlan2.ip_add(ipaddress('{}:3::{}/64'.format(net_addr6, i+1)))
+        for host in [host1, host2]:
+            host.vlan0.ip_add(next(vlan0_ipv4_addr))
+            host.vlan1.ip_add(next(vlan1_ipv4_addr))
+            host.vlan2.ip_add(next(vlan2_ipv4_addr))
+            host.vlan0.ip_add(next(vlan0_ipv6_addr))
+            host.vlan1.ip_add(next(vlan1_ipv6_addr))
+            host.vlan2.ip_add(next(vlan2_ipv6_addr))
 
         for dev in [host1.eth0, host1.eth1, host1.team0, host1.vlan0,
             host1.vlan1, host1.vlan2, host2.eth0, host2.vlan0, host2.vlan1,

--- a/lnst/Recipes/ENRT/VlansRecipe.py
+++ b/lnst/Recipes/ENRT/VlansRecipe.py
@@ -1,5 +1,5 @@
-from lnst.Common.Parameters import Param, IntParam
-from lnst.Common.IpAddress import ipaddress
+from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
+from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -53,6 +53,15 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
+    vlan0_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
+    vlan0_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
+
+    vlan1_ipv4 = IPv4NetworkParam(default="192.168.20.0/24")
+    vlan1_ipv6 = IPv6NetworkParam(default="fc00:0:0:2::/64")
+
+    vlan2_ipv4 = IPv4NetworkParam(default="192.168.30.0/24")
+    vlan2_ipv6 = IPv6NetworkParam(default="fc00:0:0:3::/64")
+
     def test_wide_configuration(self):
         """
         Test wide configuration for this recipe involves creating three
@@ -89,16 +98,20 @@ class VlansRecipe(VlanPingEvaluatorMixin,
             configuration.test_wide_devices.extend([host.vlan0, host.vlan1,
                 host.vlan2])
 
-        net_addr = "192.168"
-        net_addr6 = "fc00:0:0"
+        vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
+        vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6)
+        vlan1_ipv4_addr = interface_addresses(self.params.vlan1_ipv4)
+        vlan1_ipv6_addr = interface_addresses(self.params.vlan1_ipv6)
+        vlan2_ipv4_addr = interface_addresses(self.params.vlan2_ipv4)
+        vlan2_ipv6_addr = interface_addresses(self.params.vlan2_ipv6)
 
-        for i, host in enumerate([host1, host2]):
-            host.vlan0.ip_add(ipaddress('{}.10.{}/24'.format(net_addr, i+1)))
-            host.vlan1.ip_add(ipaddress('{}.20.{}/24'.format(net_addr, i+1)))
-            host.vlan2.ip_add(ipaddress('{}.30.{}/24'.format(net_addr, i+1)))
-            host.vlan0.ip_add(ipaddress('{}:1::{}/64'.format(net_addr6, i+1)))
-            host.vlan1.ip_add(ipaddress('{}:2::{}/64'.format(net_addr6, i+1)))
-            host.vlan2.ip_add(ipaddress('{}:3::{}/64'.format(net_addr6, i+1)))
+        for host in [host1, host2]:
+            host.vlan0.ip_add(next(vlan0_ipv4_addr))
+            host.vlan1.ip_add(next(vlan1_ipv4_addr))
+            host.vlan2.ip_add(next(vlan2_ipv4_addr))
+            host.vlan0.ip_add(next(vlan0_ipv6_addr))
+            host.vlan1.ip_add(next(vlan1_ipv6_addr))
+            host.vlan2.ip_add(next(vlan2_ipv6_addr))
             for dev in [host.eth0, host.vlan0, host.vlan1, host.vlan2]:
                 dev.up()
 


### PR DESCRIPTION
Description:  

This is the start of changes to LNST to allow IP subnets to be passed as parameters. Right now only SimpleNetworkRecipe and VlansRecipe have it. More to come either in this PR or future PRs. 
  
Tests:  

Will upload test script soon. 

Reviews:  

@lnst-project/developers

Closes: #  
