### PR TITLE
Add linux bridge over bond recipe

### DIFF
--- a/docs/source/linux_bridge_over_bond_recipe.rst
+++ b/docs/source/linux_bridge_over_bond_recipe.rst
@@ -1,0 +1,6 @@
+LinuxBridgeOverBondRecipe
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: lnst.Recipes.ENRT.LinuxBridgeOverBondRecipe.LinuxBridgeOverBondRecipe
+    :members:
+    :show-inheritance:

--- a/docs/source/specific_scenarios.rst
+++ b/docs/source/specific_scenarios.rst
@@ -27,3 +27,4 @@ Specific ENRT scenarios
     vxlan_gpe_tunnel_recipe
     l2tp_tunnel_recipe
     linux_bridge_recipe
+    linux_bridge_over_bond_recipe

--- a/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
@@ -1,0 +1,179 @@
+from lnst.Common.Parameters import (
+    IntParam,
+    StrParam,
+    IPv4NetworkParam,
+    IPv6NetworkParam,
+)
+from lnst.Common.IpAddress import interface_addresses
+from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
+from lnst.Recipes.ENRT.ConfigMixins.MTUHWConfigMixin import MTUHWConfigMixin
+from lnst.Devices import BondDevice, BridgeDevice
+from lnst.Devices.BridgeDevice import BridgeDevice as BridgeDeviceType
+from lnst.Devices.BondDevice import BondDevice as BondDeviceType
+
+
+class LinuxBridgeOverBondRecipe(MTUHWConfigMixin, BaremetalEnrtRecipe):
+    """
+    This recipe implements Enrt testing for a network scenario that looks
+    as follows
+
+    .. code-block:: none
+
+             .----------------------------------------.
+             |                switch                  |
+             '----------------------------------------'
+              |        |                    |        |
+          .---'--. .---'--.             .---'--. .---'--.
+        .-| eth0 |-| eth1 |-.        .-| eth0 |-| eth1 |-.
+        | '------' '------' |        | '------' '------' |
+        |       \   /       |        |       \   /       |
+        |       bond0       |        |       bond0       |
+        |         |         |        |         |         |
+        |        br0        |        |        br0        |
+        |                   |        |                   |
+        |       host1       |        |       host2       |
+        '-------------------'        '-------------------'
+
+    All sub configurations are included via Mixin classes.
+
+    The actual test machinery is implemented in the :any:`BaseEnrtRecipe` class.
+    """
+
+    host1 = HostReq()
+    host1.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+    host1.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+
+    host2 = HostReq()
+    host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+    host2.eth1 = DeviceReq(label="net1", driver=RecipeParam("driver"))
+
+    net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
+    net_ipv6 = IPv6NetworkParam(default="fc00::/64")
+
+    bonding_mode = StrParam(mandatory=True)
+    miimon_value = IntParam(mandatory=True)
+
+    def test_wide_configuration(self):
+        """
+        Test wide configuration for this recipe involves
+        * creating a bonding device from the matched NICs
+        * adding the bonding device into a Linux bridge
+        * adding an IPv4 and IPv6 address on the bridge device
+
+        host1.br0 = 192.168.101.1/24 and fc00::1/64
+
+        host2.br0 = 192.168.101.2/24 and fc00::2/64
+        """
+        host1, host2 = self.matched.host1, self.matched.host2
+        configuration = super().test_wide_configuration()
+        configuration.test_wide_devices = []
+
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+
+        for host in [host1, host2]:
+            host.bond0 = BondDevice(
+                mode=self.params.bonding_mode, miimon=self.params.miimon_value
+            )
+            for dev in [host.eth0, host.eth1]:
+                dev.down()
+                host.bond0.slave_add(dev)
+
+            host.br0 = BridgeDevice()
+            host.bond0.down()
+            host.br0.slave_add(host.bond0)
+
+            for dev in [host.eth0, host.eth1, host.bond0, host.br0]:
+                dev.up()
+
+            host.br0.ip_add(next(ipv4_addr))
+            host.br0.ip_add(next(ipv6_addr))
+
+            configuration.test_wide_devices.append(host.br0)
+            configuration.test_wide_devices.append(host.bond0)
+
+        self.wait_tentative_ips(configuration.test_wide_devices)
+
+        return configuration
+
+    def generate_test_wide_description(self, config):
+        """
+        Test wide description is extended with the configured addresses
+        """
+        desc = super().generate_test_wide_description(config)
+        desc += [
+            "\n".join(
+                [
+                    "Created bond device {} on host {}".format(
+                        dev.name,
+                        dev.host.hostid,
+                    )
+                    for dev in config.test_wide_devices if isinstance(dev, BondDeviceType)
+                ]
+            ),
+            "\n".join(
+                [
+                    "Created bridge device {} on host {}".format(
+                        dev.name,
+                        dev.host.hostid,
+                    )
+                    for dev in config.test_wide_devices if isinstance(dev, BridgeDeviceType)
+                ]
+            ),
+            "\n".join(
+                [
+                    "Added device {} to bridge device {} on host {}".format(
+                        dev.name,
+                        br_dev.name,
+                        dev.host.hostid,
+                    )
+                    for br_dev in config.test_wide_devices
+                    for dev in br_dev.slaves if isinstance(br_dev, BridgeDeviceType)
+                ]
+            ),
+            "\n".join(
+                [
+                    "Configured {}.{}.ips = {}".format(
+                        dev.host.hostid, dev.name, dev.ips
+                    )
+                    for dev in config.test_wide_devices if isinstance(dev, BridgeDeviceType)
+                ]
+            ),
+        ]
+        return desc
+
+    def test_wide_deconfiguration(self, config):
+        """"""  # overriding the parent docstring
+        del config.test_wide_devices
+
+        super().test_wide_deconfiguration(config)
+
+    def generate_ping_endpoints(self, config):
+        """
+        The ping endpoints for this recipe are the created bridge devices:
+
+        host1.br0 and host2.br0
+
+        Returned as::
+
+            [PingEndpoints(self.matched.host1.br0, self.matched.host2.br0)]
+        """
+        return [PingEndpoints(self.matched.host1.br0, self.matched.host2.br0)]
+
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for this recipe are the created bridge devices:
+
+        host1.br0 and host2.br0
+
+        Returned as::
+
+            [(self.matched.host1.br0, self.matched.host2.br0)]
+        """
+        return [(self.matched.host1.br0, self.matched.host2.br0)]
+
+    @property
+    def mtu_hw_config_dev_list(self):
+        return [self.matched.host1.eth0, self.matched.host2.eth0]

--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -103,6 +103,7 @@ from lnst.Recipes.ENRT.MPTCPRecipe import MPTCPRecipe
 from lnst.Recipes.ENRT.SRIOVNetnsOvSRecipe import SRIOVNetnsOvSRecipe
 from lnst.Recipes.ENRT.SRIOVNetnsBridgeRecipe import SRIOVNetnsBridgeRecipe
 from lnst.Recipes.ENRT.LinuxBridgeRecipe import LinuxBridgeRecipe
+from lnst.Recipes.ENRT.LinuxBridgeOverBondRecipe import LinuxBridgeOverBondRecipe
 
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe


### PR DESCRIPTION
### Description

This adds new recipe into ENRT recipe set. The network configuration is:

* a bond device is created over two NICs
* a linux bridge device is created and bond device is added to the bridge
* ipv4 and ipv6 address is configured on the bridge
* the test does not have any performance tweaks compared to e.g. SimpleNetworkRecipe

### Tests

Tested with containers locally (removed one DeviceReq form the code as containers do not support that).

Redhat lab job id 7503695

### Reviews

@all

