### PR TITLE
Add ip adress param to tunnel recipes

### DIFF
--- a/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
@@ -5,11 +5,18 @@ from lnst.Common.IpAddress import (
     ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
 from lnst.Devices import GeneveDevice, LoopbackDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
-from lnst.Common.Parameters import Param, StrParam, ChoiceParam
+from lnst.Common.Parameters import (
+    Param,
+    StrParam,
+    ChoiceParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
@@ -75,6 +82,8 @@ class GeneveLwtTunnelRecipe(
     # TODO: ping over IPv6 does not work yet
     ip_versions = Param(default=("ipv4",))
     carrier_ipversion = ChoiceParam(type=StrParam, choices=set(["ipv4", "ipv6"]))
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
     def configure_underlying_network(self, configuration):
         """
@@ -82,11 +91,13 @@ class GeneveLwtTunnelRecipe(
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for device in [host1.eth0, host2.eth0]:
             if self.params.carrier_ipversion == "ipv4":
-                device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+                device.ip_add(next(ipv4_addr))
             else:
-                device.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+                device.ip_add(next(ipv6_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/GeneveOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GeneveOvsTunnelRecipe.py
@@ -4,8 +4,12 @@ from lnst.Common.IpAddress import (
     ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import (
+    Param,
+    IPv4NetworkParam,
+)
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Devices import OvsBridgeDevice
@@ -67,14 +71,17 @@ class GeneveOvsTunnelRecipe(
         )
     )
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.eth0, host2.eth0]:
+            device.ip_add(next(ipv4_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/GreLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreLwtTunnelRecipe.py
@@ -5,11 +5,18 @@ from lnst.Common.IpAddress import (
     ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
 from lnst.Devices import GreDevice, LoopbackDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
-from lnst.Common.Parameters import Param, StrParam, ChoiceParam
+from lnst.Common.Parameters import (
+    Param,
+    StrParam,
+    ChoiceParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
@@ -75,6 +82,8 @@ class GreLwtTunnelRecipe(
     # TODO: ping over IPv6 does not work yet
     ip_versions = Param(default=("ipv4",))
     carrier_ipversion = ChoiceParam(type=StrParam, choices=set(["ipv4", "ipv6"]))
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
     def configure_underlying_network(self, configuration):
         """
@@ -82,11 +91,13 @@ class GreLwtTunnelRecipe(
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for device in [host1.eth0, host2.eth0]:
             if self.params.carrier_ipversion == "ipv4":
-                device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+                device.ip_add(next(ipv4_addr))
             else:
-                device.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+                device.ip_add(next(ipv6_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/GreOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreOvsTunnelRecipe.py
@@ -4,8 +4,12 @@ from lnst.Common.IpAddress import (
     ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import (
+    Param,
+    IPv4NetworkParam,
+)
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Devices import OvsBridgeDevice
@@ -67,14 +71,17 @@ class GreOvsTunnelRecipe(
         )
     )
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.eth0, host2.eth0]:
+            device.ip_add(next(ipv4_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/GreTunnelOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverBondRecipe.py
@@ -1,11 +1,16 @@
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
-    ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param, IntParam, StrParam
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    StrParam,
+    IPv4NetworkParam,
+)
 from lnst.Devices import GreDevice, BondDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
@@ -84,6 +89,8 @@ class GreTunnelOverBondRecipe(
         )
     )
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of two Ethernet
@@ -107,8 +114,9 @@ class GreTunnelOverBondRecipe(
                 dev.down()
                 host.bond.slave_add(dev)
 
-        for i, device in enumerate([host1.bond, host2.bond]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.bond, host2.bond]:
+            device.ip_add(next(ipv4_addr))
             configuration.test_wide_devices.append(device)
 
         for dev in [

--- a/lnst/Recipes/ENRT/GreTunnelOverMacvlanRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverMacvlanRecipe.py
@@ -1,11 +1,14 @@
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
-    ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import (
+    Param,
+    IPv4NetworkParam,
+)
 from lnst.Devices import GreDevice, MacvlanDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
@@ -72,6 +75,8 @@ class GreTunnelOverMacvlanRecipe(
         )
     )
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of two MACVLAN
@@ -82,8 +87,9 @@ class GreTunnelOverMacvlanRecipe(
         host1.macvlan10 = MacvlanDevice(realdev=host1.eth0, hwaddr="0A:00:00:00:00:01")
         host2.macvlan10 = MacvlanDevice(realdev=host2.eth0, hwaddr="0A:00:00:00:00:02")
 
-        for i, device in enumerate([host1.macvlan10, host2.macvlan10]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.macvlan10, host2.macvlan10]:
+            device.ip_add(next(ipv4_addr))
             configuration.test_wide_devices.append(device)
 
         for dev in [

--- a/lnst/Recipes/ENRT/GreTunnelOverMacvlanRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverMacvlanRecipe.py
@@ -60,11 +60,9 @@ class GreTunnelOverMacvlanRecipe(
 
     host1 = HostReq()
     host1.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
-    host1.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
-    host2.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
     offload_combinations = Param(
         default=(

--- a/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
@@ -61,11 +61,9 @@ class GreTunnelOverVlanRecipe(
 
     host1 = HostReq()
     host1.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
-    host1.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
     host2 = HostReq()
     host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
-    host2.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 
     vlan_id = IntParam(default=10)
 

--- a/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
@@ -1,11 +1,15 @@
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
-    ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param, IntParam
+from lnst.Common.Parameters import (
+    Param,
+    IntParam,
+    IPv4NetworkParam,
+)
 from lnst.Devices import GreDevice, VlanDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
@@ -74,6 +78,8 @@ class GreTunnelOverVlanRecipe(
         )
     )
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of two Ethernet
@@ -85,8 +91,9 @@ class GreTunnelOverVlanRecipe(
         host1.vlan0 = VlanDevice(realdev=host1.eth0, vlan_id=self.params.vlan_id)
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
-        for i, device in enumerate([host1.vlan0, host2.vlan0]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.vlan0, host2.vlan0]:
+            device.ip_add(next(ipv4_addr))
             configuration.test_wide_devices.append(device)
 
         for dev in [

--- a/lnst/Recipes/ENRT/GreTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelRecipe.py
@@ -1,11 +1,14 @@
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
-    ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import (
+    Param,
+    IPv4NetworkParam,
+)
 from lnst.Devices import GreDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
@@ -67,14 +70,17 @@ class GreTunnelRecipe(
         )
     )
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.eth0, host2.eth0]:
+            device.ip_add(next(ipv4_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/Ip6GreTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/Ip6GreTunnelRecipe.py
@@ -1,11 +1,14 @@
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET6,
-    ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import (
+    Param,
+    IPv6NetworkParam,
+)
 from lnst.Devices import Ip6GreDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
@@ -67,14 +70,17 @@ class Ip6GreTunnelRecipe(
         )
     )
 
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
-            device.ip_add(ipaddress("fc00:0:0:0::" + str(i + 1) + "/64"))
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for device in [host1.eth0, host2.eth0]:
+            device.ip_add(next(ipv6_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/SitTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/SitTunnelRecipe.py
@@ -1,14 +1,18 @@
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
-    ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
 from lnst.Devices import SitDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
-from lnst.Common.Parameters import StrParam, ChoiceParam
+from lnst.Common.Parameters import (
+    StrParam,
+    ChoiceParam,
+    IPv4NetworkParam,
+)
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.ConfigMixins.MTUHWConfigMixin import MTUHWConfigMixin
 from lnst.Recipes.ENRT.ConfigMixins.PauseFramesHWConfigMixin import (
@@ -60,6 +64,7 @@ class SitTunnelRecipe(MTUHWConfigMixin, PauseFramesHWConfigMixin, BaseTunnelReci
     tunnel_mode = ChoiceParam(
         type=StrParam, choices=set(["any", "ip6ip", "ipip", "mplsip"]), mandatory=True
     )
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
 
     def configure_underlying_network(self, configuration):
         """
@@ -67,8 +72,9 @@ class SitTunnelRecipe(MTUHWConfigMixin, PauseFramesHWConfigMixin, BaseTunnelReci
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.eth0, host2.eth0]:
+            device.ip_add(next(ipv4_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
@@ -5,11 +5,18 @@ from lnst.Common.IpAddress import (
     ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
 from lnst.Devices import VxlanDevice, LoopbackDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
-from lnst.Common.Parameters import Param, StrParam, ChoiceParam
+from lnst.Common.Parameters import (
+    Param,
+    StrParam,
+    ChoiceParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
@@ -76,6 +83,8 @@ class VxlanGpeTunnelRecipe(
     ip_versions = Param(default=("ipv4",))
     # TODO: IPv6 does not work as carrier network
     carrier_ipversion = ChoiceParam(type=StrParam, choices=set(["ipv4"]))
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
     def configure_underlying_network(self, configuration):
         """
@@ -83,11 +92,13 @@ class VxlanGpeTunnelRecipe(
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for device in [host1.eth0, host2.eth0]:
             if self.params.carrier_ipversion == "ipv4":
-                device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+                device.ip_add(next(ipv4_addr))
             else:
-                device.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+                device.ip_add(next(ipv6_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
@@ -5,11 +5,18 @@ from lnst.Common.IpAddress import (
     ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
 from lnst.Devices import VxlanDevice, LoopbackDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
-from lnst.Common.Parameters import Param, StrParam, ChoiceParam
+from lnst.Common.Parameters import (
+    Param,
+    StrParam,
+    ChoiceParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
@@ -76,6 +83,8 @@ class VxlanLwtTunnelRecipe(
     ip_versions = Param(default=("ipv4",))
     # TODO: IPv6 does not work as carrier network
     carrier_ipversion = ChoiceParam(type=StrParam, choices=set(["ipv4"]))
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
     def configure_underlying_network(self, configuration):
         """
@@ -83,11 +92,13 @@ class VxlanLwtTunnelRecipe(
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for device in [host1.eth0, host2.eth0]:
             if self.params.carrier_ipversion == "ipv4":
-                device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+                device.ip_add(next(ipv4_addr))
             else:
-                device.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+                device.ip_add(next(ipv6_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 

--- a/lnst/Recipes/ENRT/VxlanOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanOvsTunnelRecipe.py
@@ -4,8 +4,12 @@ from lnst.Common.IpAddress import (
     ipaddress,
     Ip4Address,
     Ip6Address,
+    interface_addresses,
 )
-from lnst.Common.Parameters import Param
+from lnst.Common.Parameters import (
+    Param,
+    IPv4NetworkParam,
+)
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Devices import OvsBridgeDevice
@@ -67,14 +71,17 @@ class VxlanOvsTunnelRecipe(
         )
     )
 
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+
     def configure_underlying_network(self, configuration):
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, device in enumerate([host1.eth0, host2.eth0]):
-            device.ip_add(ipaddress("192.168.101." + str(i + 1) + "/24"))
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        for device in [host1.eth0, host2.eth0]:
+            device.ip_add(next(ipv4_addr))
             device.up()
             configuration.test_wide_devices.append(device)
 


### PR DESCRIPTION
### Description

This updates all ENRT recipes that inherit from BaseTunnelRecipe so that underlying network IP/IP6 address is parametrized, either `net_ipv4` or `net_ipv6` or both.

The MR is based on https://github.com/LNST-project/lnst/pull/265 and must be merged onlywhen that MR is merged.

### Tests

Tested locally and in RedHat labs.

### Reviews

@LNST-project/lnst-developers 