### PR TITLE
Update containers fedora release

### DIFF
--- a/container_files/Dockerfile
+++ b/container_files/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM fedora:34
+FROM fedora:36
 
 RUN dnf install -y initscripts \
     iputils \

--- a/container_files/Dockerfile
+++ b/container_files/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf install -y initscripts \
     libnl3 \
     git \
     perf \
+    tcpdump \
     libnl3-devel &&  \
     curl -sSL https://install.python-poetry.org |  \
     python3 - --version 1.3.1


### PR DESCRIPTION
### Description

This updates the container's base image to Fedora 36. Also tcpdump is installed when creating the container image.

### Tests

Ran locally SimpleNetworkRecipe. Works fine.

### Reviews

@Axonis @Kuba314 @olichtne @enhaut 