### PR TITLE
TODO: Remove RPM item

### DIFF
--- a/TODO
+++ b/TODO
@@ -33,10 +33,6 @@ them to be implemented in Python Recipes, with notes where relevant.
     Device classes, but we have the capability to sync arbitrary python code so
     this shouldn't be too big a problem
 
-* RPM:
-    * add python-ethtool as dependency
-    * pyroute2 dependency needs an update to the version, some devices (vti
-      require newer versions)
 
 * Port test_modules
     * Netperf needs to be resynced with the legacy version there are some


### PR DESCRIPTION
Primarily doing this to bump the commit hash so I can test a tool that uses it for something.

This seemed like an easy way to do that. I removed those lines since they where the easiest thing to point to that was already done.  

Also got sick of seeing 
```
Changed "slave" -> "agent" in TODO file` when you go to the main page for lnst. 
```

This TODO obviously could really use some work, but that for another time. 