### PR TITLE
pyproject.toml: enforce pyroute2 0.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = ["schema-am.rng", "install/*", "lnst-ctl.conf"]
 python = "^3.9"
 lxml = "*"
 ethtool = "*"
-pyroute2 = "*"
+pyroute2 = "0.7.3"
 
 libvirt-python = {version = "*", optional = true }
 podman = {version = "*", optional = true }


### PR DESCRIPTION
### Description

With update of pyroute2 to 0.7.4 we hit a bug described in
https://github.com/svinota/pyroute2/issues/1068

The bug is triggered from Agent's InterfaceManager code when calling
IPRSocket.put().

This bug breaks github CI for lnst and esentially any run of LNST recipe,
so this is a temporary fix to use pyroute2 0.7.3 until the issue is resolved.

### Tests

CI is sufficient

### Reviews

@olichtne