### PR TITLE
Common.Utils: Avoid using regex inline flags

### DIFF
--- a/lnst/Common/Utils.py
+++ b/lnst/Common/Utils.py
@@ -95,9 +95,9 @@ def int_it(val):
 
 def bool_it(val):
     if isinstance(val, str):
-        if re.match("^\s*(?i)(true)", val) or re.match("^\s*(?i)(yes)", val):
+        if re.match("^\s*(true|yes)", val, flags=re.IGNORECASE):
             return True
-        elif re.match("^\s*(?i)(false)", val) or re.match("^\s*(?i)(no)", val):
+        elif re.match("^\s*(false|no)", val, flags=re.IGNORECASE):
             return False
     return True if int_it(val) else False
 


### PR DESCRIPTION
### Description
Regex inline flags have been deprecated since Python 3.6. The deprecation warning is an exception since Python 3.11(?).

We should use `re.IGNORECASE` flag to achieve the same behaviour. I also combined the "true" and "yes" checks to a single regex pattern.

### Tests
```py
>>> re.match("^\s*(true|yes)", "True", flags=re.IGNORECASE)
<re.Match object; span=(0, 4), match='True'>
>>> re.match("^\s*(true|yes)", "yeS", flags=re.IGNORECASE)
<re.Match object; span=(0, 3), match='yeS'>
```

### Reviews
@pgagne @olichtne