### PR TITLE
Linuxperf fix

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -104,6 +104,7 @@ class LinuxPerfMeasurement(BaseMeasurement):
         for job, (host, _, _) in zip(self._running_jobs, self.configurations):
             if not job.wait(timeout=120):
                 logging.error(f"timeout while waiting for linuxperf job to finish on host {host.hostid}")
+                job.kill()
 
         self._end_timestamp = time.time()
         self._finished_jobs = self._running_jobs

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -13,6 +13,7 @@ from lnst.RecipeCommon.Perf.Measurements.Results import (
     LinuxPerfMeasurementResults,
     AggregatedLinuxPerfMeasurementResults
 )
+
 from lnst.Controller.Job import Job
 from lnst.Controller.Host import Host
 from lnst.Controller.Recipe import BaseRecipe

--- a/lnst/RecipeCommon/Perf/Measurements/Results/LinuxPerfMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/LinuxPerfMeasurementResults.py
@@ -12,7 +12,7 @@ class LinuxPerfMeasurementResults(BaseMeasurementResults):
 
     def __init__(
         self,
-        measurement: "LinuxPerfMeasurementResults",
+        measurement,
         host: Host,
         filename: str,
         cpus: list[int],

--- a/lnst/RecipeCommon/Perf/Measurements/__init__.py
+++ b/lnst/RecipeCommon/Perf/Measurements/__init__.py
@@ -3,3 +3,4 @@ from lnst.RecipeCommon.Perf.Measurements.IperfFlowMeasurement import IperfFlowMe
 from lnst.RecipeCommon.Perf.Measurements.TRexFlowMeasurement import TRexFlowMeasurement
 from lnst.RecipeCommon.Perf.Measurements.StatCPUMeasurement import StatCPUMeasurement
 from lnst.RecipeCommon.Perf.Measurements.NeperFlowMeasurement import NeperFlowMeasurement
+from lnst.RecipeCommon.Perf.Measurements.LinuxPerfMeasurement import LinuxPerfMeasurement


### PR DESCRIPTION
### Description
Previously, the `_jobs` list was initialized only once, leading to jobs
from multiple iterations being appended. This led to errors when zipping
with current configurations and killing the jobs.

Moving the `_jobs` variable to the constructor fixes this issue.

### Tests
`J:7588038` - ~~have to confirm it's fixed once the job finishes.~~

### Reviews
@enhaut @olichtne 

Closes: #290 
