### PR TITLE
Fix linuxperf measurement for SimpleNetworkTunableRecipe

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -27,8 +27,7 @@ def timestamp() -> str:
 class LinuxPerfMeasurement(BaseMeasurement):
     _MEASUREMENT_VERSION: int = 1
 
-    hosts: list[Host]
-    linuxperf_cpus: list[list[int]]
+    linuxperf_cpus: dict[Host, list[list[int]]]
     _start_timestamp: float
     _end_timestamp: float
     _data_folder: str
@@ -40,14 +39,12 @@ class LinuxPerfMeasurement(BaseMeasurement):
 
     def __init__(
         self,
-        hosts: list[Host],
-        linuxperf_cpus: list[list[int]],
+        linuxperf_cpus: dict[Host, list[list[int]]],
         data_folder: str,
         recipe_conf: Any = None,
     ):
         super().__init__(recipe_conf)
 
-        self.hosts = hosts
         self.linuxperf_cpus = linuxperf_cpus
         self._data_folder = data_folder
 
@@ -57,6 +54,10 @@ class LinuxPerfMeasurement(BaseMeasurement):
                 os.mkdir(os.path.join(self._data_folder, host.hostid))
             except FileExistsError:
                 pass
+
+    @property
+    def hosts(self) -> list[Host]:
+        return list(self.linuxperf_cpus.keys())
 
     @property
     def version(self) -> Optional[dict[str, Any]]:
@@ -89,7 +90,7 @@ class LinuxPerfMeasurement(BaseMeasurement):
     @property
     def configurations(self) -> Iterable[tuple[Host, int, list[int]]]:
         for host in self.hosts:
-            for cpu_list_id, cpu_list in enumerate(self.linuxperf_cpus):
+            for cpu_list_id, cpu_list in enumerate(self.linuxperf_cpus[host]):
                 yield (host, cpu_list_id, cpu_list)
 
     def start(self) -> None:

--- a/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
@@ -23,7 +23,9 @@ class BaremetalEnrtMeasurementGenerators(
 ):
     @property
     def linuxperf_cpus(self):
-        return [self.params.dev_intr_cpu, self.params.perf_tool_cpu]
+        return {
+            host: [self.params.dev_intr_cpu, self.params.perf_tool_cpu] for host in self.matched
+        }
 
 
 class BaremetalEnrtCommonMixins(

--- a/lnst/Recipes/ENRT/SimpleNetworkTunableRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleNetworkTunableRecipe.py
@@ -105,3 +105,16 @@ class SimpleNetworkTunableRecipe(
     @property
     def coalescing_hw_config_dev_list(self):
         return [self.matched.host1.eth0, self.matched.host2.eth0]
+
+    @property
+    def linuxperf_cpus(self):
+        result = {
+            self.matched.host1: [self.params.perf_tool_generator_cpu],
+            self.matched.host2: [self.params.perf_tool_receiver_cpu],
+        }
+
+        device_settings = self._parse_device_settings(self.params.multi_dev_interrupt_config)
+        for dev, dev_config in device_settings.items():
+            result[dev.host].append(dev_config["cpus"])
+
+        return result


### PR DESCRIPTION
### Description

The SimpleNetworkTunableRecipe uses different cpupin parameters and therefore cannot use the LinuxPerfMeasurementGenerator in its current form.

This patch enhances the LinuxPerfMeasurement so that perf tool can profile different sets of cpus on recipe hosts.

### Tests

Tested locally, for the recipes inheriting from BaremetalEnrtRecipe the change is transparent. Tested also the SimpleNetworkTunableRecipe.

Scheduled tests in Beaker: J:8062080 J:8062081

Closes: #315 
