### PR TITLE
LACP support

### DIFF
--- a/lnst/Devices/BondDevice.py
+++ b/lnst/Devices/BondDevice.py
@@ -353,10 +353,15 @@ class BondDevice(MasterDevice):
 
     @xmit_hash_policy.setter
     def xmit_hash_policy(self, val):
-        m = ["layer2", "layer2+3", "layer3+4", "encap2+3", "encap3+4"]
+        m = ["layer2", "layer3+4", "layer2+3",  "encap2+3", "encap3+4"]
+
+        try:
+            m.index(val)
+        except ValueError:
+            raise DeviceConfigError(f"Hash policy {val} not supported.")
 
         if val in m:
-            self._set_linkinfo_data_attr("IFLA_BOND_XMIT_HASH_POLICY", val)
+            self._set_linkinfo_data_attr("IFLA_BOND_XMIT_HASH_POLICY", m.index(val))
         else:
             raise DeviceConfigError("Invalid value, must be in {}}.".format(m))
         self._nl_link_sync("set")

--- a/lnst/Recipes/ENRT/BaseLACPRecipe.py
+++ b/lnst/Recipes/ENRT/BaseLACPRecipe.py
@@ -1,0 +1,78 @@
+from lnst.Common.Parameters import (
+    IntParam,
+    StrParam,
+    DictParam
+)
+from lnst.Devices import BondDevice
+from lnst.Common.IpAddress import interface_addresses
+from lnst.Recipes.ENRT.DoubleBondRecipe import DoubleBondRecipe
+
+
+class BaseLACPRecipe(DoubleBondRecipe):
+    bonding_mode = StrParam(mandatory=True)
+    miimon_value = IntParam(mandatory=True)
+
+    lacp_mode = StrParam(default="ACTIVE", choices=["ACTIVE", "PASSIVE", "ON"])
+    topology = DictParam(mandatory=True)
+    """
+    Topology should be in following format:
+    ```
+    {
+        "SWITCH_LACP_INTERFACE": [
+            "INTERFACE1",
+            "INTERFACE2"
+        ]
+    }
+    ```
+    """
+
+    def test_wide_switch_configuration(self):
+        """
+        This method needs to implement switch configuration for LACP.
+        """
+        raise NotImplementedError()
+
+    def test_wide_configuration(self):
+        """
+        This method is almost the same as DoubleBondRecipe.test_wide_configuration,
+        however, it configures multiple IP addresses on the bond0 interface as well as
+        it calls switch configuration method.
+        """
+        host1, host2 = self.matched.host1, self.matched.host2
+
+        ipv4_addr = interface_addresses(self.params.net_ipv4)
+        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        for host in [host1, host2]:
+            host.bond0 = BondDevice(mode=self.params.bonding_mode,
+                                    miimon=self.params.miimon_value)
+            host.bond0.xmit_hash_policy = "layer2+3"
+
+            for dev in [host.eth0, host.eth1]:
+                dev.down()
+                host.bond0.slave_add(dev)
+
+            host.bond0.ip_add(next(ipv4_addr))
+            host.bond0.ip_add(next(ipv4_addr))
+
+            host.bond0.ip_add(next(ipv6_addr))
+            host.bond0.ip_add(next(ipv6_addr))
+
+            for dev in [host.eth0, host.eth1, host.bond0]:
+                dev.up()
+
+        self.test_wide_switch_configuration()
+
+        configuration = super(DoubleBondRecipe, self).test_wide_configuration()
+        configuration.test_wide_devices = [host1.bond0, host2.bond0]
+
+        self.wait_tentative_ips(configuration.test_wide_devices)
+
+        return configuration
+
+    def test_wide_switch_deconfiguration(self):
+        raise NotImplementedError()
+
+    def test_wide_deconfiguration(self, config):
+        self.test_wide_switch_deconfiguration()
+
+        super().test_wide_deconfiguration(config)

--- a/lnst/Recipes/ENRT/ConfigMixins/BaseRESTConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/BaseRESTConfigMixin.py
@@ -1,0 +1,41 @@
+import logging
+import requests
+
+from lnst.Common.LnstError import LnstError
+from lnst.Common.Parameters import BoolParam, StrParam
+
+
+class BaseRESTConfigMixin:
+    api_url = StrParam()
+    rest_user = StrParam()
+    rest_password = StrParam()
+    ssl_verify = BoolParam(default=True, mandatory=False)
+
+    @staticmethod
+    def __get_request_function(method: str):
+        try:
+            return getattr(requests, method)
+        except AttributeError:
+            raise LnstError(f"Method {method} is not supported")
+
+    def __build_request(self, endpoint: str, **kwargs):
+        kwargs["url"] = self.params.api_url + endpoint
+
+        if self.params.rest_user and self.params.rest_password:
+            kwargs["auth"] = (self.params.rest_user, self.params.rest_password)
+
+        kwargs["verify"] = self.params.ssl_verify
+
+        return kwargs
+
+    def api_request(self, method: str, endpoint: str, response_code: int = 200, **kwargs) -> bytes:
+        request = self.__build_request(endpoint, **kwargs)
+        req_func = self.__get_request_function(method)
+
+        response = req_func(**request)
+        if response.status_code != response_code:
+            raise LnstError(f"Request failed with status code {response.status_code}")
+
+        logging.debug("API response: %s", response.content)
+
+        return response.content

--- a/lnst/Recipes/ENRT/DellLACPRecipe.py
+++ b/lnst/Recipes/ENRT/DellLACPRecipe.py
@@ -1,0 +1,37 @@
+from lnst.Recipes.ENRT.BaseLACPRecipe import BaseLACPRecipe
+from lnst.Recipes.ENRT.ConfigMixins.BaseRESTConfigMixin import BaseRESTConfigMixin
+
+
+class DellLACPRecipe(BaseRESTConfigMixin, BaseLACPRecipe):
+    def test_wide_switch_configuration(self):
+        for bond, interfaces in self.params.topology.items():
+            interfaces = [
+                {"name": interface, "lacp-mode": self.params.lacp_mode}
+                for interface in interfaces
+            ]
+
+            self.api_request(
+                "patch",
+                f"/restconf/data/ietf-interfaces:interfaces/interface/{bond}",
+                response_code=204,
+                json={
+                    "ietf-interfaces:interface": [
+                        {
+                            "name": bond,
+                            "dell-interface:member-ports": interfaces
+                        }
+                    ]
+                },
+            )
+
+    def test_wide_switch_deconfiguration(self):
+        for bond, interfaces in self.params.topology.items():
+            for interface in interfaces:
+                self.api_request(
+                    "delete",
+                    f"/restconf/data/ietf-interfaces:interfaces/interface/{bond}",
+                    response_code=204,
+                    json={
+                        "dell-interface:member-ports": [{"name": interface}]
+                    }
+                )

--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -107,6 +107,7 @@ from lnst.Recipes.ENRT.LinuxBridgeRecipe import LinuxBridgeRecipe
 from lnst.Recipes.ENRT.LinuxBridgeOverBondRecipe import LinuxBridgeOverBondRecipe
 from lnst.Recipes.ENRT.TrafficControlRecipe import TrafficControlRecipe
 from lnst.Recipes.ENRT.BaseLACPRecipe import BaseLACPRecipe
+from lnst.Recipes.ENRT.DellLACPRecipe import DellLACPRecipe
 
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe

--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -106,6 +106,7 @@ from lnst.Recipes.ENRT.SRIOVNetnsTcRecipe import SRIOVNetnsTcRecipe
 from lnst.Recipes.ENRT.LinuxBridgeRecipe import LinuxBridgeRecipe
 from lnst.Recipes.ENRT.LinuxBridgeOverBondRecipe import LinuxBridgeOverBondRecipe
 from lnst.Recipes.ENRT.TrafficControlRecipe import TrafficControlRecipe
+from lnst.Recipes.ENRT.BaseLACPRecipe import BaseLACPRecipe
 
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ podman = {version = "*", optional = true }
 cryptography = {version = "*", optional = true }
 pyyaml = {version = "*", optional = true}
 psutil = "^5.9.4"
+requests = "^2.30.0"
 
 urllib3 = "<2"
 


### PR DESCRIPTION
### Description
* Since LACP requires breaking switch configuration, it needs to be configured dynamically. Following classes does the job:
  * `DellLACPRecipe` support of dell's REST API [documentation here](https://www.dell.com/support/manuals/en-us/smartfabric-os10-emp-partner/smartfabric-os-user-guide-10-5-4/lacp-individual-port-feature-interactions?guid=guid-03d5c911-7eeb-406f-842a-c133e710b405&lang=en-us)
  * `BaseLACPRecipe` the base class that is missing switch-specific configuration (e.g. `DellLACPRecipe`)
  * `BaseRESTConfigMixin` REST API abstraction
* fixed setting xmit hash policy
* Support of spreading multiple flows to multiple IPs


#### Example params to run LACP recipe
```
ssl_verify=False
api_url='https://example.com'
perf_spread_parallel_over_ips=True
rest_user='xxxx'
rest_password='xxxx'
topology={'port-channel':['ethernet1/1/1','ethernet1/1/2'],'port-port-channel2':['ethernet1/1/3','ethernet1/1/4']}
```


### Tests
Functional tests of LACP in `J:7973327` (2x21 gbps)  
Functional tests of other bond recipes in `J:7973409` (due to xmit hash policy changes)

### Reviews
@jtluka @olichtne 
