### PR TITLE
Recipes.ENRT.SRIOVNetnsTcRecipe: delete qdisc

### DIFF
--- a/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
@@ -230,9 +230,10 @@ class SRIOVNetnsTcRecipe(
         for i, host in enumerate([host1, host2]):
             host.run(f"echo 0 > /sys/class/net/{host.eth0.name}/device/sriov_numvfs")
             time.sleep(2)
+            host.run(f"tc qdisc del dev {host.eth0.name} ingress")
+            time.sleep(2)
             host.run(f"devlink dev eswitch set pci/{host.eth0.bus_info} mode legacy")
             time.sleep(3)
-            #TODO remove tc filters and qdiscs
         del config.test_wide_devices
 
         super().test_wide_deconfiguration(config)


### PR DESCRIPTION
### Description
Using devlink to switch card back to legacy mode
wasn't working due to device being busy

Tc qdisc was causing the command to hang up and fail

Fixes:
```
[root@server ~]# devlink dev eswitch set pci/0000:81:00.0 mode legacy
Error: mlx5_core: Can't change mode, E-Switch is busy.
kernel answers: Device or resource busy
```

### Tests
Manual run:
```
[root@server ~]# tc qdisc del dev p5p1 ingress
[root@server ~]# devlink dev eswitch set pci/0000:81:00.0 mode legacy
```
