### PR TITLE
Common.Utils: Use psutil when searching for running processes

### DIFF
--- a/lnst/Common/Utils.py
+++ b/lnst/Common/Utils.py
@@ -14,6 +14,7 @@ import logging
 import time
 import re
 import os
+import psutil
 import hashlib
 import tempfile
 import subprocess
@@ -171,12 +172,7 @@ def _is_newer_than(f, threshold):
     return stat.st_mtime > threshold
 
 def check_process_running(process_name):
-    try:
-        proc = subprocess.check_call(["pgrep", process_name],
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        return True
-    except subprocess.CalledProcessError:
-        return False
+    return process_name in (p.name() for p in psutil.process_iter())
 
 def mkdir_p(path):
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ libvirt-python = {version = "*", optional = true }
 podman = {version = "*", optional = true }
 cryptography = {version = "*", optional = true }
 pyyaml = {version = "*", optional = true}
+psutil = "^5.9.4"
 
 [tool.poetry.extras]
 virt = ["libvirt-python"]


### PR DESCRIPTION
Description:  
`pgrep` is not installed on all distros by default. We better specify a python dependency than silently require `pgrep` to be installed.
  
Tests:  
Function successfully checks whether a process with a certain name is running.

Reviews:  
@LNST-project/lnst-developers 