### PR TITLE
Common.Utils: Prefetch process name in check_process_running

### DIFF
--- a/lnst/Common/Utils.py
+++ b/lnst/Common/Utils.py
@@ -172,7 +172,7 @@ def _is_newer_than(f, threshold):
     return stat.st_mtime > threshold
 
 def check_process_running(process_name):
-    return process_name in (p.name() for p in psutil.process_iter())
+    return process_name in (p.info["name"] for p in psutil.process_iter(["name"]))
 
 def mkdir_p(path):
     try:


### PR DESCRIPTION
### Description
Previously there was a race condition that occured in https://prod-jenkins-csb-lnst.apps.ocp-c1.prod.psi.redhat.com/job/LNST-BREW-kernel-candidate/326/console.

This change should prevent this error by prefetching the "name" attribute and storing it in the `.info` dict.

### Tests
Tested the function locally.

### Reviews
@olichtne @jtluka 