### PR TITLE
Recipes/ENRT/{Gre,VxlanGpe}TunnelRecipe.py: override generate_perf_endpoints()

### DIFF
--- a/lnst/Recipes/ENRT/GreLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreLwtTunnelRecipe.py
@@ -235,6 +235,17 @@ class GreLwtTunnelRecipe(
 
         return pa_config
 
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for this recipe are the loopback devices that
+        are configured with IP addresses of the tunnelled networks.
+
+        Returned as::
+
+            [(self.matched.host1.lo, self.matched.host2.lo)]
+        """
+        return [(self.matched.host1.lo, self.matched.host2.lo)]
+
     @property
     def offload_nics(self):
         return [self.matched.host1.eth0, self.matched.host2.eth0]

--- a/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
@@ -229,6 +229,17 @@ class VxlanGpeTunnelRecipe(
 
         return pa_config
 
+    def generate_perf_endpoints(self, config):
+        """
+        The perf endpoints for this recipe are the loopback devices that
+        are configured with IP addresses of the tunnelled networks.
+
+        Returned as::
+
+            [(self.matched.host1.lo, self.matched.host2.lo)]
+        """
+        return [(self.matched.host1.lo, self.matched.host2.lo)]
+
     @property
     def offload_nics(self):
         return [self.matched.host1.eth0, self.matched.host2.eth0]


### PR DESCRIPTION
### Description

These tests assign IP addresses not directly on the tunnel interfaces but on a loopback interface. So, the BaseTunnelRecipe.generate_perf_endpoints needs to be overridden to use loopback's IP addresses for the performance test.

Before the fix, running the tests would crash with:
```
Traceback (most recent call last):
  File "/mnt/tests/data.lnst.anl.lab.eng.bos.redhat.com/data-server-content/gitlab-tasks/beaker-lnst-tasks/master.tar.gz/lnst/test-runner/./do-my-test", line 34, in main
    ctl.run(recipe)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Controller/Controller.py", line 172, in run
    recipe.test()
  File "/root/rhextensions-lnst/lnst/RHExtensions/RHRecipeMixin.py", line 79, in test
    super(RHRecipeMixin, self).test()
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/BaseEnrtRecipe.py", line 172, in test
    self.do_tests(recipe_config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/BaseEnrtRecipe.py", line 294, in do_tests
    self.do_perf_tests(recipe_config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/BaseEnrtRecipe.py", line 318, in do_perf_tests
    for perf_config in self.generate_perf_configurations(recipe_config):
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/BaseEnrtRecipe.py", line 405, in generate_perf_configurations
    for measurements in self.generate_perf_measurements_combinations(
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/MeasurementGenerators/FlowEndpointsStatCPUMeasurementGenerator.py", line 13, in generate_perf_measurements_combinations
    for combination in combinations:
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py", line 25, in generate_perf_measurements_combinations
    combinations = super().generate_perf_measurements_combinations(config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/MeasurementGenerators/FlowMeasurementGenerator.py", line 110, in generate_perf_measurements_combinations
    for flow_combination in self.generate_flow_combinations(config):
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py", line 91, in generate_flow_combinations
    for flows in super().generate_flow_combinations(config):
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/MeasurementGenerators/FlowMeasurementGenerator.py", line 136, in generate_flow_combinations
    client_bind = client_nic.ips_filter(**ip_filter)[0]
IndexError: list index out of range
```

Fixes commit 876922db53f54c9049313191b939d2fba42643d5

### Tests

Tested both recipes with the same setup, there's no crash anymore.

### Reviews

Will deploy as a hotfix.