### PR TITLE
SRIOVNetnsOvSRecipe fix missing return

### DIFF
--- a/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
@@ -150,6 +150,7 @@ class SRIOVNetnsOvSRecipe(
             f"Configured {dev.host.hostid}.{dev.name}.ips = {dev.ips}"
             for dev in config.test_wide_devices
         ]
+        return desc
 
     def test_wide_deconfiguration(self, config):
         """


### PR DESCRIPTION
### Description
`generate_test_wide_description` method of SRIOVNetnsOvSRecipe had missing return, causing it to crash the recipe

### Tests
R:13939757 in J:7873990
