### PR TITLE
Add RDMA bandwidth testing capability

### DIFF
--- a/container_files/Dockerfile
+++ b/container_files/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf install -y initscripts \
     libnl3 \
     git \
     perf \
+    perftest \
     tcpdump \
     libnl3-devel &&  \
     curl -sSL https://install.python-poetry.org |  \

--- a/lnst/Common/Parameters.py
+++ b/lnst/Common/Parameters.py
@@ -51,6 +51,15 @@ class Param(object):
         """
         return value
 
+class ConstParam(Param):
+    def __init__(self, value):
+        super().__init__(default=value)
+
+    def type_check(self, value):
+        if hasattr(self, "default") and value != self.default:
+            raise ParamError(f"Different value for constant parameter was provided ({value} != {self.default})")
+        return value
+
 class IntParam(Param):
     def type_check(self, value):
         try:

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -1,169 +1,64 @@
+from dataclasses import dataclass
 import textwrap
+from typing import Optional, Union
+from lnst.Common.IpAddress import BaseIpAddress
+from lnst.Controller import Job, Namespace
 
 from lnst.Controller.RecipeResults import ResultType
+from lnst.Devices import Device
 from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
 from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
 from lnst.RecipeCommon.Perf.Measurements.Results import FlowMeasurementResults, AggregatedFlowMeasurementResults
 from lnst.RecipeCommon.Perf.Results import ParallelPerfResult
 
-class Flow(object):
-    def __init__(self,
-                 type,
-                 generator,
-                 generator_bind,
-                 receiver,
-                 receiver_bind,
-                 duration,
-                 parallel_streams,
-                 generator_nic=None,
-                 generator_port=None,
-                 receiver_nic=None,
-                 receiver_port=None,
-                 msg_size=None,
-                 generator_cpupin=None,
-                 receiver_cpupin=None,
-                 aggregated_flow=False,
-                 warmup_duration=0):
-        self._type = type
 
-        self._generator = generator
-        self._generator_bind = generator_bind
-        self._generator_nic = generator_nic
-        self._generator_port = generator_port
-        self._receiver = receiver
-        self._receiver_bind = receiver_bind
-        self._receiver_nic = receiver_nic
-        self._receiver_port = receiver_port
-
-        self._msg_size = msg_size
-        self._duration = duration
-        self._parallel_streams = parallel_streams
-        self._generator_cpupin = generator_cpupin
-        self._receiver_cpupin = receiver_cpupin
-        self._aggregated_flow=aggregated_flow
-        self._warmup_duration = warmup_duration
-
-    @property
-    def type(self):
-        return self._type
-
-    @property
-    def generator(self):
-        return self._generator
-
-    @property
-    def generator_bind(self):
-        return self._generator_bind
-
-    @property
-    def generator_nic(self):
-        return self._generator_nic
-
-    @property
-    def generator_port(self):
-        return self._generator_port
-
-    @property
-    def receiver(self):
-        return self._receiver
-
-    @property
-    def receiver_bind(self):
-        return self._receiver_bind
-
-    @property
-    def receiver_nic(self):
-        return self._receiver_nic
-
-    @property
-    def receiver_port(self):
-        return self._receiver_port
-
-    @property
-    def msg_size(self):
-        return self._msg_size
-
-    @property
-    def duration(self):
-        return self._duration
-
-    @property
-    def parallel_streams(self):
-        return self._parallel_streams
-
-    @property
-    def generator_cpupin(self):
-        return self._generator_cpupin
-
-    @property
-    def receiver_cpupin(self):
-        return self._receiver_cpupin
-
-    @property
-    def aggregated_flow(self):
-        return self._aggregated_flow
-
-    @property
-    def warmup_duration(self):
-        return self._warmup_duration
+@dataclass
+class Flow:
+    type: str
+    generator: Namespace
+    generator_bind: BaseIpAddress
+    receiver: Namespace
+    receiver_bind: BaseIpAddress
+    duration: int
+    parallel_streams: int
+    generator_nic: Optional[Union[Device, str]] = None
+    generator_port: Optional[int] = None
+    receiver_nic: Optional[Union[Device, str]] = None
+    receiver_port: Optional[int] = None
+    msg_size: Optional[int] = None
+    generator_cpupin: Optional[list[int]] = None
+    receiver_cpupin: Optional[list[int]] = None
+    aggregated_flow: bool = False
+    warmup_duration: int = 0
 
     def __repr__(self):
-        string = """
+        string = f"""
         Flow(
-            type={type},
-            generator={generator}, 
-            generator_bind={generator_bind},
-            generator_nic={generator_nic},
-            generator_port={generator_port},
-            receiver={receiver}, 
-            receiver_bind={receiver_bind},
-            receiver_nic={receiver_nic},
-            receiver_port={receiver_port},
-            msg_size={msg_size}, 
-            duration={duration},
-            parallel_streams={parallel_streams},
-            generator_cpupin={generator_cpupin},
-            receiver_cpupin={receiver_cpupin},
-            aggregated_flow={aggregated_flow}
-            warmup_duration={warmup_duration},
-        )""".format(
-            type=self.type,
-            generator=str(self.generator),
-            generator_bind=self.generator_bind,
-            generator_nic=self.generator_nic,
-            generator_port=self.generator_port,
-            receiver=str(self.receiver),
-            receiver_bind=self.receiver_bind,
-            receiver_nic=self.receiver_nic,
-            receiver_port=self.receiver_port,
-            msg_size=self.msg_size,
-            duration=self.duration,
-            parallel_streams=self.parallel_streams,
-            generator_cpupin=self.generator_cpupin,
-            receiver_cpupin=self.receiver_cpupin,
-            aggregated_flow=self._aggregated_flow,
-            warmup_duration=self._warmup_duration
-        )
-        string = textwrap.dedent(string).strip()
-        return string
+            type={self.type},
+            generator={self.generator},
+            generator_bind={self.generator_bind},
+            generator_nic={self.generator_nic},
+            generator_port={self.generator_port},
+            receiver={self.receiver},
+            receiver_bind={self.receiver_bind},
+            receiver_nic={self.receiver_nic},
+            receiver_port={self.receiver_port},
+            msg_size={self.msg_size},
+            duration={self.duration},
+            parallel_streams={self.parallel_streams},
+            generator_cpupin={self.generator_cpupin},
+            receiver_cpupin={self.receiver_cpupin},
+            aggregated_flow={self.aggregated_flow}
+            warmup_duration={self.warmup_duration},
+        )"""
+        return textwrap.dedent(string).strip()
 
-class NetworkFlowTest(object):
-    def __init__(self, flow, server_job, client_job):
-        self._flow = flow
-        self._server_job = server_job
-        self._client_job = client_job
 
-    @property
-    def flow(self):
-        return self._flow
-
-    @property
-    def server_job(self):
-        return self._server_job
-
-    @property
-    def client_job(self):
-        return self._client_job
+@dataclass
+class NetworkFlowTest:
+    flow: Flow
+    server_job: Job
+    client_job: Job
 
 
 class BaseFlowMeasurement(BaseMeasurement):

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 import textwrap
 from typing import Optional, Union
 from lnst.Common.IpAddress import BaseIpAddress
-from lnst.Controller import Job, Namespace
+from lnst.Controller.Job import Job
+from lnst.Controller.Namespace import Namespace
 
 from lnst.Controller.RecipeResults import ResultType
 from lnst.Devices import Device

--- a/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
@@ -1,0 +1,141 @@
+from typing import Any, Optional
+import time
+
+from lnst.Controller.Job import Job
+from lnst.Controller.Recipe import BaseRecipe
+from lnst.Controller.RecipeResults import ResultType
+from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import Flow, NetworkFlowTest
+from lnst.RecipeCommon.Perf.Results import PerfInterval
+from lnst.Tests.RDMABandwidth import RDMABandwidthServer, RDMABandwidthClient
+from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import BaseFlowMeasurement
+from lnst.RecipeCommon.Perf.Measurements.Results import (
+    RDMABandwidthMeasurementResults,
+    AggregatedRDMABandwidthMeasurementResults
+)
+
+
+class RDMABandwidthMeasurement(BaseFlowMeasurement):
+    def __init__(
+        self,
+        flows: list[Flow],
+        recipe_conf: Any = None,
+    ):
+        super().__init__(recipe_conf)
+
+        self._flows = flows
+        self._endpoint_tests: list[NetworkFlowTest] = []
+
+    @property
+    def flows(self) -> list[Flow]:
+        return self._flows
+
+    def start(self) -> None:
+        self._endpoint_tests.extend(self._prepare_endpoint_tests())
+
+        for endpoint_test in self._endpoint_tests:
+            endpoint_test.server_job.start(bg=True)
+
+        time.sleep(2)
+
+        self._start_timestamp = time.time()
+        for endpoint_test in self._endpoint_tests:
+            endpoint_test.client_job.start(bg=True)
+
+    def finish(self) -> None:
+        try:
+            for endpoint_test in self._endpoint_tests:
+                timeout = endpoint_test.flow.duration + 5
+                endpoint_test.client_job.wait(timeout=timeout)
+                endpoint_test.server_job.wait(timeout=timeout)
+        finally:
+            for endpoint_test in self._endpoint_tests:
+                endpoint_test.client_job.kill()
+                endpoint_test.server_job.kill()
+
+    def collect_results(self) -> list[RDMABandwidthMeasurementResults]:
+        results: list[RDMABandwidthMeasurementResults] = []
+        for endpoint_test in self._endpoint_tests:
+            bandwidth = endpoint_test.client_job.result["bandwidth"]
+            duration = endpoint_test.flow.duration
+            result = RDMABandwidthMeasurementResults(
+                measurement=self,
+                flow=endpoint_test.flow,
+            )
+            result.bandwidth = PerfInterval(
+                # pre-multiply to get the total amount of bytes sent
+                value=bandwidth * duration,
+                duration=duration,
+                unit="MiB",
+                timestamp=self._start_timestamp,
+            )
+            results.append(result)
+        self._endpoint_tests.clear()
+        return results
+
+    def _prepare_endpoint_tests(self) -> list[NetworkFlowTest]:
+        return [
+            NetworkFlowTest(
+                flow=flow,
+                server_job=self._prepare_server_job(flow),
+                client_job=self._prepare_client_job(flow),
+            )
+            for flow in self.flows
+        ]
+
+    def _prepare_server_job(self, flow: Flow) -> Job:
+        params = {
+            "device_name": self.recipe_conf.rdma_device_name,
+            "duration": flow.duration,
+            "port": flow.receiver_port,
+            "size": flow.msg_size,
+        }
+        if flow.receiver_cpupin is not None:
+            params["cpu_bind"] = flow.receiver_cpupin
+
+        return flow.receiver.prepare_job(RDMABandwidthServer(**params))
+
+    def _prepare_client_job(self, flow: Flow) -> Job:
+        params = {
+            "device_name": self.recipe_conf.rdma_device_name,
+            "dst_ip": flow.receiver_bind,
+            "src_ip": flow.generator_bind,
+            "duration": flow.duration,
+            "port": flow.receiver_port,
+            "size": flow.msg_size,
+        }
+        if flow.generator_cpupin is not None:
+            params["cpu_bind"] = flow.generator_cpupin
+
+        if flow.warmup_duration > 0:
+            params["perform_warmup"] = True
+
+        return flow.generator.prepare_job(RDMABandwidthClient(**params))
+
+    @classmethod
+    def aggregate_results(
+        cls,
+        old: Optional[list[AggregatedRDMABandwidthMeasurementResults]],
+        new: list[RDMABandwidthMeasurementResults],
+    ) -> list[AggregatedRDMABandwidthMeasurementResults]:
+        if old is None:
+            agg_results = []
+            for result in new:
+                agg_result = AggregatedRDMABandwidthMeasurementResults(result.measurement, result.flow)
+                agg_result.add_results(result)
+                agg_results.append(agg_result)
+            return agg_results
+
+        aggregated: list[AggregatedRDMABandwidthMeasurementResults] = []
+        for old_measurements, new_measurement in zip(old, new):
+            old_measurements.add_results(new_measurement)
+            aggregated.append(old_measurements)
+        return aggregated
+
+    @classmethod
+    def report_results(
+        cls,
+        recipe: BaseRecipe,
+        aggregated_results: list[AggregatedRDMABandwidthMeasurementResults],
+    ) -> None:
+        for aggregated_result in aggregated_results:
+            recipe.add_result(ResultType.PASS, aggregated_result.describe())

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedRDMABandwidthMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedRDMABandwidthMeasurementResults.py
@@ -1,0 +1,20 @@
+from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
+from lnst.RecipeCommon.Perf.Measurements.Results.RDMABandwidthMeasurementResults import RDMABandwidthMeasurementResults
+from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
+
+
+class AggregatedRDMABandwidthMeasurementResults(RDMABandwidthMeasurementResults):
+    def __init__(self, measurement: BaseMeasurement, flow: "Flow"):
+        super().__init__(measurement, flow)
+        self._individual_results = []
+
+    @property
+    def individual_results(self) -> list[RDMABandwidthMeasurementResults]:
+        return self._individual_results
+
+    @property
+    def bandwidth(self) -> SequentialPerfResult:
+        return SequentialPerfResult([result.bandwidth for result in self.individual_results])
+
+    def add_results(self, result: RDMABandwidthMeasurementResults) -> None:
+        self._individual_results.append(result)

--- a/lnst/RecipeCommon/Perf/Measurements/Results/BaseMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/BaseMeasurementResults.py
@@ -1,4 +1,4 @@
-from lnst.RecipeCommon.Perf.Measurements import BaseMeasurement
+from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
 
 
 class BaseMeasurementResults(object):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/RDMABandwidthMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/RDMABandwidthMeasurementResults.py
@@ -1,0 +1,50 @@
+from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
+from lnst.RecipeCommon.Perf.Measurements.Results.BaseMeasurementResults import BaseMeasurementResults
+from lnst.RecipeCommon.Perf.Results import PerfInterval, PerfResult
+
+
+class RDMABandwidthMeasurementResults(BaseMeasurementResults):
+    def __init__(self, measurement: BaseMeasurement, flow: "Flow"):
+        super().__init__(measurement)
+
+        self._flow = flow
+
+    @property
+    def flow(self):
+        return self._flow
+
+    @property
+    def bandwidth(self) -> PerfInterval:
+        return self._bandwidth
+
+    @bandwidth.setter
+    def bandwidth(self, bandwidth: PerfInterval) -> None:
+        self._bandwidth = bandwidth
+
+    @property
+    def start_timestamp(self):
+        return self._bandwidth.start_timestamp
+
+    @property
+    def end_timestamp(self):
+        return self._bandwidth.end_timestamp
+
+    def time_slice(self, start, end):
+        result_copy = RDMABandwidthMeasurementResults(self.measurement, self.flow)
+        result_copy.bandwidth = self.bandwidth.time_slice(start, end)
+        return result_copy
+
+    def describe(self) -> str:
+        bw = self.bandwidth
+        return "ib_send_bw measured bandwidth: {avg:.2f} +-{stddev:.2f}({percentage:.2f}%) MiB/s.".format(
+            avg=bw.average,
+            stddev=bw.std_deviation,
+            percentage=self._deviation_percentage(bw),
+        )
+
+    @classmethod
+    def _deviation_percentage(cls, result: PerfResult) -> float:
+        try:
+            return (result.std_deviation/result.average) * 100
+        except ZeroDivisionError:
+            return float('inf') if result.std_deviation >= 0 else float("-inf")

--- a/lnst/RecipeCommon/Perf/Measurements/Results/__init__.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/__init__.py
@@ -3,9 +3,12 @@ from lnst.RecipeCommon.Perf.Measurements.Results.AggregatedFlowMeasurementResult
     AggregatedFlowMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.AggregatedLinuxPerfMeasurementResults import \
     AggregatedLinuxPerfMeasurementResults
+from lnst.RecipeCommon.Perf.Measurements.Results.AggregatedRDMABandwidthMeasurementResults import \
+    AggregatedRDMABandwidthMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.BaseMeasurementResults import BaseMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.CPUMeasurementResults import CPUMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.FlowMeasurementResults import FlowMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.LinuxPerfMeasurementResults import LinuxPerfMeasurementResults
+from lnst.RecipeCommon.Perf.Measurements.Results.RDMABandwidthMeasurementResults import RDMABandwidthMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.StatCPUMeasurementResults import StatCPUMeasurementResults
 from lnst.RecipeCommon.Perf.Measurements.Results.TcRunMeasurementResults import TcRunMeasurementResults

--- a/lnst/RecipeCommon/Perf/Measurements/__init__.py
+++ b/lnst/RecipeCommon/Perf/Measurements/__init__.py
@@ -4,3 +4,4 @@ from lnst.RecipeCommon.Perf.Measurements.TRexFlowMeasurement import TRexFlowMeas
 from lnst.RecipeCommon.Perf.Measurements.StatCPUMeasurement import StatCPUMeasurement
 from lnst.RecipeCommon.Perf.Measurements.NeperFlowMeasurement import NeperFlowMeasurement
 from lnst.RecipeCommon.Perf.Measurements.LinuxPerfMeasurement import LinuxPerfMeasurement
+from lnst.RecipeCommon.Perf.Measurements.RDMABandwidthMeasurement import RDMABandwidthMeasurement

--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -129,6 +129,12 @@ class BaseEnrtRecipe(
         utilization on specified hosts.
     :type cpu_perf_tool: :any:`BaseCPUMeasurement` (default StatCPUMeasurement)
 
+    :param perf_iterations:
+        Parameter used by the :any:`generate_perf_configurations` generator. To
+        specify how many times should each performance measurement be repeated
+        to generate cumulative results which can be statistically analyzed.
+    :type perf_iterations: :any:`IntParam` (default 5)
+
     :param perf_evaluation_strategy:
         Parameter used by the :any:`evaluator_by_measurement` selector to
         pick correct performance measurement evaluators based on the strategy
@@ -149,6 +155,7 @@ class BaseEnrtRecipe(
     ping_psize = IntParam(default=56)
 
     # generic perf test params
+    perf_iterations = IntParam(default=5)
     perf_evaluation_strategy = StrParam(default="all")
 
     def test(self):

--- a/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
@@ -10,7 +10,10 @@ from lnst.Common.Parameters import (
 from lnst.Common.IpAddress import AF_INET, AF_INET6
 
 from lnst.RecipeCommon.Perf.Measurements import Flow as PerfFlow
-from lnst.RecipeCommon.Perf.Measurements import IperfFlowMeasurement, NeperFlowMeasurement
+from lnst.RecipeCommon.Perf.Measurements import (
+    IperfFlowMeasurement,
+    NeperFlowMeasurement,
+)
 
 from lnst.Recipes.ENRT.MeasurementGenerators.BaseMeasurementGenerator import BaseMeasurementGenerator
 
@@ -84,7 +87,7 @@ class BaseFlowMeasurementGenerator(BaseMeasurementGenerator):
     def generate_perf_measurements_combinations(self, config):
         combinations = super().generate_perf_measurements_combinations(config)
         for flow_combination in self.generate_flow_combinations(config):
-            combinations.append([self.net_perf_tool_class(flow_combination)])
+            combinations.append([self.net_perf_tool_class(flow_combination, recipe_conf=config)])
         return combinations
 
     def generate_flow_combinations(self, config):

--- a/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
@@ -43,12 +43,6 @@ class BaseFlowMeasurementGenerator(BaseMeasurementGenerator):
         specify the duration of the performance measurements, in seconds.
     :type perf_duration: :any:`IntParam` (default 60)
 
-    :param perf_iterations:
-        Parameter used by the :any:`generate_perf_configurations` generator. To
-        specify how many times should each performance measurement be repeated
-        to generate cumulative results which can be statistically analyzed.
-    :type perf_iterations: :any:`IntParam` (default 5)
-
     :param perf_parallel_streams:
         Parameter used by the :any:`generate_flow_combinations` generator. To
         specify how many parallel streams of the same network flow should be
@@ -72,7 +66,6 @@ class BaseFlowMeasurementGenerator(BaseMeasurementGenerator):
     # common perf test params
     perf_tests = Param(default=("tcp_stream", "udp_stream", "sctp_stream"))
     perf_duration = IntParam(default=60)
-    perf_iterations = IntParam(default=5)
     perf_parallel_streams = IntParam(default=1)
     perf_parallel_processes = IntParam(default=1)
     perf_msg_sizes = ListParam(default=[123])

--- a/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
@@ -34,14 +34,20 @@ class BaseSimpleNetworkRecipe(BaseEnrtRecipe):
         host1, host2 = self.matched.host1, self.matched.host2
         configuration = super().test_wide_configuration()
         configuration.test_wide_devices = []
+        configuration.ipv4s = []
+        configuration.ipv6s = []
 
-        ipv4_addr = interface_addresses(self.params.net_ipv4)
-        ipv6_addr = interface_addresses(self.params.net_ipv6)
+        ipv4_addr_pool = interface_addresses(self.params.net_ipv4)
+        ipv6_addr_pool = interface_addresses(self.params.net_ipv6)
 
         for host in [host1, host2]:
-            host.eth0.ip_add(next(ipv4_addr))
-            host.eth0.ip_add(next(ipv6_addr))
+            ipv4_address = next(ipv4_addr_pool)
+            ipv6_address = next(ipv6_addr_pool)
+            host.eth0.ip_add(ipv4_address)
+            host.eth0.ip_add(ipv6_address)
             host.eth0.up_and_wait()
+            configuration.ipv4s.append(ipv4_address)
+            configuration.ipv6s.append(ipv6_address)
             configuration.test_wide_devices.append(host.eth0)
 
         self.wait_tentative_ips(configuration.test_wide_devices)

--- a/lnst/Recipes/ENRT/SoftwareRDMARecipe.py
+++ b/lnst/Recipes/ENRT/SoftwareRDMARecipe.py
@@ -1,0 +1,47 @@
+from lnst.Common.Parameters import ChoiceParam, ConstParam, StrParam
+from lnst.RecipeCommon.Perf.Measurements import RDMABandwidthMeasurement
+from lnst.Recipes.ENRT.SimpleNetworkRecipe import SimpleNetworkRecipe
+from lnst.RecipeCommon.Perf.Recipe import RecipeConf
+
+
+class SoftwareRDMARecipe(SimpleNetworkRecipe):
+    """
+    RDMA / InfiniBand bandwidth test recipe
+    """
+
+    # rxe driver / siw driver
+    software_rdma_type = ChoiceParam(type=StrParam, choices={"rxe", "siw"}, mandatory=True)
+
+    # override BaseFlowMeasurementGenerator's incompatible params
+    perf_tests = ConstParam(value=["rdma_stream"])
+    net_perf_tool = ConstParam(value="rdma-measurement")
+    ip_versions = ConstParam(value=["ipv4"])
+
+    @property
+    def net_perf_tool_class(self) -> type[RDMABandwidthMeasurement]:
+        return RDMABandwidthMeasurement
+
+    @property
+    def device_name(self) -> str:
+        return f"{self.params.software_rdma_type}0"
+
+    def test_wide_configuration(self) -> RecipeConf:
+        config = super().test_wide_configuration()
+        host1, host2 = self.matched.host1, self.matched.host2
+
+        # setup RDMA link, emulating InfiniBand on Ethernet
+        for host in [host1, host2]:
+            host.run(
+                f"rdma link add {self.device_name} type {self.params.software_rdma_type} netdev {host.eth0.name}"
+            )
+
+        config.rdma_device_name = self.device_name
+        return config
+
+    def test_wide_deconfiguration(self, config: RecipeConf) -> None:
+        host1, host2 = self.matched.host1, self.matched.host2
+
+        for host in [host1, host2]:
+            host.run(f"rdma link delete {self.device_name}")
+
+        super().test_wide_deconfiguration(config)

--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -108,6 +108,7 @@ from lnst.Recipes.ENRT.LinuxBridgeOverBondRecipe import LinuxBridgeOverBondRecip
 from lnst.Recipes.ENRT.TrafficControlRecipe import TrafficControlRecipe
 from lnst.Recipes.ENRT.BaseLACPRecipe import BaseLACPRecipe
 from lnst.Recipes.ENRT.DellLACPRecipe import DellLACPRecipe
+from lnst.Recipes.ENRT.SoftwareRDMARecipe import SoftwareRDMARecipe
 
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe

--- a/lnst/Tests/RDMABandwidth.py
+++ b/lnst/Tests/RDMABandwidth.py
@@ -1,0 +1,85 @@
+from abc import ABC, abstractmethod
+import logging
+
+from lnst.Tests.BaseTestModule import BaseTestModule
+from lnst.Common.Parameters import BoolParam, IntParam, IpParam, ListParam, StrParam
+from lnst.Common.ExecCmd import exec_cmd
+from lnst.Common.Utils import is_installed
+
+
+class RDMABandwidthBase(ABC, BaseTestModule):
+    """
+    RDMA / InfiniBand bandwidth test using `ib_send_bw`
+    """
+    device_name = StrParam(mandatory=True)
+    duration = IntParam()
+    port = IntParam()
+    cpu_bind = ListParam(type=IntParam())
+    size = IntParam(default=65536)
+
+    def run(self) -> bool:
+        self._res_data = {}
+        if not is_installed("ib_send_bw"):
+            self._res_data["msg"] = "perftest package (providing ib_send_bw) is not installed on this machine!"
+            logging.error(self._res_data["msg"])
+            return False
+
+        command = self._compose_cmd()
+        logging.debug(command)
+        out, _ = exec_cmd(command)
+        bandwidth = float(out.strip())
+
+        self._res_data["bandwidth"] = bandwidth
+        return True
+
+    def _compose_cmd(self) -> str:
+        command = self._compose_base_cmd()
+        command += " --output bandwidth"
+        command += " --rdma_cm"  # required for siw, optional for rxe
+        command += f" --ib-dev {self.params.device_name}"
+        command += f" --size {self.params.size}"
+
+        if "duration" in self.params:
+            command += f" --duration {self.params.duration}"
+
+        if "port" in self.params:
+            command += f" --port {self.params.port}"
+
+        if "opts" in self.params:
+            command += f" {self.params.opts}"
+
+        if "cpu_bind" in self.params and self.params.cpu_bind:
+            prefix = "taskset -c " + ",".join(map(str, self.params.cpu_bind))
+            command = f"{prefix} {command}"
+
+        return command
+
+    @abstractmethod
+    def _compose_base_cmd(self) -> str:
+        ...
+
+
+class RDMABandwidthServer(RDMABandwidthBase):
+    def _compose_base_cmd(self) -> str:
+        return "ib_send_bw"
+
+
+class RDMABandwidthClient(RDMABandwidthBase):
+    dst_ip = IpParam(mandatory=True)
+    src_ip = IpParam(mandatory=True)
+    mtu = IntParam()
+    perform_warmup = BoolParam(default=False)
+
+    def _compose_base_cmd(self) -> str:
+        command = (
+            f"ib_send_bw {self.params.dst_ip}"
+            f" --source_ip {self.params.src_ip}"
+        )
+
+        if "mtu" in self.params:
+            command += f" --mtu {self.params.mtu}"
+
+        if self.params.perform_warmup:
+            command += " --perform_warm_up"
+
+        return command

--- a/lnst/Tests/__init__.py
+++ b/lnst/Tests/__init__.py
@@ -15,5 +15,6 @@ olichtne@redhat.com (Ondrej Lichtner)
 from lnst.Tests.Ping import Ping
 from lnst.Tests.PacketAssert import PacketAssert
 from lnst.Tests.Iperf import IperfClient, IperfServer
+from lnst.Tests.RDMABandwidth import RDMABandwidthClient, RDMABandwidthServer
 
 #TODO add support for test classes from lnst-ctl.conf


### PR DESCRIPTION
### Description
Adds RDMA (Remote Direct Memory Access) testing using [linux-rdma/perftest](https://github.com/linux-rdma/perftest)'s program `ib_send_bw`. In order for this measurement to work, we have to have an RDMA-capable pair of devices on two hosts. These are currently setup in software using `rdma link add`. There's also an option for hardware RDMA, which requires RDMA-capable NICs. Software RDMA can run on any NIC supporting Ethernet.

Currently, there are two software methods that enable RDMA - `rxe` (Soft-RoCE (Software RDMA over Converged Ethernet)) and `siw` (Software iWARP). One of these has to be selected in the recipe parameters.

### Tests
J:8103516