### PR TITLE
Recipes/OffloadSubConfigMixin.py: remove gro offload config check

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/OffloadSubConfigMixin.py
@@ -99,11 +99,6 @@ class OffloadSubConfigMixin(BaseSubConfigMixin):
         if getattr(config, "offload_settings", None):
             for flow in flows:
                 if (
-                    flow.type == "udp_stream"
-                    and config.offload_settings.get("gro", "on") == "off"
-                ):
-                    return True
-                elif (
                     flow.type == "sctp_stream"
                     and "off" in config.offload_settings.values()
                     and config.offload_settings.get("gso", "on") == "on"


### PR DESCRIPTION
### Description

Resolves #300

Since kernel 5.10 GRO is enabled for UDP:
https://developers.redhat.com/articles/2021/11/05/improve-udp-performance-rhel-85#benchmarking_gro

### Tests

Tested with following test configuration:
```
recipe = SimpleNetworkRecipe(                                                   
    ping_count=1,                                                               
    perf_duration=5,                                                            
    perf_iterations=1,                                                          
    perf_parallel_processes=1,                                                  
    perf_tests=['udp_stream'],                                                  
    ip_versions=['ipv4'],                                                       
    perf_msg_sizes=[16384],                                                     
    offload_combinations=[{'gro': 'off'}],                                      
```

* master branch: no iperf test was run
* this devel branch: iperf test was run

### Reviews

Closes: #300 
