### PR TITLE
Recipes/ENRT: fix recipes after cpupin split

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/MultiCoalescingHWConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/MultiCoalescingHWConfigMixin.py
@@ -47,9 +47,8 @@ class MultiCoalescingHWConfigMixin(BaseHWConfigMixin):
                 )
 
     def hw_deconfig(self, config):
-        for device, device_setting in zip(
-            self.coalescing_hw_config_dev_list, self.params.get("coalescing_settings")
-        ):
+        device_settings = self._parse_device_settings(self.params.coalescing_settings)
+        for device, device_setting in device_settings.items():
             device_setting_copy = copy(device_setting)
             for param in device_setting:
                 if param in ["adaptive-tx", "adaptive-rx"]:

--- a/lnst/Recipes/ENRT/ConfigMixins/PerfReversibleFlowMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/PerfReversibleFlowMixin.py
@@ -33,7 +33,8 @@ class PerfReversibleFlowMixin(object):
         server_bind,
         server_port,
         msg_size,
-        cpupin,
+        generator_cpupin,
+        receiver_cpupin,
     ) -> PerfFlow:
         if self.params.perf_reverse:
             return super()._create_perf_flow(
@@ -44,7 +45,8 @@ class PerfReversibleFlowMixin(object):
                     client_bind,
                     server_port,
                     msg_size,
-                    cpupin,
+                    generator_cpupin,
+                    receiver_cpupin,
             )
         else:
             return super()._create_perf_flow(
@@ -55,5 +57,6 @@ class PerfReversibleFlowMixin(object):
                     server_bind,
                     server_port,
                     msg_size,
-                    cpupin,
+                    generator_cpupin,
+                    receiver_cpupin,
             )

--- a/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
@@ -207,7 +207,9 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
                     duration=self.params.perf_duration,
                     warmup_duration=self.params.perf_warmup_duration,
                     parallel_streams=self.params.perf_parallel_streams,
-                    cpupin=self.params.perf_tool_cpu if (
+                    generator_cpupin=self.params.perf_tool_cpu if (
+                            "perf_tool_cpu" in self.params) else None,
+                    receiver_cpupin=self.params.perf_tool_cpu if (
                             "perf_tool_cpu" in self.params) else None
                 )
                 yield [flow]

--- a/lnst/Recipes/ENRT/IpsecEspAhCompRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAhCompRecipe.py
@@ -163,7 +163,10 @@ class IpsecEspAhCompRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
                     duration = self.params.perf_duration,
                     parallel_streams = self.params.perf_parallel_streams,
                     warmup_duration=self.params.perf_warmup_duration,
-                    cpupin = self.params.perf_tool_cpu if (
+                    generator_cpupin = self.params.perf_tool_cpu if (
+                        "perf_tool_cpu" in self.params) else None
+                    ,
+                    receiver_cpupin = self.params.perf_tool_cpu if (
                         "perf_tool_cpu" in self.params) else None
                     )
                 yield [flow]

--- a/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
+++ b/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
@@ -295,7 +295,8 @@ class OvSDPDKBondRecipe(BaseEnrtRecipe):
                 msg_size=self.params.perf_msg_size,
                 duration=self.params.perf_duration,
                 parallel_streams=1,
-                cpupin=None))
+                generator_cpupin=None,
+                receiver_cpupin=None))
 
         perf_recipe_conf = dict(
             recipe_config=config,

--- a/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
+++ b/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
@@ -151,7 +151,8 @@ class OvSDPDKPvPRecipe(BasePvPRecipe):
                 msg_size=self.params.perf_msg_size,
                 duration=self.params.perf_duration,
                 parallel_streams=self.params.perf_streams,
-                cpupin=None))
+                generator_cpupin=None,
+                receiver_cpupin=None))
 
         perf_recipe_conf=dict(
             recipe_config=config,

--- a/lnst/Recipes/ENRT/VhostNetPvPRecipe.py
+++ b/lnst/Recipes/ENRT/VhostNetPvPRecipe.py
@@ -134,7 +134,8 @@ class VhostNetPvPRecipe(BasePvPRecipe):
                                   msg_size=self.params.perf_msg_size,
                                   duration=self.params.perf_duration,
                                   parallel_streams=self.params.perf_streams,
-                                  cpupin=None)
+                                  generator_cpupin=None,
+                                  receiver_cpupin=None)
                          )
 
         return PerfRecipeConf(

--- a/lnst/Tests/Iperf.py
+++ b/lnst/Tests/Iperf.py
@@ -158,6 +158,8 @@ class IperfClient(IperfBase):
 
         if "client_port" in self.params:
             client_port = "--cport {:d}".format(self.params.client_port)
+        else:
+            client_port = ""
 
         if "blksize" in self.params:
             blksize = "-l {:d}".format(self.params.blksize)


### PR DESCRIPTION
### Description

PR https://github.com/LNST-project/lnst/pull/306 changed how cpupin parameter is used. I forgot to update other recipes that use the PerfFlow directly. This PR fixes that.

### Tests

J:8023660, no coverage for perf_reverse as we have no tests in the database.

### Reviews

@olichtne 
