### PR TITLE
docs/requirements.txt: add psutil

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,6 +68,6 @@ autodoc_default_options = {
 
 autodoc_inherit_docstrings = False
 
-autodoc_mock_imports = ["pyroute2", "libvirt", "ethtool", "lxml", "yaml", "podman"]
+autodoc_mock_imports = ["pyroute2", "libvirt", "ethtool", "lxml", "yaml", "podman", "psutil"]
 
 master_doc = "index"


### PR DESCRIPTION
### Description
After the recent change of dependencies we've started using `psutil`
module in our lnst.Common.Utils module. This leads to an undefined
import when building the docs with just the `docs/requirements.txt`
dependencies and creates a lot of empty pages.

Adding the dependency to mock imports fixes the issue as we don't
actually need this when building the documentation.

### Tests
local build of the docs now completes without `missing psutils` errors

### Reviews
@jtluka 

Closes: #
