### PR TITLE
Device: Add {up,down}_and_wait methods

### DIFF
--- a/lnst/Common/Utils.py
+++ b/lnst/Common/Utils.py
@@ -23,7 +23,7 @@ import ast
 import collections
 import math
 import itertools
-from collections.abc import Iterable
+from collections.abc import Iterable, Callable
 from contextlib import AbstractContextManager
 from _ast import Call, Attribute
 from lnst.Common.ExecCmd import exec_cmd
@@ -350,3 +350,14 @@ class nullcontext(AbstractContextManager):
 
     def __exit__(self, *excinfo):
         pass
+
+
+def wait_for_condition(condition: Callable[[], bool], timeout: int):
+    attempts = 0
+    while True:
+        attempts += 1
+        if condition():
+            return
+        if attempts == timeout:
+            raise TimeoutError(f"Timeout while waiting for condition")
+        time.sleep(1)

--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -26,6 +26,7 @@ from lnst.Common.DeviceError import DeviceConfigError, DeviceConfigValueError
 from lnst.Common.DeviceError import DeviceFeatureNotSupported
 from lnst.Common.IpAddress import ipaddress, AF_INET
 from lnst.Common.HWAddress import hwaddress
+from lnst.Common.Utils import wait_for_condition
 
 from pyroute2.netlink.rtnl import RTM_NEWLINK
 from pyroute2.netlink.rtnl import RTM_NEWADDR
@@ -645,6 +646,14 @@ class Device(object, metaclass=DeviceMeta):
         """set device down"""
         self._nl_link_update["state"] = "down"
         self._nl_link_sync("set")
+
+    def up_and_wait(self, timeout: int):
+        self.up()
+        wait_for_condition(lambda: "up" in self.state, timeout=timeout)
+
+    def down_and_wait(self, timeout: int):
+        self.down()
+        wait_for_condition(lambda: "up" not in self.state, timeout=timeout)
 
     #TODO looks like python ethtool module doesn't support these so we'll keep
     #exec_cmd for now...


### PR DESCRIPTION
### Description
These methods will call up/down on a interface and wait for it to be in the desired state or raise an exception.

### Tests
Tested locally by running `.github/runner.py` and replacing `.up()` with `.up_and_wait(timeout=5)`.

### Reviews
@LNST-project/lnst-developers 

Closes: #305 
