### PR TITLE
Recipes/BaseTunnelRecipe: add generate_perf_endpoints()

### DIFF
--- a/lnst/Recipes/ENRT/BaseTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/BaseTunnelRecipe.py
@@ -137,3 +137,11 @@ class BaseTunnelRecipe(
         :rtype: :any:`PacketAssertConf`
         """
         raise NotImplementedError
+
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for recipes derived from this class are usually
+        the tunnel endpoints. The derived class can override the endpoints
+        if needed.
+        """
+        return [tuple(config.tunnel_devices)]


### PR DESCRIPTION
### Description

This enables all recipes derived from BaseTunnelRecipe to run performance tests.

### Tests

Test run of GreTunnelRecipe in RH labs, job id 7512901.
