### PR TITLE
Use PerfParalellResult and `asyncio.subprocess` for TrafficControl results

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from lnst.Controller.Namespace import Namespace
 from lnst.Devices import Device
 from lnst.RecipeCommon.Perf.Measurements.Results import BaseMeasurementResults
-from lnst.RecipeCommon.Perf.Results import PerfInterval
+from lnst.RecipeCommon.Perf.Results import ParallelPerfResult
 
 
 class TcRunMeasurementResults(BaseMeasurementResults):
@@ -15,7 +15,7 @@ class TcRunMeasurementResults(BaseMeasurementResults):
     ):
         super().__init__(measurement, warmup_rules)
         self._device = device
-        self._rule_install_rate: PerfInterval = None
+        self._rule_install_rate: ParallelPerfResult = None
         self._run_success: bool = None
 
     @property
@@ -27,12 +27,12 @@ class TcRunMeasurementResults(BaseMeasurementResults):
         return self.device.host
 
     @property
-    def rule_install_rate(self) -> PerfInterval:
+    def rule_install_rate(self) -> ParallelPerfResult:
         return self._rule_install_rate
 
     @rule_install_rate.setter
-    def rule_install_rate(self, interval: PerfInterval):
-        self._rule_install_rate = interval
+    def rule_install_rate(self, result: ParallelPerfResult):
+        self._rule_install_rate = result
 
     @property
     def run_success(self) -> bool:
@@ -46,7 +46,9 @@ class TcRunMeasurementResults(BaseMeasurementResults):
     def description(self):
         return f"{self.device.host.hostid}.{self.device.name}" \
                f" tc run with {self.rule_install_rate.value} rules" \
-               f" took {self.rule_install_rate.duration} seconds"
+               f" num_instances={self.measurement.num_instances}" \
+               f" took {self.rule_install_rate.duration} seconds " \
+               f"({self.rule_install_rate.average} rules/sec)"
 
     @property
     def time_taken(self):

--- a/lnst/Tests/TrafficControl.py
+++ b/lnst/Tests/TrafficControl.py
@@ -1,45 +1,59 @@
 import logging
-import subprocess
+import shutil
+import asyncio
 import time
 
-from lnst.Common.Parameters import StrParam
+from lnst.Common.Parameters import StrParam, ListParam
 from lnst.Tests.BaseTestModule import BaseTestModule
 
 
 class TrafficControlRunner(BaseTestModule):
-
-    batchfile = StrParam(required=True)
+    batchfiles = ListParam(type=StrParam(), required=True)
 
     def run(self) -> bool:
         self._res_data = {}
+        instance_results = asyncio.run(self.run_instances())
+        all_success = all((i["success"] for i in instance_results))
+        self._res_data["data"] = dict(
+            instance_results=instance_results,
+        )
+        msgs = []
+        for result in instance_results:
+            if not result["success"]:
+                msg = f"tc -b {result['batchfile']} failed"
+                logging.warning(msg)
+                logging.error(result["stderr"])
+                msgs.append(msg)
+                msgs.append(result["stderr"])
+        self._res_data["msg"] = "\n".join(msgs)
 
-        start_timestamp, time_taken, res = self.run_tc(self.params.batchfile)
-        success = res.returncode == 0
+        return all_success
 
-        self._res_data["data"] = {
-            "time_taken": time_taken,
-            "start_timestamp": start_timestamp
-        }
+    async def run_instances(self) -> list[dict]:
+        tc_exec = shutil.which("tc")
+        instances = [
+            self.run_tc(tc_exec, bf)
+            for bf in self.params.batchfiles
+        ]
+        results = await asyncio.gather(*instances)
+        return results
 
-        msg = f"took {time_taken} sec"
-        if success:
-            self._res_data["msg"] = f"tc run successful, {msg}"
-            logging.info(self._res_data["msg"])
-        else:
-            self._res_data["msg"] = f"tc run failed, {msg}"
-            self._res_data["stderr"] = res.stderr
-            logging.warning(self._res_data["msg"])
-            logging.error(self._res_data["stderr"])
-
-        return success
-
-    def run_tc(self, batchfile: str) -> tuple[float, subprocess.CompletedProcess]:
-
+    async def run_tc(self, tc_exec: str, batchfile: str) -> dict[str]:
         start_timestamp = time.time()
-        st = time.perf_counter()
-        res = subprocess.run(f"tc -b {batchfile}", shell=True)
-        et = time.perf_counter()
-
-        time_taken = et - st
-
-        return start_timestamp, time_taken, res
+        start_time = time.perf_counter()
+        proc = await asyncio.create_subprocess_exec(
+            tc_exec, "-b", batchfile,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        elapsed = time.perf_counter() - start_time
+        success = proc.returncode == 0
+        return dict(
+            time_taken=elapsed,
+            start_timestamp=start_timestamp,
+            success=success,
+            stdout=stdout.decode(),
+            stderr=stderr.decode(),
+            batchfile=batchfile,
+        )


### PR DESCRIPTION
### Description
Changing to perf paralell result. mostly complete. commiting for test and review purposes. 

Also use asyncio.subprocess to run multiple tc instances client side. 

For reference here is a sample of the `tc` process start timestamps: 
```
    data:
        instance_results:
            item 0:
                ...
                start_timestamp: 1681069428.9487906
                ...
            item 1:
                ...
                start_timestamp: 1681069428.9511075
                ... 
            item 2:
                ...
                start_timestamp: 1681069428.9530337
                ...
            item 3:
                ...
                start_timestamp: 1681069428.9548721
                ...
```