### PR TITLE
Using rules/sec for TrafficControlRecipe results

### DIFF
--- a/lnst/RecipeCommon/Perf/Evaluators/BaselineTcRunAverageEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/BaselineTcRunAverageEvaluator.py
@@ -18,7 +18,7 @@ class BaselineTcRunAverageEvaluator(BaselineEvaluator):
             result_index: int = 0,
     ) -> list[MetricComparison]:
 
-        metric_name = f"{result_index}_time_taken"
+        metric_name = f"{result_index}_rule_install_rate"
 
         if baseline is None:
             return [
@@ -29,14 +29,15 @@ class BaselineTcRunAverageEvaluator(BaselineEvaluator):
                 )
             ]
         elif (threshold := self._thresholds.get(metric_name, None)) is not None:
-            difference = ((result.time_taken / baseline.time_taken) * 100 ) - 100
+            difference = ((result.rule_install_rate.average / baseline.rule_install_rate.average) * 100) - 100
             direction = "higher" if difference >= 0 else "lower"
             text = [
                 f"{self.__class__.__name__} of tc run with {metric_name}",
                 f"{result.description}",
-                f"baseline time_taken={baseline.time_taken}",
-                f"{difference:2f} {direction} than baseline ",
-                f"Allowed differences: {threshold}% ",
+                f"Baseline: {baseline.rule_install_rate.average} rules/sec",
+                f"Measured: {result.rule_install_rate.average} rules/sec",
+                f"{abs(difference):2f}% {direction} than baseline ",
+                f"Allowed difference: {threshold}% ",
             ]
             if difference < -threshold:
                 comparison = ResultType.WARNING

--- a/lnst/RecipeCommon/Perf/Evaluators/MaxTimeTakenEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/MaxTimeTakenEvaluator.py
@@ -13,7 +13,7 @@ class MaxTimeTakenEvaluator(BaseResultEvaluator):
         self._max_time = max_time
 
     def _check_interval(self, timed_run: TcRunMeasurementResults) -> ResultType:
-        if timed_run.run_interval.duration <= self._max_time:
+        if timed_run.rule_install_rate.duration <= self._max_time:
             return ResultType.PASS
         return ResultType.FAIL
 

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedTcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedTcRunMeasurementResults.py
@@ -27,17 +27,17 @@ class AggregatedTcRunMeasurementResults(TcRunMeasurementResults):
                f" num_rules={self.num_rules}"
 
     @property
-    def run_interval(self) -> SequentialPerfResult:
-        return SequentialPerfResult([i.run_interval for i in self.individual_results])
+    def rule_install_rate(self) -> SequentialPerfResult:
+        return SequentialPerfResult([i.rule_install_rate for i in self.individual_results])
 
     @property
     def time_taken(self) -> float:
         # Return average time for all runs
-        return mean([i.duration for i in self.run_interval])
+        return mean([i.duration for i in self.rule_install_rate])
 
     @property
     def num_rules(self) -> tuple[int]:
-        return tuple([r.value for r in self.run_interval])
+        return tuple([r.value for r in self.rule_install_rate])
 
     @property
     def num_instances(self):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
@@ -15,7 +15,7 @@ class TcRunMeasurementResults(BaseMeasurementResults):
     ):
         super().__init__(measurement, warmup_rules)
         self._device = device
-        self._run_interval: PerfInterval = None
+        self._rule_install_rate: PerfInterval = None
         self._run_success: bool = None
 
     @property
@@ -27,8 +27,12 @@ class TcRunMeasurementResults(BaseMeasurementResults):
         return self.device.host
 
     @property
-    def run_interval(self) -> PerfInterval:
-        return self._run_interval
+    def rule_install_rate(self) -> PerfInterval:
+        return self._rule_install_rate
+
+    @rule_install_rate.setter
+    def rule_install_rate(self, interval: PerfInterval):
+        self._rule_install_rate = interval
 
     @property
     def run_success(self) -> bool:
@@ -38,24 +42,20 @@ class TcRunMeasurementResults(BaseMeasurementResults):
     def run_success(self, v: bool):
         self._run_success = v
 
-    @run_interval.setter
-    def run_interval(self, interval: PerfInterval):
-        self._run_interval = interval
-
     @property
     def description(self):
         return f"{self.device.host.hostid}.{self.device.name}" \
-               f" tc run with {self.run_interval.value} rules" \
-               f" took {self.run_interval.duration} seconds"
+               f" tc run with {self.rule_install_rate.value} rules" \
+               f" took {self.rule_install_rate.duration} seconds"
 
     @property
     def time_taken(self):
-        return self.run_interval.duration
+        return self.rule_install_rate.duration
 
     @property
     def start_timestamp(self):
-        return self.run_interval.start_timestamp
+        return self.rule_install_rate.start_timestamp
 
     @property
     def end_timestamp(self):
-        return self.run_interval.end_timestamp
+        return self.rule_install_rate.end_timestamp

--- a/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
@@ -196,7 +196,7 @@ class TcRunMeasurement(BaseMeasurement):
                 measurement=self,
                 device=self.device,
             )
-            run_result.run_interval = PerfInterval(
+            run_result.rule_install_rate = PerfInterval(
                 value=self._rules_per_instance,
                 duration=job.result['data']['time_taken'],
                 unit='rules',
@@ -219,8 +219,7 @@ class TcRunMeasurement(BaseMeasurement):
             r_type,
             f"{r_type} {result.description}",
             data=dict(
-                num_rules=result.run_interval.value,
-                time_taken=result.run_interval.duration,
+                rule_install_rate=result.rule_install_rate,
             )
         )
 


### PR DESCRIPTION
### Description
Previously we where evaluating `time_taken`. This changes it to evaluate `rules/sec`


