### PR TITLE
Common.Utils: Use command instead of which for is_installed check

### DIFF
--- a/lnst/Common/Utils.py
+++ b/lnst/Common/Utils.py
@@ -295,7 +295,7 @@ def is_installed(program):
     """
     Returns True if program is detected by which, False otherwise
     """
-    cmd = "which %s" % program
+    cmd = f"command -v {program}"
     try:
         subprocess.check_call(cmd, shell=True, stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)


### PR DESCRIPTION
### Description
`command` is POSIX compatible and also is usually a shell built-in. `which` is a program that might not be installed on the machine.
  
### Tests
Tested just the `is_installed()` function. It works as expected.

### Reviews
@jtluka @enhaut 