### PR TITLE
Enable empty offloads

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
@@ -16,7 +16,7 @@ class OffloadSubConfigMixin(BaseSubConfigMixin):
     """
 
     offload_combinations = Param(
-        default=(dict(gro="on", gso="on", tso="on", tx="on", rx="on"),)
+        default=()
     )
 
     @property

--- a/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
@@ -29,6 +29,9 @@ class OffloadSubConfigMixin(BaseSubConfigMixin):
 
     def generate_sub_configurations(self, config):
         for parent_config in super().generate_sub_configurations(config):
+            if not self.params.offload_combinations:
+                yield parent_config
+
             for offload_settings in self.params.offload_combinations:
                 new_config = copy.copy(config)
                 new_config.offload_settings = offload_settings
@@ -52,16 +55,20 @@ class OffloadSubConfigMixin(BaseSubConfigMixin):
 
     def generate_sub_configuration_description(self, config):
         description = super().generate_sub_configuration_description(config)
-        description.append(
-            "Currently configured offload combination: {}".format(
-                " ".join(
-                    [
-                        "{}={}".format(k, v)
-                        for k, v in config.offload_settings.items()
-                    ]
+        if getattr(config, "offload_settings", None):
+            description.append(
+                "Currently configured offload combination: {}".format(
+                    " ".join(
+                        [
+                            "{}={}".format(k, v)
+                            for k, v in config.offload_settings.items()
+                        ]
+                    )
                 )
             )
-        )
+        else:
+            description.append("NIC offload configuration skipped")
+
         return description
 
     def remove_sub_configuration(self, config):

--- a/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
@@ -33,7 +33,7 @@ class OffloadSubConfigMixin(BaseSubConfigMixin):
                 yield parent_config
 
             for offload_settings in self.params.offload_combinations:
-                new_config = copy.copy(config)
+                new_config = copy.copy(parent_config)
                 new_config.offload_settings = offload_settings
 
                 yield new_config


### PR DESCRIPTION
### Description

This allows user to specify empty value for `offload_combinations` parameter for ENRT recipes to skip NIC offload configuration (run with default NIC setting) when running performance tests. This was not possible before.

### Tests

Ran SimpleNetworkRecipe with empty set, one and two offload configurations. Tests ran fine.

### Reviews

@LNST-project/lnst-developers 