### PR TITLE
RecipeCommon.Perf.MeasurementResults: refactor result description generation

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/BaseCPUMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseCPUMeasurement.py
@@ -34,17 +34,9 @@ class BaseCPUMeasurement(BaseMeasurement):
         if not len(results):
             return
 
-        cpu_data = {}
-        desc = ["CPU Utilization on host {host}:".format(
-                    host=results[0].host.hostid)]
-        for result in results:
-            utilization = result.utilization
-            cpu_data[result.cpu] = utilization
-            desc.append("cpu '{cpu}': {average:.2f} +-{deviation:.2f} {unit} per second"
-                    .format(cpu=result.cpu,
-                            average=utilization.average,
-                            deviation=utilization.std_deviation,
-                            unit=utilization.unit))
+        cpu_data = {result.cpu: result.utilization for result in results}
+
+        desc = [result.describe() for result in results]
 
         recipe.add_result(ResultType.PASS, "\n".join(desc), data=cpu_data)
 

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -181,24 +181,7 @@ class BaseFlowMeasurement(BaseMeasurement):
 
         desc = []
         desc.append(str(flow_results.flow))
-        desc.append("Generator measured throughput: {tput:.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second."
-                .format(tput=generator.average,
-                        deviation=generator.std_deviation,
-                        percentage=cls._deviation_percentage(generator),
-                        unit=generator.unit))
-        desc.append("Generator process CPU data: {cpu:.2f} +-{cpu_deviation:.2f} {cpu_unit} per second."
-                .format(cpu=generator_cpu.average,
-                        cpu_deviation=generator_cpu.std_deviation,
-                        cpu_unit=generator_cpu.unit))
-        desc.append("Receiver measured throughput: {tput:.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second."
-                .format(tput=receiver.average,
-                        deviation=receiver.std_deviation,
-                        percentage=cls._deviation_percentage(receiver),
-                        unit=receiver.unit))
-        desc.append("Receiver process CPU data: {cpu:.2f} +-{cpu_deviation:.2f} {cpu_unit} per second."
-                .format(cpu=receiver_cpu.average,
-                        cpu_deviation=receiver_cpu.std_deviation,
-                        cpu_unit=receiver_cpu.unit))
+        desc.append(flow_results.describe())
 
         recipe_result = ResultType.PASS
         metrics = {"Generator": generator, "Generator process": generator_cpu,
@@ -233,13 +216,6 @@ class BaseFlowMeasurement(BaseMeasurement):
         new_result.add_results(old_flow)
         new_result.add_results(new_flow)
         return new_result
-
-    @classmethod
-    def _deviation_percentage(cls, result):
-        try:
-            return (result.std_deviation/result.average) * 100
-        except ZeroDivisionError:
-            return float('inf') if result.std_deviation >= 0 else float("-inf")
 
     @staticmethod
     def aggregate_multi_flow_results(results):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/BaseMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/BaseMeasurementResults.py
@@ -16,3 +16,6 @@ class BaseMeasurementResults(object):
 
     def align_data(self, start, end):
         return self
+
+    def describe(self):
+        return ""

--- a/lnst/RecipeCommon/Perf/Measurements/Results/CPUMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/CPUMeasurementResults.py
@@ -1,4 +1,6 @@
-from lnst.RecipeCommon.Perf.Measurements.Results.BaseMeasurementResults import BaseMeasurementResults
+from lnst.RecipeCommon.Perf.Measurements.Results.BaseMeasurementResults import (
+    BaseMeasurementResults,
+)
 
 
 class CPUMeasurementResults(BaseMeasurementResults):
@@ -23,3 +25,12 @@ class CPUMeasurementResults(BaseMeasurementResults):
     @utilization.setter
     def utilization(self, value):
         self._utilization = value
+
+    def describe(self):
+        return "host {host} cpu '{cpu}' utilization: {average:.2f} +-{deviation:.2f} {unit} per second".format(
+            host=self.host.hostid,
+            cpu=self.cpu,
+            average=self.utilization.average,
+            deviation=self.utilization.std_deviation,
+            unit=self.utilization.unit,
+        )

--- a/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
@@ -103,3 +103,36 @@ class FlowMeasurementResults(BaseMeasurementResults):
         result_copy.receiver_results = self.receiver_results.time_slice(start, end)
 
         return result_copy
+
+    def describe(self):
+        generator = self.generator_results
+        generator_cpu = self.generator_cpu_stats
+        receiver = self.receiver_results
+        receiver_cpu = self.receiver_cpu_stats
+        desc = []
+        desc.append("Generator measured throughput: {tput:.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second."
+                .format(tput=generator.average,
+                        deviation=generator.std_deviation,
+                        percentage=self._deviation_percentage(generator),
+                        unit=generator.unit))
+        desc.append("Generator process CPU data: {cpu:.2f} +-{cpu_deviation:.2f} {cpu_unit} per second."
+                .format(cpu=generator_cpu.average,
+                        cpu_deviation=generator_cpu.std_deviation,
+                        cpu_unit=generator_cpu.unit))
+        desc.append("Receiver measured throughput: {tput:.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second."
+                .format(tput=receiver.average,
+                        deviation=receiver.std_deviation,
+                        percentage=self._deviation_percentage(receiver),
+                        unit=receiver.unit))
+        desc.append("Receiver process CPU data: {cpu:.2f} +-{cpu_deviation:.2f} {cpu_unit} per second."
+                .format(cpu=receiver_cpu.average,
+                        cpu_deviation=receiver_cpu.std_deviation,
+                        cpu_unit=receiver_cpu.unit))
+        return "\n".join(desc)
+
+    @staticmethod
+    def _deviation_percentage(result):
+        try:
+            return (result.std_deviation/result.average) * 100
+        except ZeroDivisionError:
+            return float('inf') if result.std_deviation >= 0 else float("-inf")


### PR DESCRIPTION
### Description
Previously the descriptions were generated directly or almost directly as part of the Measurement classmethod "report_results" which also creates a RecipeResult object that is added to the current RecipeRun instance.

This meant that it wasn't possible to do custom descriptions or custom result objects without calling this "report_results" method which would also create the recipe result object.

This refactors the code a bit so that the MeasurementResult description is generated directly by the MeasurementResult object and the "report_results" method simply calls this when needed.

Unfortunatelly this means that the format for the CPUMeasurementResults has to change a bit as these are not grouped by "host" anymore and each individual result will contain the host id.

### Tests
CI tests should be ok for the normal functionality/syntax checks.

I did test this locally with container deployment and ran this many times with a local database as well to get a bunch of data. I'll proceed with running some internal tests on real hardware next after I reorganize my internal code updates.

### Reviews
(Please add a list of reviewers that should check the validity and sanity of
this merge request before it's accepted. Use the `@username` syntax. If you
don't know who to mention just link `@all`.)

Closes: #
