### PR TITLE
Setting initial state of used devices to down

### DIFF
--- a/lnst/Agent/Agent.py
+++ b/lnst/Agent/Agent.py
@@ -131,6 +131,7 @@ class RemoteMethods:
 
         for device in self._if_manager.get_devices():
             try:
+                device.down()
                 device.store_cleanup_data()
             except DeviceDisabled:
                 pass

--- a/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
@@ -33,9 +33,6 @@ class SimpleMacsecRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = [host1.eth0, host2.eth0]
 
-        host1.eth0.down()
-        host2.eth0.down()
-
         self.wait_tentative_ips(configuration.test_wide_devices)
 
         configuration.endpoint1 = host1.eth0


### PR DESCRIPTION
### Description
* setting initial state of used devices to down -
  * Sometimes may happen, that used interfaces are not in down state which may leads to nondeterministic behaviour of recipes that relies on initial state of device. Setting used device to down state as part of pre-test configuration sets same initial state of devices across the recipes.
* Removed setting devices down from MACsec recipes, which was just 
workaround


### Tests
Scheduled 1 test for each recipe class we have with my changes `J:7541084` and without my changes `J:7541167` to check whether my changes breaks (changes) indexing or not (should not).

### Reviews
@LNST-project/lnst-developers 
