### PR TITLE
ENRT.OffloadSubConfigMixin: fix empty offloads use case

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
@@ -96,16 +96,17 @@ class OffloadSubConfigMixin(BaseSubConfigMixin):
                 yield flows
 
     def _check_test_offload_conflicts(self, config, flows):
-        for flow in flows:
-            if (
-                flow.type == "udp_stream"
-                and config.offload_settings.get("gro", "on") == "off"
-            ):
-                return True
-            elif (
-                flow.type == "sctp_stream"
-                and "off" in config.offload_settings.values()
-                and config.offload_settings.get("gso", "on") == "on"
-            ):
-                return True
+        if getattr(config, "offload_settings", None):
+            for flow in flows:
+                if (
+                    flow.type == "udp_stream"
+                    and config.offload_settings.get("gro", "on") == "off"
+                ):
+                    return True
+                elif (
+                    flow.type == "sctp_stream"
+                    and "off" in config.offload_settings.values()
+                    and config.offload_settings.get("gso", "on") == "on"
+                ):
+                    return True
         return False


### PR DESCRIPTION
### Description

Even if empty offload list is used for a recipe using the mixin the `_check_test_offload_conflicts` is called. This raises an exception because it attempts to access non existing attribute of the config object.

Fixes #287

### Tests

Internal RH lab Beaker job id 7543578. The job covers VxlanRemoteRecipe with both default empty offload_combinations and one offload combination.

* default 
```
         'offload_combinations': (),
...
        Sub configuration description:
        NIC offload configuration skipped
...
        Flow(
            type=udp_stream,
            generator=Host(machine_id=host1), 
            generator_bind=192.168.100.1,
            generator_nic=VxlanDevice(machine=host1, id=vxlan0, name=t_vxlan0, ifindex=10),
            receiver=Host(machine_id=host2), 
            receiver_bind=192.168.100.2,
            receiver_nic=VxlanDevice(machine=host2, id=vxlan0, name=t_vxlan0, ifindex=10),
            receiver_port=12000,
            msg_size=1400, 
            duration=60,
            parallel_streams=1,
            cpupin=[5],
            aggregated_flow=False
            warmup_duration=3,
        )
        Generator measured throughput: 4036022247.69 +-10448105.40(0.26%) bits per second.
        Generator process CPU data: 94.47 +-0.17 cpu_percent per second.
        Receiver measured throughput: 2339189930.96 +-11775016.35(0.50%) bits per second.
        Receiver process CPU data: 51.07 +-0.16 cpu_percent per second.
```
* offloads set
```
         'offload_combinations': [{'gso': 'on',
                                   'rx-udp_tunnel-port-offload': 'on',
                                   'tx-gso-partial': 'on',
                                   'tx-udp_tnl-csum-segmentation': 'on',
                                   'tx-udp_tnl-segmentation': 'on'}],
...
        Sub configuration description:
        Currently configured offload combination: gso=on tx-gso-partial=on rx-udp_tunnel-port-offload=on tx-udp_tnl-segmentation=on tx-udp_tnl-csum-segmentation=on
...
        Flow(
            type=tcp_stream,
            generator=Host(machine_id=host1), 
            generator_bind=192.168.100.1,
            generator_nic=VxlanDevice(machine=host1, id=vxlan0, name=t_vxlan0, ifindex=12),
            receiver=Host(machine_id=host2), 
            receiver_bind=192.168.100.2,
            receiver_nic=VxlanDevice(machine=host2, id=vxlan0, name=t_vxlan0, ifindex=12),
            receiver_port=12000,
            msg_size=16384, 
            duration=30,
            parallel_streams=1,
            cpupin=None,
            aggregated_flow=False
            warmup_duration=0,
        )
        Generator measured throughput: 24170731311.52 +-0.00(0.00%) bits per second.
        Generator process CPU data: 56.16 +-0.00 cpu_percent per second.
        Receiver measured throughput: 24136997163.15 +-0.00(0.00%) bits per second.
        Receiver process CPU data: 99.67 +-0.00 cpu_percent per second.
```

### Reviews

This is a hofix.