### PR TITLE
Added XDP testing capability

### DIFF
--- a/lnst/Common/Utils.py
+++ b/lnst/Common/Utils.py
@@ -86,6 +86,25 @@ def kmod_in_use(modulename, tries = 1):
         return kmod_in_use(modulename, tries)
     return ret
 
+
+def kmod_loaded(modulename, tries = 1):
+    tries -= 1
+    ret = False
+    mod_file = "/proc/modules"
+    handle = open(mod_file, "r")
+    for line in handle:
+        match = re.match(r'^(\S+)\s\d+\s\d+\s\S+\s(Live|Loading|Unloading).*$', line)
+        if not match or not match.groups()[0] in re.split('\s+', modulename):
+            continue
+        if match.groups()[1] == "Live":
+            ret = True
+        break
+    handle.close()
+    if (ret and tries):
+        return kmod_loaded(modulename, tries)
+    return ret
+
+
 def int_it(val):
     try:
         num = int(val)

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
@@ -1,0 +1,24 @@
+from lnst.RecipeCommon.Perf.Measurements.Results.XDPBenchMeasurementResults import (
+    XDPBenchMeasurementResults,
+)
+from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
+from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
+
+
+class AggregatedXDPBenchMeasurementResults(XDPBenchMeasurementResults):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._generator_results = SequentialPerfResult()
+        self._receiver_results = SequentialPerfResult()
+
+    def add_results(self, results):
+        if results is None:
+            return
+        elif isinstance(results, AggregatedXDPBenchMeasurementResults):
+            self.generator_results.extend(results.generator_results)
+            self.receiver_results.extend(results.receiver_results)
+        elif isinstance(results, XDPBenchMeasurementResults):
+            self.generator_results.append(results.generator_results)
+            self.receiver_results.append(results.receiver_results)
+        else:
+            raise MeasurementError("Adding incorrect results.")

--- a/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
@@ -1,0 +1,50 @@
+from lnst.RecipeCommon.Perf.Results import ParallelPerfResult
+from lnst.RecipeCommon.Perf.Measurements.Results.FlowMeasurementResults import (
+    FlowMeasurementResults,
+)
+from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
+
+
+class XDPBenchMeasurementResults(FlowMeasurementResults):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._generator_results = ParallelPerfResult()  # multiple instances of pktgen
+        self._receiver_results = ParallelPerfResult()  # single instance of xdpbench
+
+    def add_results(self, results):
+        if results is None:
+            return
+        if isinstance(results, XDPBenchMeasurementResults):
+            self.generator_results.append(results.generator_results)
+            self.receiver_results.append(results.receiver_results)
+        else:
+            raise MeasurementError("Adding incorrect results.")
+
+    def time_slice(self, start, end):
+        result_copy = XDPBenchMeasurementResults(
+            self.measurement, self.flow, warmup_duration=0
+        )
+
+        result_copy.generator_results = self.generator_results.time_slice(start, end)
+        result_copy.receiver_results = self.receiver_results.time_slice(start, end)
+
+        return result_copy
+
+    def describe(self):
+        generator = self.generator_results
+        receiver = self.receiver_results
+
+        desc = []
+        desc.append(str(self.flow))
+        desc.append(
+            "Generator generated: {tput:,f} {unit} per second.".format(
+                tput=generator.average, unit=generator.unit
+            )
+        )
+        desc.append(
+            "Receiver processed: {tput:,f} {unit} per second.".format(
+                tput=receiver.average, unit=receiver.unit
+            )
+        )
+
+        return desc

--- a/lnst/RecipeCommon/Perf/Measurements/Results/__init__.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/__init__.py
@@ -12,3 +12,5 @@ from lnst.RecipeCommon.Perf.Measurements.Results.LinuxPerfMeasurementResults imp
 from lnst.RecipeCommon.Perf.Measurements.Results.RDMABandwidthMeasurementResults import RDMABandwidthMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.StatCPUMeasurementResults import StatCPUMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.TcRunMeasurementResults import TcRunMeasurementResults
+from lnst.RecipeCommon.Perf.Measurements.Results.XDPBenchMeasurementResults import XDPBenchMeasurementResults
+

--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -1,0 +1,189 @@
+from lnst.RecipeCommon.Perf.Measurements.Results.AggregatedXDPBenchMeasurementResults import (
+    AggregatedXDPBenchMeasurementResults,
+)
+from lnst.Controller.RecipeResults import ResultType
+from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import (
+    Flow,
+    NetworkFlowTest,
+)
+from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
+from lnst.RecipeCommon.Perf.Measurements.Results.XDPBenchMeasurementResults import (
+    XDPBenchMeasurementResults,
+)
+from lnst.RecipeCommon.Perf.Results import (
+    PerfInterval,
+    ParallelPerfResult,
+    SequentialPerfResult,
+)
+from lnst.Tests.PktGen import PktGen
+from lnst.Tests.XDPBench import XDPBench
+from lnst.Controller.Job import Job
+from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import BaseFlowMeasurement
+
+
+class XDPBenchMeasurement(BaseFlowMeasurement):
+    def __init__(self, flows: list[Flow], xdp_command: str, recipe_conf=None):
+        super().__init__(recipe_conf)
+        self._flows = flows
+        self._running_measurements = []
+        self._finished_measurements = []
+
+        self.command = xdp_command
+
+    def version(self):
+        return 1.0
+
+    @property
+    def flows(self):
+        return self._flows
+
+    def start(self):
+        net_flows = self._prepare_flows()
+        for flow in net_flows:
+            flow.server_job.start(bg=True)
+            flow.client_job.start(bg=True)
+            # server starts immediately, no need to wait
+            self._running_measurements.append(flow)
+
+        self._running_measurements = net_flows
+
+    def _prepare_server(self, flow: Flow):
+        params = {
+            "command": self.command,
+            "interface": flow.receiver_nic,
+            "duration": flow.duration + flow.warmup_duration * 2,
+        }
+        bench = XDPBench(**params)
+        job = flow.receiver.prepare_job(bench)
+
+        return job
+
+    def _prepare_client(self, flow: Flow):
+        params = {
+            "src_if": flow.generator_nic,
+            "dst_mac": flow.receiver_nic.hwaddr,
+            "src_ip": flow.generator_bind,
+            "dst_ip": flow.receiver_bind,
+            "cpus": flow.generator_cpupin,
+            "pkt_size": flow.msg_size,
+            "duration": flow.duration + flow.warmup_duration * 2,
+        }
+        pktgen = PktGen(**params)
+
+        job = flow.generator.prepare_job(pktgen)
+
+        return job
+
+    def _prepare_flows(self) -> list[NetworkFlowTest]:
+        flows = []
+        for flow in self.flows:
+            client = self._prepare_client(flow)
+            server = self._prepare_server(flow)
+            net_flow = NetworkFlowTest(flow, server, client)
+            flows.append(net_flow)
+
+        return flows
+
+    def finish(self):
+        try:
+            for flow in self._running_measurements:
+                client_job = flow.client_job.what
+                flow.client_job.wait(timeout=client_job.runtime_estimate())
+                flow.server_job.wait(timeout=5)
+        finally:
+            for flow in self._running_measurements:
+                flow.server_job.kill()
+                flow.client_job.kill()
+        self._finished_measurements = self._running_measurements
+        self._running_measurements = []
+
+    def collect_results(self):
+        test_flows = self._finished_measurements
+
+        results = []
+        for test_flow in test_flows:
+            flow_results = XDPBenchMeasurementResults(
+                measurement=self,
+                flow=test_flow.flow,
+                warmup_duration=test_flow.flow.warmup_duration,
+            )
+            flow_results.generator_results = self._parse_generator_results(
+                test_flow.client_job,
+            )
+            flow_results.receiver_results = self._parse_receiver_results(
+                test_flow.server_job
+            )
+
+            results.append(flow_results)
+        return results
+
+    def _parse_generator_results(self, job: Job):
+        results = ParallelPerfResult()  # container for multiple instances of pktgen
+
+        for _, raw_results in job.result.items():
+            instance_results = SequentialPerfResult()  # instance (device) of pktgen
+            for raw_result in raw_results:
+                sample = PerfInterval(
+                    raw_result["packets"],
+                    raw_result["duration"],
+                    "packets",
+                    raw_result["timestamp"],
+                )
+                instance_results.append(sample)
+            results.append(instance_results)
+
+        return results
+
+    def _parse_receiver_results(self, job: Job):
+        result = (
+            ParallelPerfResult()
+        )  # just a placeholder to keep data structure same as other Measurements
+        results = SequentialPerfResult()  # single instance of xdp-bench
+
+        for sample in job.result:
+            results.append(
+                PerfInterval(
+                    sample["rx"], sample["duration"], "packets", sample["timestamp"]
+                )
+            )
+
+        result.append(results)
+
+        return result
+
+    def _aggregate_flows(self, old_flow, new_flow):
+        if old_flow is not None and old_flow.flow is not new_flow.flow:
+            raise MeasurementError("Aggregating incompatible Flows")
+
+        new_result = AggregatedXDPBenchMeasurementResults(
+            measurement=self, flow=new_flow.flow
+        )
+
+        new_result.add_results(old_flow)
+        new_result.add_results(new_flow)
+        return new_result
+
+    @classmethod
+    def _report_flow_results(cls, recipe, flow_results):
+        generator = flow_results.generator_results
+        receiver = flow_results.receiver_results
+
+        desc = []
+        desc.extend(flow_results.describe())
+
+        recipe_result = ResultType.PASS
+        metrics = {"Generator": generator, "Receiver": receiver}
+        for name, result in metrics.items():
+            if cls._invalid_flow_duration(result):
+                recipe_result = ResultType.FAIL
+                desc.append("{} has invalid duration!".format(name))
+
+        recipe.add_result(
+            recipe_result,
+            "\n".join(desc),
+            data=dict(
+                generator_flow_data=generator,
+                receiver_flow_data=receiver,
+                flow_results=flow_results,
+            ),
+        )

--- a/lnst/RecipeCommon/Perf/Measurements/__init__.py
+++ b/lnst/RecipeCommon/Perf/Measurements/__init__.py
@@ -5,3 +5,5 @@ from lnst.RecipeCommon.Perf.Measurements.StatCPUMeasurement import StatCPUMeasur
 from lnst.RecipeCommon.Perf.Measurements.NeperFlowMeasurement import NeperFlowMeasurement
 from lnst.RecipeCommon.Perf.Measurements.LinuxPerfMeasurement import LinuxPerfMeasurement
 from lnst.RecipeCommon.Perf.Measurements.RDMABandwidthMeasurement import RDMABandwidthMeasurement
+from lnst.RecipeCommon.Perf.Measurements.XDPBenchMeasurement import XDPBenchMeasurement
+

--- a/lnst/Recipes/ENRT/MeasurementGenerators/XDPFlowMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/XDPFlowMeasurementGenerator.py
@@ -1,0 +1,31 @@
+from lnst.Common.Parameters import ChoiceParam, StrParam
+from lnst.RecipeCommon.Perf.Measurements.XDPBenchMeasurement import XDPBenchMeasurement
+from lnst.Recipes.ENRT.MeasurementGenerators.BaseFlowMeasurementGenerator import (
+    BaseFlowMeasurementGenerator,
+)
+
+from lnst.Tests.XDPBench import XDP_BENCH_COMMANDS
+
+
+class XDPFlowMeasurementGenerator(BaseFlowMeasurementGenerator):
+    xdp_command = ChoiceParam(type=StrParam, choices=XDP_BENCH_COMMANDS)
+
+    @property
+    def net_perf_tool_class(self):
+        """
+        This method uses the concept of partial application [1].
+
+        BaseFlowMeasurementGenerator.generate_perf_measurement_combinations
+        calls net_perf_tool_class and passes some arguments to the returned class.
+        However, XDPBenchMeasurement requires additional arguments, so the
+        only way to pass them is to either redefine the entire
+        generate_perf_measurement_combinations method or return a partially 
+        "initialised" class from net_perf_tool_class.
+
+        [1] https://github.com/LNST-project/lnst/pull/310#discussion_r1305763175
+        """
+        def XDPBenchMeasurement_partial(*args, **kwargs):
+            return XDPBenchMeasurement(*args, self.params.xdp_command, **kwargs)
+
+        return XDPBenchMeasurement_partial
+

--- a/lnst/Recipes/ENRT/XDPDropRecipe.py
+++ b/lnst/Recipes/ENRT/XDPDropRecipe.py
@@ -1,0 +1,17 @@
+from lnst.Common.Parameters import ConstParam
+from lnst.Recipes.ENRT.ConfigMixins.MultiDevInterruptHWConfigMixin import (
+    MultiDevInterruptHWConfigMixin,
+)
+from lnst.Recipes.ENRT.SimpleNetworkRecipe import SimpleNetworkRecipe
+from lnst.Recipes.ENRT.MeasurementGenerators.XDPFlowMeasurementGenerator import (
+    XDPFlowMeasurementGenerator,
+)
+
+
+class XDPDropRecipe(
+    XDPFlowMeasurementGenerator, MultiDevInterruptHWConfigMixin, SimpleNetworkRecipe
+):
+    xdp_command = ConstParam(value="drop")
+    # NOTE: Receiver's IRQs needs to be pinned to single CPU (due to test stability)
+    # Generator needs to reach line rate, therefore its' IRQ CPUs should not be limited.
+    # Simply use `multi_dev_interrupt_config` with single host.

--- a/lnst/Tests/PktGen.py
+++ b/lnst/Tests/PktGen.py
@@ -1,0 +1,218 @@
+import re
+import time
+import logging
+from subprocess import Popen
+from threading import Thread
+from typing import Iterator, Union
+
+from lnst.Common.Utils import kmod_loaded
+from lnst.Common.IpAddress import Ip4Address
+from lnst.Tests.BaseTestModule import BaseTestModule, TestModuleError
+from lnst.Common.Parameters import IntParam, IpParam, StrParam, ListParam, DeviceParam
+
+
+class PktGenResultsSampler:
+    def __init__(self, devs: list[str], duration: int) -> None:
+        """
+        PktGen output is just a table with current stats of devices. Therefore,
+        each device has a separate thread that captures current status of device
+        each second for `duration`.
+        """
+        self._devs = devs
+        self._duration = duration
+
+        self._sampling_threads: list[Thread] = []
+        self._raw_samples = {}
+
+    def start_sampling(self):
+        """
+        This is a separate method just to emphasize that pktgen
+        needs to be started immediately after the start of sampling.
+        """
+        self._setup_capturing()
+
+        for thread in self._sampling_threads:
+            thread.start()
+
+    def _setup_capturing(self):
+        for device in self._devs:
+            thread = Thread(target=self._read_dev_samples, args=(device,))
+            self._sampling_threads.append(thread)
+
+    def _read_dev_samples(self, device: str):
+        self._raw_samples[device] = []
+
+        for _ in range(0, self._duration + 1):  # +1 because first sample is "empty"
+            with open(f"/proc/net/pktgen/{device}", "r") as file:
+                self._raw_samples[device].append((time.time(), file.read()))
+                # TODO: ^^^ when upgrading to python interpreter without GIL check thread safety
+                # NOTE: samples are saved at it's end => the timestamp represents ending time, not the start
+            time.sleep(1)
+
+    @property
+    def device_samples(self) -> dict[str, list[dict[str, Union[float, int, dict]]]]:
+        for thread in self._sampling_threads:
+            thread.join(timeout=2)
+
+        samples = {}
+        for device in self._devs:
+            samples[device] = []
+            packets_sofar = 0
+            start_timestamp = self._raw_samples[device][0][0]  # first "empty" sample
+            # NOTE: sample's timestamp represent the end of sampling
+            # so each sample actually starts at the timestamp of previous sample
+
+            for timestamp, raw_sample in self._raw_samples[device][
+                1:
+            ]:  # ignore first empty sample
+                params, current = self._split_output(raw_sample)
+                current = self._parse_values(current)
+
+                packets = int(current["sofar"]) - packets_sofar
+
+                samples[device].append(
+                    {
+                        "timestamp": start_timestamp,
+                        "duration": timestamp - start_timestamp,
+                        "packets": packets,
+                        "errors": int(current["errors"]),
+                        "params": params,
+                    }
+                )
+                packets_sofar += packets
+                start_timestamp = timestamp
+
+        return samples
+
+    def _read_dev_outputs(self) -> Iterator[tuple[str, str]]:
+        for device in self._devs:
+            output = ""
+            with open(f"/proc/net/pktgen/{device}", "r") as f:
+                output = f.readlines()
+            yield device, "\n".join(output)
+
+    def _split_output(self, output: str) -> tuple:
+        match = re.search(r"Params:(.+)Current:(.+)Result:\s(?:\w+)", output, re.DOTALL)
+        if not match:
+            raise TestModuleError(f"Could not parse pktgen devide output: {output}")
+
+        return match.groups()
+
+    def _parse_values(self, params) -> dict[str, str]:
+        values = {}
+
+        for key, value in re.findall(r"(\w+):?\s(\S+)", params, re.MULTILINE):
+            values[key.lower()] = value
+
+        return values
+
+
+class PktGen(BaseTestModule):
+    """
+    In the scope of this module, the physical interface is refered as `interface`.
+    Pktgen device (interface@anything) is refered as device.
+
+    Inspired by https://github.com/torvalds/linux/blob/master/samples/pktgen/pktgen_sample03_burst_single_flow.sh
+    """
+
+    cpus = ListParam(type=IntParam())  # each CPU is 1 generator
+
+    src_if = DeviceParam()
+    dst_mac = StrParam()
+
+    src_ip = IpParam()
+    dst_ip = IpParam()
+
+    count = IntParam(default=0)  # 0 = no upper limit
+    pkt_size = IntParam(default=60)  # 4 bytes are added for CRC by NIC
+    frags = IntParam(default=1)
+    burst = IntParam(default=8)
+
+    duration = IntParam(default=60)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self._devices = []
+
+        self._res_data = {}
+        self._output_parser = None
+
+    def run(self):
+        if not kmod_loaded("pktgen"):
+            raise TestModuleError("pktgen module is not loaded")
+
+        self._pg_ctrl("reset")
+        self._configure_generator()
+
+        output_parser = PktGenResultsSampler(self._devices, self.params.duration)
+        output_parser.start_sampling()
+
+        logging.debug("Starting generator")
+        pktgen = Popen("echo 'start' > /proc/net/pktgen/pgctrl", shell=True)
+        # ^^ echoing start to controller is blocking => needs to be separated
+
+        time.sleep(self.params.duration)
+
+        pktgen.kill()  # stops pktgen
+
+        self._res_data = output_parser.device_samples
+
+        self._deconfigure_generator()
+        return True
+
+    def _configure_generator(self):
+        logging.debug("Configuring generator")
+
+        ipv6 = True
+        if isinstance(self.params.src_ip, Ip4Address):
+            ipv6 = False
+
+        src = f"src{6 if ipv6 else ''}"
+        dest = f"dst{6 if ipv6 else ''}"
+
+        for cpu in self.params.cpus:
+            dev = f"{self.params.src_if.name}@{cpu}"
+            logging.debug(f"Adding interface {self.params.src_if.name} to cpu {cpu}")
+
+            self._pg_thread(cpu, f"add_device {dev}")
+
+            self._pg_set(cpu, f"flag QUEUE_MAP_CPU")
+            self._pg_set(cpu, f"count {self.params.count}")
+            self._pg_set(cpu, f"pkt_size {self.params.pkt_size}")
+            self._pg_set(cpu, f"flag NO_TIMESTAMP")
+
+            self._pg_set(cpu, f"dst_mac {self.params.dst_mac}")
+            self._pg_set(cpu, f"src_mac {self.params.src_if.hwaddr}")
+
+            self._pg_set(cpu, f"{dest}_min {self.params.dst_ip}")
+            self._pg_set(cpu, f"{dest}_max {self.params.dst_ip}")
+            self._pg_set(cpu, f"{src}_min {self.params.src_ip}")
+            self._pg_set(cpu, f"{src}_max {self.params.src_ip}")
+
+            self._pg_set(cpu, f"burst {self.params.burst}")
+            self._devices.append(dev)
+
+    def _deconfigure_generator(self):
+        logging.debug("Deconfiguring generator")
+        for cpu in self.params.cpus:
+            self._pg_thread(cpu, "rem_device_all")
+
+        self._pg_ctrl("reset")
+
+    def _pg_ctrl(self, cmd: str):
+        self._write_command("/proc/net/pktgen/pgctrl", cmd)
+
+    def _pg_thread(self, thread: int, cmd: str):
+        self._write_command(f"/proc/net/pktgen/kpktgend_{thread}", cmd)
+
+    def _pg_set(self, thread: int, cmd: str):
+        self._write_command(f"/proc/net/pktgen/{self.params.src_if.name}@{thread}", cmd)
+
+    def _write_command(self, file: str, cmd: str):
+        logging.debug(f"Writing {cmd} to {file}")
+        with open(file, "w") as f:
+            f.write(f"{cmd}\n")
+
+    def runtime_estimate(self):
+        return self.params.duration + 2

--- a/lnst/Tests/XDPBench.py
+++ b/lnst/Tests/XDPBench.py
@@ -1,0 +1,164 @@
+import re
+import time
+import signal
+import logging
+from subprocess import Popen, PIPE
+from threading import Thread
+from lnst.Devices.Device import Device
+
+from lnst.Tests.BaseTestModule import BaseTestModule, TestModuleError
+from lnst.Common.Parameters import (
+    ChoiceParam,
+    StrParam,
+    IntParam,
+    DeviceParam,
+)
+
+
+class XDPBenchOutputParser:
+    def __init__(self, process: Popen):
+        self._process = process
+        self._raw_samples = []
+        self._capturing_start = 0
+
+    def start_sampling(self):
+        thread = Thread(target=self._capture_output)
+        thread.start()
+        self._capturing_start = time.time()
+
+    def _capture_output(self):
+        try:
+            for sample in iter(self._process.stdout.readline, ""):
+                self._raw_samples.append((time.time(), sample.decode()))
+        except ValueError:
+            pass  # .readline raises exception on killing xdp-bench subprocess
+
+    def parse_output(self) -> list[dict]:
+        _, stderr = self._process.communicate()
+
+        logging.debug("Stderr of xdp-bench:")
+        logging.debug(str(stderr))
+
+        results = []
+        previous_timestamp = self._capturing_start
+
+        for timestamp, sample in self._raw_samples:
+            try:
+                rx, err = self._parse_line(sample)
+            except ValueError:
+                if sample:  # ignore empty lines
+                    logging.error(f"Could not parse line: '{sample}'")
+                continue
+
+            duration = timestamp - previous_timestamp
+            results.append(
+                {"rx": rx, "err": err, "duration": duration, "timestamp": timestamp}
+            )
+
+            previous_timestamp = timestamp
+
+        if not results:
+            raise TestModuleError("Could not get xdp-bench output")
+
+        return results
+
+    def _parse_line(self, line: str) -> tuple:
+        match = re.search(r"Summary\s+([\d,]+)\srx/s\s+([\d,]+)\serr/s?", line)
+
+        if not match:  # skip summary line at the end + corrupted lines
+            raise ValueError("Invalid line format")
+
+        rx = match.group(1).replace(",", "")
+        err = match.group(2).replace(",", "")
+        # ^^ remove thousands separators
+
+        return int(rx), int(err)
+
+
+XDP_BENCH_COMMANDS = (
+    "pass",
+    "drop",
+    "tx",
+    "redirect",
+    "redirect-cpu",
+    "redirect-map",
+    "redirect-multi",
+)
+
+
+class XDPBench(BaseTestModule):
+    """
+    xdp-bench tool abstraction. [1]
+
+    This tool does NOT check params validity.
+
+    xdp-bench is expected to be included in PATH env variable.
+
+    [1] https://github.com/xdp-project/xdp-tools/
+    """
+
+    command = ChoiceParam(
+        type=StrParam,
+        choices=XDP_BENCH_COMMANDS,
+        mandatory=True,
+    )
+    interface = DeviceParam(mandatory=True)
+    interface2 = DeviceParam()  # used for redirect modes
+
+    interval = IntParam(default=1)
+
+    redirect_device = DeviceParam()
+    xdp_mode = ChoiceParam(type=StrParam, choices=("native", "skb"), default="native")
+    load_mode = ChoiceParam(type=StrParam, choices=("dpa", "load-bytes"))
+    packet_operation = ChoiceParam(
+        type=StrParam, choices=("no-touch", "read-data", "parse-ip", "swap-macs")
+    )
+    qsize = IntParam()
+    remote_action = ChoiceParam(
+        type=StrParam, choices=("disabled", "drop", "pass", "redirect")
+    )
+
+    # NOTE: order and names of params above matters. xdp-bench accepts params in that way
+    duration = IntParam(default=60, mandatory=True)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._res_data = []
+
+    def run(self):
+        logging.debug("Starting xdp-bench")
+        command = self._prepare_command()
+
+        bench = Popen(command, stdout=PIPE)
+        output_parser = XDPBenchOutputParser(bench)
+        output_parser.start_sampling()
+        time.sleep(self.params.duration)
+
+        bench.send_signal(signal.SIGINT)  # needs to be shutdown gracefully
+
+        self._res_data = output_parser.parse_output()
+
+        return True
+
+    def _prepare_command(self):
+        return ["xdp-bench"] + self._prepare_arguments()
+
+    def _prepare_arguments(self):
+        args = []
+        for param, value in self.params:
+            if param == "duration":
+                continue  # not a xdp-bench argument
+
+            if param not in ("interface", "interface2", "command"):
+                # ^^^ those 3 arguments are passed without arg name
+                args.append(f"--{param.replace('_', '-')}")
+
+            if isinstance(value, Device):
+                value = value.name  # get if name
+
+            args.append(str(value))
+
+        return args
+
+    def runtime_estimate(self):
+        return self.params.duration + 2

--- a/lnst/Tests/__init__.py
+++ b/lnst/Tests/__init__.py
@@ -16,5 +16,6 @@ from lnst.Tests.Ping import Ping
 from lnst.Tests.PacketAssert import PacketAssert
 from lnst.Tests.Iperf import IperfClient, IperfServer
 from lnst.Tests.RDMABandwidth import RDMABandwidthClient, RDMABandwidthServer
+from lnst.Tests.PktGen import PktGen
 
 #TODO add support for test classes from lnst-ctl.conf

--- a/lnst/Tests/__init__.py
+++ b/lnst/Tests/__init__.py
@@ -17,5 +17,5 @@ from lnst.Tests.PacketAssert import PacketAssert
 from lnst.Tests.Iperf import IperfClient, IperfServer
 from lnst.Tests.RDMABandwidth import RDMABandwidthClient, RDMABandwidthServer
 from lnst.Tests.PktGen import PktGen
-
+from lnst.Tests.XDPBench import XDPBench
 #TODO add support for test classes from lnst-ctl.conf


### PR DESCRIPTION
### Description

* added `Utils.kmod_loaded` function that checks whether module is loaded or not 
* PktGen test module implementation
  * PktGen is connection-less packet generator that simply "injects" packets to NIC's TX buffer. Because of that it requires `pktgen` kernel module if kernel wasn't compiled with `CONFIG_NET_PKTGEN` flag.
  * Outputs of devices are at the end parsed to `PktGen._res_data` attr in following format: `{[OUTPUT_DEV]: {"params": {DEVICE_CONFIGURATION}, "current": {CURRENT_STATS}, "state": "[ACTUAL_STATE]"}}`
* `XDPBench` test module that utilizes [xdp-bench](https://github.com/xdp-project/xdp-tools/tree/master/xdp-bench)
  * see problem with output reading https://github.com/xdp-project/xdp-tools/issues/344
* `XDPDropRecipe` is basically just `SimpleNetworkRecipe` that uses `XDPBenchMeasurement(Generator)` instead, so it uses pktgen+xdp-bench 

### Tests
* Invidivual `PktGen`/`XDPBench` test modules (examples in commit messages)
* Manual `XDPDropRecipe` testing - reviewed generator, receiver result data as well as cpu measurement results


Minimal example:
```python
from lnst.Controller import Controller
from lnst.Controller.Recipe import export_recipe_run
from lnst.Recipes.ENRT.XDPDropRecipe import XDPDropRecipe

ctl = Controller(
    debug=1,
)

recipe_instance = XDPDropRecipe(
        driver='ice',
        perf_tool_cpu=[5,6,7,8,9],
        perf_tool_cpu_policy='all',
        perf_iterations=1,
        perf_duration=60,
        multi_dev_interrupt_config={"host2":{"eth0": {"cpus":[5],"cpu_policy":"all"}}},
        ip_versions=['ipv4'],
        perf_msg_sizes=[60],
        disable_turboboost=True,
        drop_caches=True,
        offload_combinations=[{'gro': 'on', 'gso': 'on', 'tso': 'on', 'tx': 'on'}],
        perf_warmup_duration=3)
r = ctl.run(recipe_instance)

export_recipe_run(recipe_instance.runs[0], "/root/")
```
### Reviews
@LNST-project/lnst-developers 
