### PR TITLE
Revert "pyproject.toml: enforce pyroute2 0.7.3"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = ["schema-am.rng", "install/*", "lnst-ctl.conf"]
 python = "^3.9"
 lxml = "*"
 ethtool = "*"
-pyroute2 = "0.7.3"
+pyroute2 = "*"
 
 libvirt-python = {version = "*", optional = true }
 podman = {version = "*", optional = true }


### PR DESCRIPTION
### Description

This reverts commit 4e9ea1f0a20b3d3213e5f272fdac22e70b0c7a94.

The pyroute2 issues has been fixed, https://github.com/svinota/pyroute2/issues/1068#issuecomment-1407366608

### Tests

github CI covers this.

### Reviews

@olichtne 
