### PR TITLE
Add better endpoints definitions

### DIFF
--- a/container_files/Dockerfile
+++ b/container_files/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf install -y initscripts \
     libvirt \
     libvirt-devel \
     libnl3 \
+    lksctp-tools-devel \
     git \
     perf \
     perftest \

--- a/lnst/RecipeCommon/endpoints.py
+++ b/lnst/RecipeCommon/endpoints.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from collections.abc import Iterator
+from typing import Generic, TypeVar
+
+from lnst.Common.IpAddress import BaseIpAddress
+from lnst.Controller.Namespace import Namespace
+from lnst.Devices import RemoteDevice
+
+
+# marked as covariant to allow saving a value of type `IPEndpoint[Ip4Address]`
+# to a variable of type `IPEndpoint[BaseIpAddress]`
+TIpAddress_co = TypeVar("TIpAddress_co", bound=BaseIpAddress, covariant=True)
+
+
+@dataclass
+class Endpoint:
+    """Basic endpoint object.
+
+    The host and device name are derived from a provided device.
+    """
+
+    device: RemoteDevice
+
+    @property
+    def host(self) -> Namespace:
+        return self.device.netns
+
+    @property
+    def device_name(self) -> str:
+        return self.device.name
+
+
+@dataclass
+class IPEndpoint(Endpoint, Generic[TIpAddress_co]):
+    """IP endpoint object"""
+
+    address: TIpAddress_co
+
+
+@dataclass
+class IPPortEndpoint(Generic[TIpAddress_co], IPEndpoint[TIpAddress_co]):
+    port: int
+
+
+# marked as covariant to allow saving a value of type `EndpointPair[IPEndpoint]`
+# to a variable of type `EndpointPair[Endpoint]`
+TEndpoint_co = TypeVar("TEndpoint_co", bound=Endpoint, covariant=True)
+
+
+@dataclass
+class EndpointPair(Generic[TEndpoint_co]):
+    """Represents a pair of endpoints."""
+
+    first: TEndpoint_co
+    second: TEndpoint_co
+
+    def __iter__(self) -> Iterator[TEndpoint_co]:
+        yield self.first
+        yield self.second

--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -281,7 +281,7 @@ class BaseEnrtRecipe(
                         pprint.pformat(self.params._to_dict())))
         self.add_result(ResultType.PASS, "\n".join(description))
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         """Generates the test wide configuration description
 
         Another class inteded to be used with the collaborative version of the

--- a/lnst/Recipes/ENRT/BaseLACPRecipe.py
+++ b/lnst/Recipes/ENRT/BaseLACPRecipe.py
@@ -39,6 +39,7 @@ class BaseLACPRecipe(DoubleBondRecipe):
         it calls switch configuration method.
         """
         host1, host2 = self.matched.host1, self.matched.host2
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)
@@ -51,23 +52,20 @@ class BaseLACPRecipe(DoubleBondRecipe):
                 dev.down()
                 host.bond0.slave_add(dev)
 
-            host.bond0.ip_add(next(ipv4_addr))
-            host.bond0.ip_add(next(ipv4_addr))
+            config.configure_and_track_ip(host.bond0, next(ipv4_addr))
+            config.configure_and_track_ip(host.bond0, next(ipv4_addr))
 
-            host.bond0.ip_add(next(ipv6_addr))
-            host.bond0.ip_add(next(ipv6_addr))
+            config.configure_and_track_ip(host.bond0, next(ipv6_addr))
+            config.configure_and_track_ip(host.bond0, next(ipv6_addr))
 
             for dev in [host.eth0, host.eth1, host.bond0]:
                 dev.up()
 
         self.test_wide_switch_configuration()
 
-        configuration = super(DoubleBondRecipe, self).test_wide_configuration()
-        configuration.test_wide_devices = [host1.bond0, host2.bond0]
+        self.wait_tentative_ips(config.configured_devices)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-
-        return configuration
+        return config
 
     def test_wide_switch_deconfiguration(self):
         raise NotImplementedError()

--- a/lnst/Recipes/ENRT/BaseTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/BaseTunnelRecipe.py
@@ -1,5 +1,6 @@
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.PacketAssert import PacketAssertTestAndEvaluate
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 
 
 class BaseTunnelRecipe(
@@ -36,7 +37,6 @@ class BaseTunnelRecipe(
         """
 
         configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = []
         configuration.tunnel_endpoints = None
         configuration.tunnel_devices = []
 
@@ -83,7 +83,7 @@ class BaseTunnelRecipe(
         """
         raise NotImplementedError
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         """
         Test wide description is extended with the configured addresses
         of the underlying network devices and the configured tunnel devices
@@ -91,7 +91,7 @@ class BaseTunnelRecipe(
         desc = super().generate_test_wide_description(config)
         desc += [
             "Configured {}.{}.ips = {}".format(dev.host.hostid, dev.name, dev.ips)
-            for dev in config.test_wide_devices
+            for dev in config.configured_devices
         ]
         desc += [
             "Configured tunnel endpoint {}.{}.ips = {}".format(
@@ -104,7 +104,6 @@ class BaseTunnelRecipe(
     def test_wide_deconfiguration(self, config):
         ""  # overriding the parent docstring
         del config.tunnel_devices
-        del config.test_wide_devices
 
         super().test_wide_deconfiguration(config)
 

--- a/lnst/Recipes/ENRT/BaseTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/BaseTunnelRecipe.py
@@ -1,4 +1,8 @@
+from collections.abc import Collection
+
 from lnst.Devices import RemoteDevice
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.PacketAssert import PacketAssertTestAndEvaluate
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
@@ -140,10 +144,11 @@ class BaseTunnelRecipe(
         """
         raise NotImplementedError
 
-    def generate_perf_endpoints(self, config: EnrtConfiguration):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for recipes derived from this class are usually
         the tunnel endpoints. The derived class can override the endpoints
         if needed.
         """
-        return [tuple(config.tunnel_devices)]
+        dev1, dev2 = config.tunnel_devices
+        return [ip_endpoint_pairs(config, (dev1, dev2))]

--- a/lnst/Recipes/ENRT/BaseTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/BaseTunnelRecipe.py
@@ -110,10 +110,6 @@ class BaseTunnelRecipe(
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        ""  # overriding the parent docstring
-        super().test_wide_deconfiguration(config)
-
     def ping_test(self, ping_configs):
         pa_config = self.get_packet_assert_config(ping_configs[0])
         self.packet_assert_test_start(pa_config)

--- a/lnst/Recipes/ENRT/BondRecipe.py
+++ b/lnst/Recipes/ENRT/BondRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     IntParam,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -150,7 +153,7 @@ class BondRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
         """
         return [PingEndpoints(self.matched.host1.bond0, self.matched.host2.eth0)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the configured bonding device on
         host1 and the matched ethernet device on host2. The traffic egresses
@@ -158,13 +161,8 @@ class BondRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
 
         | host1.bond0
         | host2.eth0
-
-        Returned as::
-
-            [(self.matched.host1.bond0, self.matched.host2.eth0)]
-
         """
-        return [(self.matched.host1.bond0, self.matched.host2.eth0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.bond0, self.matched.host2.eth0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/BondRecipe.py
+++ b/lnst/Recipes/ENRT/BondRecipe.py
@@ -139,9 +139,6 @@ class BondRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         """
         The ping endpoints for this recipe are the configured bonding device on

--- a/lnst/Recipes/ENRT/DoubleBondRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleBondRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     IntParam,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -95,8 +98,8 @@ class DoubleBondRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host1.bond0, self.matched.host2.bond0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.bond0, self.matched.host2.bond0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.bond0, self.matched.host2.bond0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/DoubleBondRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleBondRecipe.py
@@ -92,9 +92,6 @@ class DoubleBondRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host1.bond0, self.matched.host2.bond0)]
 

--- a/lnst/Recipes/ENRT/DoubleTeamRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleTeamRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     StrParam,
@@ -6,6 +7,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -91,8 +94,8 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
             PingEndpoints(self.matched.host2.team0, self.matched.host1.team0)
         ]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.team0, self.matched.host2.team0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.team0, self.matched.host2.team0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/DoubleTeamRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleTeamRecipe.py
@@ -85,9 +85,6 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [
             PingEndpoints(self.matched.host1.team0, self.matched.host2.team0),

--- a/lnst/Recipes/ENRT/DoubleTeamRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleTeamRecipe.py
@@ -7,6 +7,7 @@ from lnst.Common.Parameters import (
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -37,6 +38,7 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
 
     def test_wide_configuration(self):
         host1, host2 = self.matched.host1, self.matched.host2
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)
@@ -47,19 +49,16 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
             for dev in [host.eth0, host.eth1]:
                 dev.down()
                 host.team0.slave_add(dev)
-            host.team0.ip_add(next(ipv4_addr))
-            host.team0.ip_add(next(ipv6_addr))
+            config.configure_and_track_ip(host.team0, next(ipv4_addr))
+            config.configure_and_track_ip(host.team0, next(ipv6_addr))
             for dev in [host.eth0, host.eth1, host.team0]:
                 dev.up()
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = [host1.team0, host2.team0]
+        self.wait_tentative_ips(config.configured_devices)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        return config
 
-        return configuration
-
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         host1, host2 = self.matched.host1, self.matched.host2
         desc = super().generate_test_wide_description(config)
         desc += [
@@ -67,7 +66,7 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.slaves = {}".format(
@@ -75,20 +74,18 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
                     ['.'.join([dev.host.hostid, slave.name])
                     for slave in dev.slaves]
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.runner_name = {}".format(
                     dev.host.hostid, dev.name, dev.config
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ])
         ]
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
@@ -7,7 +7,7 @@ from lnst.Common.IpAddress import (
     Ip6Address,
     interface_addresses,
 )
-from lnst.Devices import GeneveDevice, LoopbackDevice
+from lnst.Devices import GeneveDevice, LoopbackDevice, RemoteDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Common.Parameters import (
@@ -18,6 +18,7 @@ from lnst.Common.Parameters import (
     IPv6NetworkParam,
 )
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -85,26 +86,29 @@ class GeneveLwtTunnelRecipe(
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
         """
         host1, host2 = self.matched.host1, self.matched.host2
+        tunnel_endpoints = (host1.eth0, host2.eth0)
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)
-        for device in [host1.eth0, host2.eth0]:
+        for device in tunnel_endpoints:
             if self.params.carrier_ipversion == "ipv4":
-                device.ip_add(next(ipv4_addr))
+                config.configure_and_track_ip(device, next(ipv4_addr))
             else:
-                device.ip_add(next(ipv6_addr))
+                config.configure_and_track_ip(device, next(ipv6_addr))
             device.up()
-            configuration.test_wide_devices.append(device)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-        configuration.tunnel_endpoints = (host1.eth0, host2.eth0)
+        return tunnel_endpoints
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The Geneve tunnel devices are created with external flag specified
         so that the encapsulation can be defined externally by routes.
@@ -115,16 +119,12 @@ class GeneveLwtTunnelRecipe(
         IPv4 and IPv6 addresses of the tunneled networks are configured on
         the loopback devices of the matched hosts.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        if self.params.carrier_ipversion == "ipv4":
-            ip_filter = {"family": AF_INET}
-        else:
-            ip_filter = {"family": AF_INET6, "is_link_local": False}
 
-        endpoint1_ip = endpoint1.ips_filter(**ip_filter)[0]
-        endpoint2_ip = endpoint2.ips_filter(**ip_filter)[0]
+        endpoint1_ip = config.ips_for_device(endpoint1)[0]
+        endpoint2_ip = config.ips_for_device(endpoint2)[0]
 
         m1_dummy_ip = ipaddress("172.16.10.1/32")
         m1_dummy_ip6 = ipaddress("fc00:a::1/128")
@@ -137,14 +137,14 @@ class GeneveLwtTunnelRecipe(
         m2.lo = LoopbackDevice()
 
         # A
-        m1.lo.ip_add(m1_dummy_ip)
-        m1.lo.ip_add(m1_dummy_ip6)
+        config.configure_and_track_ip(m1.lo, m1_dummy_ip)
+        config.configure_and_track_ip(m1.lo, m1_dummy_ip6)
         m1.gnv_tunnel.mtu = 1400
         m1.gnv_tunnel.up()
 
         # B
-        m2.lo.ip_add(m2_dummy_ip)
-        m2.lo.ip_add(m2_dummy_ip6)
+        config.configure_and_track_ip(m2.lo, m2_dummy_ip)
+        config.configure_and_track_ip(m2.lo, m2_dummy_ip6)
         m2.gnv_tunnel.mtu = 1400
         m2.gnv_tunnel.up()
 
@@ -171,8 +171,7 @@ class GeneveLwtTunnelRecipe(
             )
         )
 
-        configuration.tunnel_devices.extend([m1.gnv_tunnel, m2.gnv_tunnel])
-        self.wait_tentative_ips([m1.lo, m2.lo])
+        return (m1.gnv_tunnel, m2.gnv_tunnel)
 
     def generate_ping_endpoints(self, config):
         """
@@ -185,7 +184,7 @@ class GeneveLwtTunnelRecipe(
         """
         return [PingEndpoints(self.matched.host1.lo, self.matched.host2.lo)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration):
         """
         The perf endpoints for this recipe are the loopback devices that
         are configured with IP addresses of the tunnelled networks.

--- a/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GeneveLwtTunnelRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
@@ -19,6 +20,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -184,16 +187,12 @@ class GeneveLwtTunnelRecipe(
         """
         return [PingEndpoints(self.matched.host1.lo, self.matched.host2.lo)]
 
-    def generate_perf_endpoints(self, config: EnrtConfiguration):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the loopback devices that
         are configured with IP addresses of the tunnelled networks.
-
-        Returned as::
-
-            [(self.matched.host1.lo, self.matched.host2.lo)]
         """
-        return [(self.matched.host1.lo, self.matched.host2.lo)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.lo, self.matched.host2.lo))]
 
     def get_packet_assert_config(self, ping_config):
         """

--- a/lnst/Recipes/ENRT/GeneveOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GeneveOvsTunnelRecipe.py
@@ -104,11 +104,11 @@ class GeneveOvsTunnelRecipe(
         m1 = endpoint1.netns
         m2 = endpoint2.netns
 
-        for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)]):
+        for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)], 1):
             host.br0 = OvsBridgeDevice()
             host.int0 = host.br0.port_add(interface_options={"type": "internal"})
-            config.configure_and_track_ip(host.int0, ipaddress("192.168.200." + str(i + 1) + "/24"))
-            config.configure_and_track_ip(host.int0, ipaddress("fc00::" + str(i + 1) + "/64"))
+            config.configure_and_track_ip(host.int0, ipaddress(f"192.168.200.{i}/24"))
+            config.configure_and_track_ip(host.int0, ipaddress(f"fc00::{i}/64"))
 
             remote_ip = config.ips_for_device(endpoint)[0]
             host.br0.tunnel_add(

--- a/lnst/Recipes/ENRT/GeneveOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GeneveOvsTunnelRecipe.py
@@ -12,8 +12,9 @@ from lnst.Common.Parameters import (
 )
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
-from lnst.Devices import OvsBridgeDevice
+from lnst.Devices import OvsBridgeDevice, RemoteDevice
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -73,7 +74,7 @@ class GeneveOvsTunnelRecipe(
 
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
@@ -81,14 +82,16 @@ class GeneveOvsTunnelRecipe(
         host1, host2 = self.matched.host1, self.matched.host2
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         for device in [host1.eth0, host2.eth0]:
-            device.ip_add(next(ipv4_addr))
+            config.configure_and_track_ip(device, next(ipv4_addr))
             device.up()
-            configuration.test_wide_devices.append(device)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-        configuration.tunnel_endpoints = (host1.eth0, host2.eth0)
+        return (host1.eth0, host2.eth0)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         OvS bridges are created on each of the matched hosts with two ports.
         One port as an integration port and another port of type Geneve acting
@@ -97,19 +100,17 @@ class GeneveOvsTunnelRecipe(
         Integration ports are configured with IPv4 and IPv6 addresses
         of the tunneled networks.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        ip_filter = {"family": AF_INET}
 
         for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)]):
-            remote_ip = endpoint.ips_filter(**ip_filter)[0]
             host.br0 = OvsBridgeDevice()
             host.int0 = host.br0.port_add(interface_options={"type": "internal"})
-            configuration.tunnel_devices.append(host.int0)
-            host.int0.ip_add(ipaddress("192.168.200." + str(i + 1) + "/24"))
-            host.int0.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+            config.configure_and_track_ip(host.int0, ipaddress("192.168.200." + str(i + 1) + "/24"))
+            config.configure_and_track_ip(host.int0, ipaddress("fc00::" + str(i + 1) + "/64"))
 
+            remote_ip = config.ips_for_device(endpoint)[0]
             host.br0.tunnel_add(
                 "geneve", {"options:remote_ip": remote_ip, "options:key": 1234}
             )
@@ -117,7 +118,7 @@ class GeneveOvsTunnelRecipe(
             host.br0.up()
             host.int0.up()
 
-        self.wait_tentative_ips(configuration.tunnel_devices)
+        return (m1.int0, m2.int0)
 
     def generate_ping_endpoints(self, config):
         """

--- a/lnst/Recipes/ENRT/GreLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreLwtTunnelRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
@@ -19,6 +20,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -233,16 +236,12 @@ class GreLwtTunnelRecipe(
 
         return pa_config
 
-    def generate_perf_endpoints(self, config: EnrtConfiguration):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the loopback devices that
         are configured with IP addresses of the tunnelled networks.
-
-        Returned as::
-
-            [(self.matched.host1.lo, self.matched.host2.lo)]
         """
-        return [(self.matched.host1.lo, self.matched.host2.lo)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.lo, self.matched.host2.lo))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/GreOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreOvsTunnelRecipe.py
@@ -104,11 +104,11 @@ class GreOvsTunnelRecipe(
         m1 = endpoint1.netns
         m2 = endpoint2.netns
 
-        for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)]):
+        for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)], 1):
             host.br0 = OvsBridgeDevice()
             host.int0 = host.br0.port_add(interface_options={"type": "internal"})
-            config.configure_and_track_ip(host.int0, ipaddress("192.168.200." + str(i + 1) + "/24"))
-            config.configure_and_track_ip(host.int0, ipaddress("fc00::" + str(i + 1) + "/64"))
+            config.configure_and_track_ip(host.int0, ipaddress(f"192.168.200.{i}/24"))
+            config.configure_and_track_ip(host.int0, ipaddress(f"fc00::{i}/64"))
 
             remote_ip = config.ips_for_device(endpoint)[0]
             host.br0.tunnel_add("gre", {"options:remote_ip": remote_ip})

--- a/lnst/Recipes/ENRT/GreOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreOvsTunnelRecipe.py
@@ -12,8 +12,9 @@ from lnst.Common.Parameters import (
 )
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
-from lnst.Devices import OvsBridgeDevice
+from lnst.Devices import OvsBridgeDevice, RemoteDevice
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -73,7 +74,7 @@ class GreOvsTunnelRecipe(
 
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
@@ -81,14 +82,16 @@ class GreOvsTunnelRecipe(
         host1, host2 = self.matched.host1, self.matched.host2
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         for device in [host1.eth0, host2.eth0]:
-            device.ip_add(next(ipv4_addr))
+            config.configure_and_track_ip(device, next(ipv4_addr))
             device.up()
-            configuration.test_wide_devices.append(device)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-        configuration.tunnel_endpoints = (host1.eth0, host2.eth0)
+        return (host1.eth0, host2.eth0)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         OvS bridges are created on each of the matched hosts with two ports.
         One port as an integration port and another port of type GRE acting
@@ -97,25 +100,23 @@ class GreOvsTunnelRecipe(
         Integration ports are configured with IPv4 and IPv6 addresses
         of the tunneled networks.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        ip_filter = {"family": AF_INET}
 
         for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)]):
-            remote_ip = endpoint.ips_filter(**ip_filter)[0]
             host.br0 = OvsBridgeDevice()
             host.int0 = host.br0.port_add(interface_options={"type": "internal"})
-            configuration.tunnel_devices.append(host.int0)
-            host.int0.ip_add(ipaddress("192.168.200." + str(i + 1) + "/24"))
-            host.int0.ip_add(ipaddress("fc00::" + str(i + 1) + "/64"))
+            config.configure_and_track_ip(host.int0, ipaddress("192.168.200." + str(i + 1) + "/24"))
+            config.configure_and_track_ip(host.int0, ipaddress("fc00::" + str(i + 1) + "/64"))
 
+            remote_ip = config.ips_for_device(endpoint)[0]
             host.br0.tunnel_add("gre", {"options:remote_ip": remote_ip})
 
             host.br0.up()
             host.int0.up()
 
-        self.wait_tentative_ips(configuration.tunnel_devices)
+        return (m1.int0, m2.int0)
 
     def generate_ping_endpoints(self, config):
         """

--- a/lnst/Recipes/ENRT/GreTunnelOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverBondRecipe.py
@@ -11,10 +11,11 @@ from lnst.Common.Parameters import (
     StrParam,
     IPv4NetworkParam,
 )
-from lnst.Devices import GreDevice, BondDevice
+from lnst.Devices import GreDevice, BondDevice, RemoteDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.MTUHWConfigMixin import (
     MTUHWConfigMixin,
 )
@@ -91,7 +92,7 @@ class GreTunnelOverBondRecipe(
 
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of two Ethernet
         devices bonded together by bonding device on both of the matched
@@ -116,8 +117,7 @@ class GreTunnelOverBondRecipe(
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         for device in [host1.bond, host2.bond]:
-            device.ip_add(next(ipv4_addr))
-            configuration.test_wide_devices.append(device)
+            config.configure_and_track_ip(device, next(ipv4_addr))
 
         for dev in [
             host1.eth0,
@@ -129,9 +129,13 @@ class GreTunnelOverBondRecipe(
         ]:
             dev.up()
 
-        configuration.tunnel_endpoints = (host1.bond, host2.bond)
+        return (host1.bond, host2.bond)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The GRE tunnel devices are configured with local and remote ip addresses
         matching the bond device IP addresses.
@@ -139,12 +143,11 @@ class GreTunnelOverBondRecipe(
         The GRE tunnel devices are configured with IPv4 and IPv6 addresses
         of individual networks. Routes are configured accordingly.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        ip_filter = {"family": AF_INET}
-        endpoint1_ip = endpoint1.ips_filter(**ip_filter)[0]
-        endpoint2_ip = endpoint2.ips_filter(**ip_filter)[0]
+        endpoint1_ip = config.ips_for_device(endpoint1)[0]
+        endpoint2_ip = config.ips_for_device(endpoint2)[0]
 
         a_ip4 = Ip4Address("192.168.6.2/24")
         a_net4 = "192.168.6.0/24"
@@ -161,20 +164,19 @@ class GreTunnelOverBondRecipe(
 
         # A
         m1.gre_tunnel.up()
-        m1.gre_tunnel.ip_add(a_ip4)
-        m1.gre_tunnel.ip_add(a_ip6)
+        config.configure_and_track_ip(m1.gre_tunnel, a_ip4)
+        config.configure_and_track_ip(m1.gre_tunnel, a_ip6)
         m1.run("ip -4 route add {} dev {}".format(b_net4, m1.gre_tunnel.name))
         m1.run("ip -6 route add {} dev {}".format(b_net6, m1.gre_tunnel.name))
 
         # B
         m2.gre_tunnel.up()
-        m2.gre_tunnel.ip_add(b_ip4)
-        m2.gre_tunnel.ip_add(b_ip6)
+        config.configure_and_track_ip(m2.gre_tunnel, b_ip4)
+        config.configure_and_track_ip(m2.gre_tunnel, b_ip6)
         m2.run("ip -4 route add {} dev {}".format(a_net4, m2.gre_tunnel.name))
         m2.run("ip -6 route add {} dev {}".format(a_net6, m2.gre_tunnel.name))
 
-        configuration.tunnel_devices.extend([m1.gre_tunnel, m2.gre_tunnel])
-        self.wait_tentative_ips(configuration.tunnel_devices)
+        return (m1.gre_tunnel, m2.gre_tunnel)
 
     def generate_ping_endpoints(self, config):
         """

--- a/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelOverVlanRecipe.py
@@ -10,10 +10,11 @@ from lnst.Common.Parameters import (
     IntParam,
     IPv4NetworkParam,
 )
-from lnst.Devices import GreDevice, VlanDevice
+from lnst.Devices import GreDevice, VlanDevice, RemoteDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.MTUHWConfigMixin import (
     MTUHWConfigMixin,
 )
@@ -78,7 +79,7 @@ class GreTunnelOverVlanRecipe(
 
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of two Ethernet
         devices on the matched hosts. A VLAN is configured on top of each
@@ -91,8 +92,7 @@ class GreTunnelOverVlanRecipe(
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         for device in [host1.vlan0, host2.vlan0]:
-            device.ip_add(next(ipv4_addr))
-            configuration.test_wide_devices.append(device)
+            config.configure_and_track_ip(device, next(ipv4_addr))
 
         for dev in [
             host1.eth0,
@@ -102,9 +102,13 @@ class GreTunnelOverVlanRecipe(
         ]:
             dev.up()
 
-        configuration.tunnel_endpoints = (host1.vlan0, host2.vlan0)
+        return (host1.vlan0, host2.vlan0)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The GRE tunnel devices are configured with local and remote ip addresses
         matching the VLAN device IP addresses.
@@ -112,12 +116,11 @@ class GreTunnelOverVlanRecipe(
         The GRE tunnel devices are configured with IPv4 and IPv6 addresses
         of individual networks. Routes are configured accordingly.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        ip_filter = {"family": AF_INET}
-        endpoint1_ip = endpoint1.ips_filter(**ip_filter)[0]
-        endpoint2_ip = endpoint2.ips_filter(**ip_filter)[0]
+        endpoint1_ip = config.ips_for_device(endpoint1)[0]
+        endpoint2_ip = config.ips_for_device(endpoint2)[0]
 
         a_ip4 = Ip4Address("192.168.6.2/24")
         a_net4 = "192.168.6.0/24"
@@ -134,20 +137,19 @@ class GreTunnelOverVlanRecipe(
 
         # A
         m1.gre_tunnel.up()
-        m1.gre_tunnel.ip_add(a_ip4)
-        m1.gre_tunnel.ip_add(a_ip6)
+        config.configure_and_track_ip(m1.gre_tunnel, a_ip4)
+        config.configure_and_track_ip(m1.gre_tunnel, a_ip6)
         m1.run("ip -4 route add {} dev {}".format(b_net4, m1.gre_tunnel.name))
         m1.run("ip -6 route add {} dev {}".format(b_net6, m1.gre_tunnel.name))
 
         # B
         m2.gre_tunnel.up()
-        m2.gre_tunnel.ip_add(b_ip4)
-        m2.gre_tunnel.ip_add(b_ip6)
+        config.configure_and_track_ip(m2.gre_tunnel, b_ip4)
+        config.configure_and_track_ip(m2.gre_tunnel, b_ip6)
         m2.run("ip -4 route add {} dev {}".format(a_net4, m2.gre_tunnel.name))
         m2.run("ip -6 route add {} dev {}".format(a_net6, m2.gre_tunnel.name))
 
-        configuration.tunnel_devices.extend([m1.gre_tunnel, m2.gre_tunnel])
-        self.wait_tentative_ips(configuration.tunnel_devices)
+        return (m1.gre_tunnel, m2.gre_tunnel)
 
     def generate_ping_endpoints(self, config):
         """

--- a/lnst/Recipes/ENRT/GreTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/GreTunnelRecipe.py
@@ -9,10 +9,11 @@ from lnst.Common.Parameters import (
     Param,
     IPv4NetworkParam,
 )
-from lnst.Devices import GreDevice
+from lnst.Devices import GreDevice, RemoteDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.MTUHWConfigMixin import (
     MTUHWConfigMixin,
 )
@@ -72,7 +73,7 @@ class GreTunnelRecipe(
 
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
@@ -80,24 +81,25 @@ class GreTunnelRecipe(
         host1, host2 = self.matched.host1, self.matched.host2
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         for device in [host1.eth0, host2.eth0]:
-            device.ip_add(next(ipv4_addr))
+            config.configure_and_track_ip(device, next(ipv4_addr))
             device.up_and_wait()
-            configuration.test_wide_devices.append(device)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-        configuration.tunnel_endpoints = (host1.eth0, host2.eth0)
+        return (host1.eth0, host2.eth0)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The GRE tunnel devices are configured with IPv4 and IPv6 addresses
         of individual networks. Routes are configured accordingly.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        ip_filter = {"family": AF_INET}
-        endpoint1_ip = endpoint1.ips_filter(**ip_filter)[0]
-        endpoint2_ip = endpoint2.ips_filter(**ip_filter)[0]
+        endpoint1_ip = config.ips_for_device(endpoint1)[0]
+        endpoint2_ip = config.ips_for_device(endpoint2)[0]
 
         a_ip4 = Ip4Address("192.168.6.2/24")
         a_net4 = "192.168.6.0/24"
@@ -114,20 +116,19 @@ class GreTunnelRecipe(
 
         # A
         m1.gre_tunnel.up_and_wait()
-        m1.gre_tunnel.ip_add(a_ip4)
-        m1.gre_tunnel.ip_add(a_ip6)
+        config.configure_and_track_ip(m1.gre_tunnel, a_ip4)
+        config.configure_and_track_ip(m1.gre_tunnel, a_ip6)
         m1.run("ip -4 route add {} dev {}".format(b_net4, m1.gre_tunnel.name))
         m1.run("ip -6 route add {} dev {}".format(b_net6, m1.gre_tunnel.name))
 
         # B
         m2.gre_tunnel.up_and_wait()
-        m2.gre_tunnel.ip_add(b_ip4)
-        m2.gre_tunnel.ip_add(b_ip6)
+        config.configure_and_track_ip(m2.gre_tunnel, b_ip4)
+        config.configure_and_track_ip(m2.gre_tunnel, b_ip6)
         m2.run("ip -4 route add {} dev {}".format(a_net4, m2.gre_tunnel.name))
         m2.run("ip -6 route add {} dev {}".format(a_net6, m2.gre_tunnel.name))
 
-        configuration.tunnel_devices.extend([m1.gre_tunnel, m2.gre_tunnel])
-        self.wait_tentative_ips(configuration.tunnel_devices)
+        return (m1.gre_tunnel, m2.gre_tunnel)
 
     def generate_ping_endpoints(self, config):
         """

--- a/lnst/Recipes/ENRT/Ip6GreTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/Ip6GreTunnelRecipe.py
@@ -9,10 +9,11 @@ from lnst.Common.Parameters import (
     Param,
     IPv6NetworkParam,
 )
-from lnst.Devices import Ip6GreDevice
+from lnst.Devices import Ip6GreDevice, RemoteDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.MTUHWConfigMixin import (
     MTUHWConfigMixin,
 )
@@ -72,7 +73,7 @@ class Ip6GreTunnelRecipe(
 
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
@@ -80,24 +81,25 @@ class Ip6GreTunnelRecipe(
         host1, host2 = self.matched.host1, self.matched.host2
         ipv6_addr = interface_addresses(self.params.net_ipv6)
         for device in [host1.eth0, host2.eth0]:
-            device.ip_add(next(ipv6_addr))
+            config.configure_and_track_ip(device, next(ipv6_addr))
             device.up()
-            configuration.test_wide_devices.append(device)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-        configuration.tunnel_endpoints = (host1.eth0, host2.eth0)
+        return (host1.eth0, host2.eth0)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The IP6GRE tunnel devices are configured with IPv4 and IPv6 addresses
         of individual networks. Routes are configured accordingly.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        ip_filter = {"family": AF_INET6, "is_link_local": False}
-        endpoint1_ip = endpoint1.ips_filter(**ip_filter)[0]
-        endpoint2_ip = endpoint2.ips_filter(**ip_filter)[0]
+        endpoint1_ip = config.ips_for_device(endpoint1)[0]
+        endpoint2_ip = config.ips_for_device(endpoint2)[0]
 
         a_ip4 = Ip4Address("192.168.6.2/24")
         a_net4 = "192.168.6.0/24"
@@ -114,20 +116,19 @@ class Ip6GreTunnelRecipe(
 
         # A
         m1.gre6_tunnel.up()
-        m1.gre6_tunnel.ip_add(a_ip4)
-        m1.gre6_tunnel.ip_add(a_ip6)
+        config.configure_and_track_ip(m1.gre6_tunnel, a_ip4)
+        config.configure_and_track_ip(m1.gre6_tunnel, a_ip6)
         m1.run("ip -4 route add {} dev {}".format(b_net4, m1.gre6_tunnel.name))
         m1.run("ip -6 route add {} dev {}".format(b_net6, m1.gre6_tunnel.name))
 
         # B
         m2.gre6_tunnel.up()
-        m2.gre6_tunnel.ip_add(b_ip4)
-        m2.gre6_tunnel.ip_add(b_ip6)
+        config.configure_and_track_ip(m2.gre6_tunnel, b_ip4)
+        config.configure_and_track_ip(m2.gre6_tunnel, b_ip6)
         m2.run("ip -4 route add {} dev {}".format(a_net4, m2.gre6_tunnel.name))
         m2.run("ip -6 route add {} dev {}".format(a_net6, m2.gre6_tunnel.name))
 
-        configuration.tunnel_devices.extend([m1.gre6_tunnel, m2.gre6_tunnel])
-        self.wait_tentative_ips(configuration.tunnel_devices)
+        return (m1.gre6_tunnel, m2.gre6_tunnel)
 
     def generate_ping_endpoints(self, config):
         """

--- a/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
@@ -116,9 +116,6 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_sub_configurations(self, config):
         """
         Test wide configuration is extended with subconfiguration containing

--- a/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
@@ -7,6 +7,7 @@ from lnst.Common.Parameters import StrParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.LnstError import LnstError
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.BaseSubConfigMixin import (
     BaseSubConfigMixin as ConfMixin)
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -71,8 +72,7 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         """
         host1, host2 = self.matched.host1, self.matched.host2
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = [host1.eth0, host2.eth0]
+        config = super().test_wide_configuration()
 
         ipv4_addr = {host1: interface_addresses(self.params.net1_ipv4),
                      host2: interface_addresses(self.params.net2_ipv4)}
@@ -80,28 +80,26 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
                      host2: interface_addresses(self.params.net2_ipv6)}
         for host in [host1, host2]:
             host.eth0.down()
-            host.eth0.ip_add(next(ipv4_addr[host]))
-            host.eth0.ip_add(next(ipv6_addr[host]))
+            config.configure_and_track_ip(host.eth0, next(ipv4_addr[host]))
+            config.configure_and_track_ip(host.eth0, next(ipv6_addr[host]))
             host.eth0.up()
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
         if self.params.ping_parallel or self.params.ping_bidirect:
             logging.debug("Parallelism in pings is not supported for this "
                           "recipe, ping_parallel/ping_bidirect will be ignored.")
 
         for host, dst in [(host1, host2), (host2, host1)]:
-            for family in [AF_INET, AF_INET6]:
-                host.run("ip route add %s dev %s" %
-                         (dst.eth0.ips_filter(family=family)[0],
-                          host.eth0.name))
+            for ip in config.ips_for_device(dst.eth0):
+                host.run(f"ip route add {ip} dev {host.eth0.name}")
 
-        configuration.endpoint1 = host1.eth0
-        configuration.endpoint2 = host2.eth0
+        config.endpoint1 = host1.eth0
+        config.endpoint2 = host2.eth0
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         """
         Test wide description is extended with the configured IP addresses,
         specified IPsec algorithm, key length and integrity check value length.
@@ -110,7 +108,7 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         desc += [
             "\n".join([
                 f"Configured {dev.host.hostid}.{dev.name}.ips = {dev.ips}"
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]).join([f"Configured IPsec {self.params.ipsec_mode} mode with {algo} algorithm "
                      f"using key length of {key_len} and icv length of {icv_len}"
                      for algo, key_len, icv_len in self.algorithm])
@@ -119,8 +117,6 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_sub_configurations(self, config):
@@ -132,13 +128,10 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         spi_values = self.spi_values
         for subconf in ConfMixin.generate_sub_configurations(self, config):
             for ipv in self.params.ip_versions:
-                if ipv == "ipv4":
-                    family = AF_INET
-                elif ipv == "ipv6":
-                    family = AF_INET6
+                family = AF_INET if ipv == "ipv4" else AF_INET6
 
-                ip1 = subconf.endpoint1.ips_filter(family=family)[0]
-                ip2 = subconf.endpoint2.ips_filter(family=family)[0]
+                ip1 = config.ips_for_device(subconf.endpoint1, family=family)[0]
+                ip2 = config.ips_for_device(subconf.endpoint2, family=family)[0]
 
                 for algo, key_len, icv_len in self.algorithm:
                     g_key = generate_key(key_len)

--- a/lnst/Recipes/ENRT/IpsecEspAhCompRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAhCompRecipe.py
@@ -85,9 +85,6 @@ class IpsecEspAhCompRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_sub_configurations(self, config):
         ipsec_mode = self.params.ipsec_mode
         spi_values = self.spi_values

--- a/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
@@ -142,10 +142,6 @@ class LinuxBridgeOverBondRecipe(MTUHWConfigMixin, BaremetalEnrtRecipe):
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        """"""  # overriding the parent docstring
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         """
         The ping endpoints for this recipe are the created bridge devices:

--- a/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     IntParam,
     StrParam,
@@ -6,6 +7,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
@@ -154,17 +157,13 @@ class LinuxBridgeOverBondRecipe(MTUHWConfigMixin, BaremetalEnrtRecipe):
         """
         return [PingEndpoints(self.matched.host1.br0, self.matched.host2.br0)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the created bridge devices:
 
         host1.br0 and host2.br0
-
-        Returned as::
-
-            [(self.matched.host1.br0, self.matched.host2.br0)]
         """
-        return [(self.matched.host1.br0, self.matched.host2.br0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.br0, self.matched.host2.br0))]
 
     @property
     def mtu_hw_config_dev_list(self):

--- a/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
@@ -107,10 +107,6 @@ class LinuxBridgeRecipe(MTUHWConfigMixin, BaremetalEnrtRecipe):
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        """"""  # overriding the parent docstring
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         """
         The ping endpoints for this recipe are the created bridge devices:

--- a/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
@@ -119,17 +122,13 @@ class LinuxBridgeRecipe(MTUHWConfigMixin, BaremetalEnrtRecipe):
         """
         return [PingEndpoints(self.matched.host1.br0, self.matched.host2.br0)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the created bridge devices:
 
         host1.br0 and host2.br0
-
-        Returned as::
-
-            [(self.matched.host1.br0, self.matched.host2.br0)]
         """
-        return [(self.matched.host1.br0, self.matched.host2.br0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.br0, self.matched.host2.br0))]
 
     @property
     def mtu_hw_config_dev_list(self):

--- a/lnst/Recipes/ENRT/MPTCPRecipe.py
+++ b/lnst/Recipes/ENRT/MPTCPRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from socket import AF_INET, AF_INET6
 from typing import List
 
@@ -7,6 +8,8 @@ from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.Host import Host
 from lnst.RecipeCommon.MPTCPManager import MPTCPManager, MPTCPFlags
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 
@@ -154,11 +157,11 @@ class MPTCPRecipe(
         return [PingEndpoints(self.matched.host1.eth0, self.matched.host2.eth0),
                 PingEndpoints(self.matched.host1.eth1, self.matched.host2.eth1)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         Due to the way MPTCP works, the the perf endpoints will be the 2 "primary" ports/flows
         """
-        return [(self.matched.host1.eth0, self.matched.host2.eth0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.eth0, self.matched.host2.eth0))]
 
     #TODO MPTCP Devs would like it to have:
     # eth0.mtu = default

--- a/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from lnst.Common.Parameters import (
     Param,
@@ -63,7 +62,7 @@ class BaseFlowMeasurementGenerator(BaseMeasurementGenerator):
         specify what different message sizes (in bytes) used generated for the
         network flow should be tested - each message size resulting in a
         separate performance measurement.
-    :type perf_msg_sizes: List[Int] (default [123])
+    :type perf_msg_sizes: list[int] (default [123])
     """
 
     # common perf test params
@@ -101,7 +100,7 @@ class BaseFlowMeasurementGenerator(BaseMeasurementGenerator):
         :any:`msg_sizes`.
 
         :return: list of Flow combinations to measure in parallel
-        :rtype: List[:any:`PerfFlow`]
+        :rtype: Iterator[:any:`PerfFlow`]
         """
         for client_nic, server_nic in self.generate_perf_endpoints(config):
             for ipv in self.params.ip_versions:
@@ -132,7 +131,7 @@ class BaseFlowMeasurementGenerator(BaseMeasurementGenerator):
         client_nic,
         server_nic,
         msg_size,
-    ) -> List[PerfFlow]:
+    ) -> list[PerfFlow]:
 
         ip_filter = {}
         if ipv == "ipv4":

--- a/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/BaseFlowMeasurementGenerator.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 
 from lnst.Common.Parameters import (
     Param,
@@ -89,7 +90,7 @@ class BaseFlowMeasurementGenerator(BaseMeasurementGenerator):
             combinations.append([self.net_perf_tool_class(flow_combination, recipe_conf=config)])
         return combinations
 
-    def generate_flow_combinations(self, config):
+    def generate_flow_combinations(self, config) -> Iterator[list[PerfFlow]]:
         """Base flow combination generator
 
         The generator loops over all endpoint pairs to test performance between

--- a/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import IPv4NetworkParam
 from lnst.Common.IpAddress import ipaddress, interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -92,8 +95,8 @@ class NoVirtOvsVxlanRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host1.int0, self.matched.host2.int0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.int0, self.matched.host2.int0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.int0, self.matched.host2.int0))]
 
     @property
     def mtu_hw_config_dev_list(self):

--- a/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
@@ -36,20 +36,18 @@ class NoVirtOvsVxlanRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
             "output:5")
         flow_entries.append("table=0,priority=100,actions=drop")
 
-        for i, host in enumerate([host1, host2]):
+        for i, host in enumerate([host1, host2], 1):
             host.eth0.down()
-            config.configure_and_track_ip(host.eth0, host_addr[i])
+            config.configure_and_track_ip(host.eth0, host_addr[i-1])
             host.br0 = OvsBridgeDevice()
             host.int0 = host.br0.port_add(
                     interface_options={
                         'type': 'internal',
                         'ofport_request': 5,
                         'name': 'int0'})
-            config.configure_and_track_ip(host.int0, ipaddress(vxlan_net_addr + "." + str(i+1) +
-                "/24"))
-            config.configure_and_track_ip(host.int0, ipaddress(vxlan_net_addr6 + "::" + str(i+1) +
-                "/64"))
-            tunnel_opts = {"option:remote_ip" : host_addr[1-i],
+            config.configure_and_track_ip(host.int0, ipaddress(f"{vxlan_net_addr}.{i}/24"))
+            config.configure_and_track_ip(host.int0, ipaddress(f"{vxlan_net_addr6}::{i}/64"))
+            tunnel_opts = {"option:remote_ip" : host_addr[2-i],
                            "option:key" : "flow", "ofport_request" : "10"}
             host.br0.tunnel_add("vxlan", tunnel_opts)
             host.br0.flows_add(flow_entries)

--- a/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
@@ -89,9 +89,6 @@ class NoVirtOvsVxlanRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host1.int0, self.matched.host2.int0)]
 

--- a/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
+++ b/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
@@ -8,7 +8,7 @@ from lnst.Common.Parameters import (
 )
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.Namespace import Namespace
-from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe, EnrtConfiguration
 from dataclasses import dataclass
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Tests.TestPMD import TestPMD
@@ -334,7 +334,7 @@ class OvSDPDKBondRecipe(BaseEnrtRecipe):
         result = self.perf_test(perf_config)
         self.perf_report_and_evaluate(result)
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         """
         Test wide description is extended with the bus info of the configured interfaces
         used for the DPDK purposes.
@@ -386,9 +386,6 @@ class OvSDPDKBondRecipe(BaseEnrtRecipe):
 
     def generate_ping_endpoints(self, config):
         return []
-
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.dummy_cfg, self.matched.host2.dummy_cfg)]
 
     def apply_perf_test_tweak(self, config):
         pass

--- a/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
+++ b/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
@@ -174,10 +174,10 @@ class OvSDPDKBondRecipe(BaseEnrtRecipe):
 
         for i, host in enumerate([host1, host2]):
             host.dummy_cfg = DummyRecipeConfig(
-                eth0=DummyEthDevice(host.eth0.bus_info, host.eth0.hwaddr, _id="eth" + str(i),
+                eth0=DummyEthDevice(host.eth0.bus_info, host.eth0.hwaddr, _id=f"eth{i}",
                                     ips=[next(ipv4_addr1), next(ipv6_addr1)]
                                     ),
-                eth1=DummyEthDevice(host.eth1.bus_info, host.eth1.hwaddr, _id="eth" + str(i + 1),
+                eth1=DummyEthDevice(host.eth1.bus_info, host.eth1.hwaddr, _id=f"eth{i+1}",
                                     ips=[next(ipv4_addr2), next(ipv6_addr2)]
                                     ),
 

--- a/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import time
 
 from lnst.Common.Parameters import (
@@ -9,6 +10,8 @@ from lnst.Common.Parameters import (
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.NetNamespace import NetNamespace
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
@@ -177,17 +180,13 @@ class SRIOVNetnsOvSRecipe(
         """
         return [PingEndpoints(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are simply the two matched NICs:
 
         host1.newns.vf_eth0 and host2.newns.vf_eth0
-
-        Returned as::
-
-            [(self.matched.host1.eth0, self.matched.host2.eth0)]
         """
-        return [(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0))]
 
     @property
     def pause_frames_dev_list(self):

--- a/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
@@ -11,6 +11,7 @@ from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.NetNamespace import NetNamespace
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -63,7 +64,7 @@ class SRIOVNetnsTcRecipe(
     versions, not having consistent naming scheme of virtual function.
 
     Solution here is to expect deterministic VF name, which is derived from the PF name.
-    With specific kernel parameter `biosdevname=1` we can expect default suffix on 
+    With specific kernel parameter `biosdevname=1` we can expect default suffix on
     VF to be created to be `_n`, where n is the index of VF created.
     """
     vf_suffix = StrParam(default="_0")
@@ -92,8 +93,7 @@ class SRIOVNetnsTcRecipe(
         host2.eth0 = 192.168.101.2/24 and fc00::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = []
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)
@@ -122,10 +122,8 @@ class SRIOVNetnsTcRecipe(
             for dev in [host.eth0, host.newns.vf_eth0, host.vf_representor_eth0]:
                 dev.up()
 
-            host.newns.vf_eth0.ip_add(next(ipv4_addr))
-            host.newns.vf_eth0.ip_add(next(ipv6_addr))
-
-            configuration.test_wide_devices.append(host.newns.vf_eth0)
+            config.configure_and_track_ip(host.newns.vf_eth0, next(ipv4_addr))
+            config.configure_and_track_ip(host.newns.vf_eth0, next(ipv6_addr))
 
         host1.run(f"tc filter add dev {host1.eth0.name} "
                   f"protocol ip ingress flower skip_sw "
@@ -134,7 +132,7 @@ class SRIOVNetnsTcRecipe(
                   f"action mirred egress redirect dev {host1.vf_representor_eth0.name}")
 
         host1.run(f"tc filter add dev {host1.eth0.name} "
-                  f"protocol arp ingress flower " 
+                  f"protocol arp ingress flower "
                   f"src_mac {host2.newns.vf_eth0.hwaddr} "
                   f"dst_mac {host1.newns.vf_eth0.hwaddr} "
                   f"action mirred egress redirect dev {host1.vf_representor_eth0.name}")
@@ -199,11 +197,11 @@ class SRIOVNetnsTcRecipe(
                   f"dst_mac FF:FF:FF:FF:FF:FF "
                   f"action mirred egress redirect dev {host2.eth0.name}")
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         desc = super().generate_test_wide_description(config)
         host1, host2 = self.matched.host1, self.matched.host2
         for i, host in enumerate([host1, host2]):
@@ -216,7 +214,7 @@ class SRIOVNetnsTcRecipe(
             ]
         desc += [
             f"Configured {dev.host.hostid}.{dev.name}.ips = {dev.ips}"
-            for dev in config.test_wide_devices
+            for dev in config.configured_devices
         ]
         return desc
 
@@ -234,7 +232,6 @@ class SRIOVNetnsTcRecipe(
             time.sleep(2)
             host.run(f"devlink dev eswitch set pci/{host.eth0.bus_info} mode legacy")
             time.sleep(3)
-        del config.test_wide_devices
 
         super().test_wide_deconfiguration(config)
 

--- a/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import time
 
 from lnst.Common.Parameters import (
@@ -9,6 +10,8 @@ from lnst.Common.Parameters import (
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.NetNamespace import NetNamespace
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
@@ -247,17 +250,13 @@ class SRIOVNetnsTcRecipe(
         """
         return [PingEndpoints(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are simply the two matched NICs:
 
         host1.newns.vf_eth0 and host2.newns.vf_eth0
-
-        Returned as::
-
-            [(self.matched.host1.eth0, self.matched.host2.eth0)]
         """
-        return [(self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0))]
 
     @property
     def pause_frames_dev_list(self):

--- a/lnst/Recipes/ENRT/ShortLivedConnectionsRecipe.py
+++ b/lnst/Recipes/ENRT/ShortLivedConnectionsRecipe.py
@@ -1,5 +1,8 @@
+from collections.abc import Collection
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Common.Parameters import (
     Param,
@@ -56,8 +59,8 @@ class ShortLivedConnectionsRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
         ]
         return desc
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.eth0, self.matched.host2.eth0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.eth0, self.matched.host2.eth0))]
 
     @property
     def mtu_hw_config_dev_list(self):

--- a/lnst/Recipes/ENRT/ShortLivedConnectionsRecipe.py
+++ b/lnst/Recipes/ENRT/ShortLivedConnectionsRecipe.py
@@ -56,9 +56,6 @@ class ShortLivedConnectionsRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_perf_endpoints(self, config):
         return [(self.matched.host1.eth0, self.matched.host2.eth0)]
 

--- a/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import copy
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Common.IpAddress import AF_INET, AF_INET6
@@ -5,6 +6,8 @@ from lnst.Common.LnstError import LnstError
 from lnst.Common.Parameters import Param, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Devices import MacsecDevice
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.BaseSubConfigMixin import (
@@ -135,8 +138,8 @@ class SimpleMacsecRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
 
                 yield [pconf]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.msec0, self.matched.host2.msec0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.msec0, self.matched.host2.msec0))]
 
     @property
     def mtu_hw_config_dev_list(self):

--- a/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
@@ -42,19 +42,6 @@ class SimpleMacsecRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
 
         return configuration
 
-    def generate_test_wide_description(self, config):
-        host1, host2 = self.matched.host1, self.matched.host2
-        desc = super().generate_test_wide_description(config)
-        desc += [
-            "\n".join([
-                "Configured {}.{}.ips = {}".format(
-                    dev.host.hostid, dev.name, dev.ips
-                )
-                for dev in config.test_wide_devices
-            ])
-        ]
-        return desc
-
     def test_wide_deconfiguration(self, config):
         del config.test_wide_devices
 
@@ -95,6 +82,18 @@ class SimpleMacsecRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
             host.eth0.up()
             host.msec0.up()
             self.wait_tentative_ips([host.eth0, host.msec0])
+
+    def generate_sub_configuration_description(self, config):
+        desc = super().generate_sub_configuration_description(config)
+        desc += [
+            "\n".join([
+                "Configured {}.{}.ips = {}".format(
+                    dev.host.hostid, dev.name, dev.ips
+                )
+                for dev in config.configured_devices
+            ])
+        ]
+        return desc
 
     def remove_sub_configuration(self, config):
         host1, host2 = config.host1, config.host2

--- a/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
@@ -39,9 +39,6 @@ class SimpleMacsecRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
 
         return config
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_sub_configurations(self, config):
         for subconf in ConfMixin.generate_sub_configurations(self, config):
             for encryption in self.params.macsec_encryption:

--- a/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
@@ -59,10 +59,6 @@ class BaseSimpleNetworkRecipe(BaseEnrtRecipe):
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        ""  # overriding the parent docstring
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         """
         The ping endpoints for this recipe are simply the two matched NICs:

--- a/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
@@ -2,6 +2,8 @@ from collections.abc import Collection
 from lnst.Common.Parameters import Param, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe, EnrtConfiguration
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
@@ -71,17 +73,13 @@ class BaseSimpleNetworkRecipe(BaseEnrtRecipe):
         """
         return [PingEndpoints(self.matched.host1.eth0, self.matched.host2.eth0)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are simply the two matched NICs:
 
         host1.eth0 and host2.eth0
-
-        Returned as::
-
-            [(self.matched.host1.eth0, self.matched.host2.eth0)]
         """
-        return [(self.matched.host1.eth0, self.matched.host2.eth0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.eth0, self.matched.host2.eth0))]
 
 
 class SimpleNetworkRecipe(

--- a/lnst/Recipes/ENRT/TeamRecipe.py
+++ b/lnst/Recipes/ENRT/TeamRecipe.py
@@ -131,9 +131,6 @@ class TeamRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         """
         The ping endpoints for this recipe are the configured team device on

--- a/lnst/Recipes/ENRT/TeamRecipe.py
+++ b/lnst/Recipes/ENRT/TeamRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     StrParam,
@@ -6,6 +7,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -146,7 +149,7 @@ class TeamRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
             PingEndpoints(self.matched.host2.eth0, self.matched.host1.team0)
         ]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the configured team device on
         host1 and the matched ethernet device on host2. The traffic egresses
@@ -154,13 +157,8 @@ class TeamRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
 
         | host1.team0
         | host2.eth0
-
-        Returned as::
-
-            [(self.matched.host1.team0, self.matched.host2.eth0)]
-
         """
-        return [(self.matched.host1.team0, self.matched.host2.eth0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.team0, self.matched.host2.eth0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/TeamVsBondRecipe.py
+++ b/lnst/Recipes/ENRT/TeamVsBondRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     IntParam,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -110,8 +113,8 @@ class TeamVsBondRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin,
             PingEndpoints(self.matched.host2.bond0, self.matched.host1.team0)
         ]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.team0, self.matched.host2.bond0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.team0, self.matched.host2.bond0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/TeamVsBondRecipe.py
+++ b/lnst/Recipes/ENRT/TeamVsBondRecipe.py
@@ -104,9 +104,6 @@ class TeamVsBondRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [
             PingEndpoints(self.matched.host1.team0, self.matched.host2.bond0),

--- a/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
@@ -84,11 +84,9 @@ class VirtOvsVxlanRecipe(VlanPingEvaluatorMixin,
             for dev in [host.eth0, host.tap0, host.tap1, host.br0]:
                 dev.up()
 
-        for i, guest in enumerate([guest1, guest2, guest3, guest4]):
-            config.configure_and_track_ip(guest.eth0, ipaddress(vxlan_net_addr + "." + str(i+1) +
-                "/24"))
-            config.configure_and_track_ip(guest.eth0, ipaddress(vxlan_net_addr6 + "::" + str(i+1) +
-                "/64"))
+        for i, guest in enumerate([guest1, guest2, guest3, guest4], 1):
+            config.configure_and_track_ip(guest.eth0, ipaddress(f"{vxlan_net_addr}.{i}/24"))
+            config.configure_and_track_ip(guest.eth0, ipaddress(f"{vxlan_net_addr6}::{i}/64"))
             guest.eth0.up()
 
         self.wait_tentative_ips(config.configured_devices)

--- a/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
@@ -123,9 +123,6 @@ class VirtOvsVxlanRecipe(VlanPingEvaluatorMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         guest1, guest2, guest3, guest4 = (self.matched.guest1,
             self.matched.guest2, self.matched.guest3, self.matched.guest4)

--- a/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
@@ -1,7 +1,10 @@
+from collections.abc import Collection
 from itertools import combinations
 from lnst.Common.IpAddress import ipaddress, interface_addresses
 from lnst.Common.Parameters import IPv4NetworkParam
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -137,8 +140,8 @@ class VirtOvsVxlanRecipe(VlanPingEvaluatorMixin,
             ) for comb in dev_combinations
         ]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.eth0, self.matched.guest3.eth0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.eth0, self.matched.guest3.eth0))]
 
     @property
     def pause_frames_dev_list(self):

--- a/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
@@ -70,14 +70,14 @@ class VirtOvsVxlanRecipe(VlanPingEvaluatorMixin,
 
         config = super().test_wide_configuration()
 
-        for i, host in enumerate([host1, host2]):
-            config.configure_and_track_ip(host.eth0, host_ips[i])
+        for host, self_ip, other_ip in zip([host1, host2], host_ips, reversed(host_ips)):
+            config.configure_and_track_ip(host.eth0, self_ip)
             host.br0 = OvsBridgeDevice()
             for dev, ofport_r in [(host.tap0, '5'), (host.tap1, '6')]:
                 host.br0.port_add(
                         device=dev,
                         interface_options={'ofport_request': ofport_r})
-            tunnel_opts = {"option:remote_ip" : host_ips[1-i],
+            tunnel_opts = {"option:remote_ip" : other_ip,
                 "option:key" : "flow", "ofport_request" : '10'}
             host.br0.tunnel_add("vxlan", tunnel_opts)
             host.br0.flows_add(flow_entries)

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import logging
 from lnst.Common.Parameters import (
     Param,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -126,8 +129,8 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.vlan0, self.matched.guest2.vlan0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.vlan0, self.matched.guest2.vlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.vlan0, self.matched.guest2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
@@ -123,9 +123,6 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.vlan0, self.matched.guest2.vlan0)]
 

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
@@ -7,6 +7,7 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
@@ -60,18 +61,16 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
         guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=self.params.vlan_id)
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = [guest1.vlan0, guest2.vlan0,
-            host1.br0, host2.br0]
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")
-        host1.br0.ip_add(next(ipv4_addr))
-        host2.br0.ip_add(next(ipv4_addr))
+        config.configure_and_track_ip(host1.br0, next(ipv4_addr))
+        config.configure_and_track_ip(host2.br0, next(ipv4_addr))
 
-        for i, guest in enumerate([guest1, guest2]):
-            guest.vlan0.ip_add(next(ipv4_addr))
-            guest.vlan0.ip_add(next(ipv6_addr))
+        for guest in [guest1, guest2]:
+            config.configure_and_track_ip(guest.vlan0, next(ipv4_addr))
+            config.configure_and_track_ip(guest.vlan0, next(ipv6_addr))
 
         for host in [host1, host2]:
             for dev in [host.eth0, host.tap0, host.br0]:
@@ -85,11 +84,11 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
                 self.params.perf_tool_cpu)
             self.params.perf_tool_cpu = None
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         host1, host2, guest1, guest2 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2)
         desc = super().generate_test_wide_description(config)
@@ -98,7 +97,7 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.vlan_id = {}".format(
@@ -125,8 +124,6 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -105,8 +108,8 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.vlan0, self.matched.host2.vlan0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.vlan0, self.matched.host2.vlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.vlan0, self.matched.host2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
@@ -102,9 +102,6 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.vlan0, self.matched.host2.vlan0)]
 

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
@@ -1,6 +1,7 @@
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
@@ -50,27 +51,25 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = [guest1.vlan0, host1.br0,
-            host2.vlan0]
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")
 
-        host1.br0.ip_add(next(ipv4_addr))
+        config.configure_and_track_ip(host1.br0, next(ipv4_addr))
         for machine in [host2, guest1]:
-            machine.vlan0.ip_add(next(ipv4_addr))
-            machine.vlan0.ip_add(next(ipv6_addr))
+            config.configure_and_track_ip(machine.vlan0, next(ipv4_addr))
+            config.configure_and_track_ip(machine.vlan0, next(ipv6_addr))
 
         for dev in [host1.eth0, host1.tap0, host1.br0, host2.eth0,
                     host2.vlan0, guest1.eth0, guest1.vlan0]:
             dev.up()
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         host1, host2 = self.matched.host1, self.matched.host2
         desc = super().generate_test_wide_description(config)
         desc += [
@@ -78,13 +77,13 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.vlan_id = {}".format(
                     dev.host.hostid, dev.name, dev.vlan_id
                 )
-                for dev in config.test_wide_devices if isinstance(dev,
+                for dev in config.configured_devices if isinstance(dev,
                     Vlan)
             ]),
             "\n".join([
@@ -92,7 +91,7 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
                     dev.host.hostid, dev.name,
                     '.'.join([dev.host.hostid, dev.realdev.name])
                 )
-                for dev in config.test_wide_devices if isinstance(dev,
+                for dev in config.configured_devices if isinstance(dev,
                     Vlan)
             ]),
             "Configured {}.{}.slaves = {}".format(
@@ -104,8 +103,6 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
@@ -123,9 +123,6 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.guest2.eth0)]
 

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import logging
 from lnst.Common.Parameters import (
     Param,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -126,8 +129,8 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.guest2.eth0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.eth0, self.matched.guest2.eth0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.eth0, self.matched.guest2.eth0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     IntParam,
@@ -6,6 +7,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -108,8 +111,8 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.host2.vlan0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.eth0, self.matched.host2.vlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.eth0, self.matched.host2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
@@ -105,9 +105,6 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.host2.vlan0)]
 

--- a/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
@@ -174,9 +174,6 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         guest1, guest2, guest3, guest4 = (self.matched.guest1,
             self.matched.guest2, self.matched.guest3, self.matched.guest4)

--- a/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import logging
 from itertools import product
 from lnst.Common.Parameters import (
@@ -9,6 +10,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -192,8 +195,8 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
                 for comb in dev_combinations
             ]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.eth0, self.matched.guest3.eth0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.eth0, self.matched.guest3.eth0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
@@ -118,9 +118,6 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.vlan0, self.matched.guest2.vlan0)]
 

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import logging
 from lnst.Common.Parameters import (
     Param,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -121,8 +124,8 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.vlan0, self.matched.guest2.vlan0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.vlan0, self.matched.guest2.vlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.vlan0, self.matched.guest2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
@@ -7,6 +7,7 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
@@ -61,14 +62,13 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
         guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=self.params.vlan_id)
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = [guest1.vlan0, guest2.vlan0]
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.3/24")
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")
         for guest in [guest1, guest2]:
-            guest.vlan0.ip_add(next(ipv4_addr))
-            guest.vlan0.ip_add(next(ipv6_addr))
+            config.configure_and_track_ip(guest.vlan0, next(ipv4_addr))
+            config.configure_and_track_ip(guest.vlan0, next(ipv6_addr))
 
         for host in [host1, host2]:
             for dev in [host.eth0, host.tap0, host.br0]:
@@ -82,11 +82,11 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
                 self.params.perf_tool_cpu)
             self.params.perf_tool_cpu = None
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         host1, host2 = self.matched.host1, self.matched.host2
         desc = super().generate_test_wide_description(config)
         desc += [
@@ -94,20 +94,20 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.vlan_id = {}".format(
                     dev.host.hostid, dev.name, dev.vlan_id
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.realdev = {}".format(
                     dev.host.hostid, dev.name,
                     '.'.join([dev.host.hostid, dev.realdev.name])
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.ports = {}".format(
@@ -119,8 +119,6 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -98,8 +101,8 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host2.vlan0, self.matched.guest1.vlan0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host2.vlan0, self.matched.guest1.vlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host2.vlan0, self.matched.guest1.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
@@ -95,9 +95,6 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host2.vlan0, self.matched.guest1.vlan0)]
 

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
@@ -1,7 +1,10 @@
+from collections.abc import Collection
 import logging
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -98,8 +101,8 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.guest2.eth0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.eth0, self.matched.guest2.eth0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.eth0, self.matched.guest2.eth0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
@@ -2,6 +2,7 @@ import logging
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
@@ -52,14 +53,13 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         guest1.eth0.down()
         guest2.eth0.down()
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = [guest1.eth0, guest2.eth0]
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.3/24")
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")
         for guest in [guest1, guest2]:
-            guest.eth0.ip_add(next(ipv4_addr))
-            guest.eth0.ip_add(next(ipv6_addr))
+            config.configure_and_track_ip(guest.eth0, next(ipv4_addr))
+            config.configure_and_track_ip(guest.eth0, next(ipv6_addr))
 
         for host in [host1, host2]:
             for dev in [host.eth0, host.tap0, host.br0]:
@@ -72,11 +72,11 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
                 self.params.perf_tool_cpu)
             self.params.perf_tool_cpu = None
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         host1, host2 = self.matched.host1, self.matched.host2
         desc = super().generate_test_wide_description(config)
         desc += [
@@ -84,7 +84,7 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.ports = {}".format(
@@ -96,8 +96,6 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
@@ -95,9 +95,6 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.guest2.eth0)]
 

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -92,8 +95,8 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.host2.vlan0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.eth0, self.matched.host2.vlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.eth0, self.matched.host2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
@@ -1,6 +1,7 @@
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
@@ -49,24 +50,23 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
 
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = [guest1.eth0, host2.vlan0]
+        config = super().test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.2/24")
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")
         for i, dev in enumerate([host2.vlan0, guest1.eth0]):
-            dev.ip_add(next(ipv4_addr))
-            dev.ip_add(next(ipv6_addr))
+            config.configure_and_track_ip(dev, next(ipv4_addr))
+            config.configure_and_track_ip(dev, next(ipv6_addr))
 
         for dev in [host1.eth0, host1.tap0, host1.br0, host2.eth0,
             host2.vlan0, guest1.eth0]:
             dev.up()
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         host1, host2 = self.matched.host1, self.matched.host2
         desc = super().generate_test_wide_description(config)
         desc += [
@@ -74,7 +74,7 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "Configured {}.{}.vlan_id = {}".format(
                 host2.hostid, host2.vlan0.name, host2.vlan0.vlan_id
@@ -90,8 +90,6 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
@@ -89,9 +89,6 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.guest1.eth0, self.matched.host2.vlan0)]
 

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 import logging
 from itertools import product
 from lnst.Common.Parameters import (
@@ -9,6 +10,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -159,8 +162,8 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
                 for comb in dev_combinations
             ]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.guest1.eth0, self.matched.guest3.eth0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.guest1.eth0, self.matched.guest3.eth0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
@@ -141,9 +141,6 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         guest1, guest2, guest3, guest4 = (self.matched.guest1,
             self.matched.guest2, self.matched.guest3, self.matched.guest4)

--- a/lnst/Recipes/ENRT/VlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverBondRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     IntParam,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -216,18 +219,15 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
                 PingEndpoints(host1.vlan1, host2.vlan1),
                 PingEndpoints(host1.vlan2, host2.vlan2)]
 
-    def generate_perf_endpoints(self, config):
+
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the VLAN tunnel endpoints with
         VLAN id from parameter vlan_ids[0] (by default: 10):
 
         host1.vlan0 and host2.vlan0
-
-        Returned as::
-
-            [(self.matched.host1.vlan0, self.matched.host2.vlan0)]
         """
-        return [(self.matched.host1.vlan0, self.matched.host2.vlan0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.vlan0, self.matched.host2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverBondRecipe.py
@@ -199,9 +199,6 @@ class VlansOverBondRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         """
         The ping endpoints for this recipe are the matching VLAN tunnel

--- a/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import (
     Param,
     IntParam,
@@ -7,6 +8,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -140,8 +143,8 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
                 PingEndpoints(host1.vlan1, host2.vlan1),
                 PingEndpoints(host1.vlan2, host2.vlan2)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.vlan0, self.matched.host2.vlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.vlan0, self.matched.host2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
@@ -133,9 +133,6 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
 

--- a/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
@@ -8,6 +8,7 @@ from lnst.Common.Parameters import (
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -19,7 +20,7 @@ from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.Devices import VlanDevice
 from lnst.Devices.VlanDevice import VlanDevice as Vlan
 from lnst.Devices import TeamDevice
-from lnst.Recipes.ENRT.PingMixins import VlanPingEvaluatorMixin
+
 
 class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
     CommonHWSubConfigMixin, OffloadSubConfigMixin,
@@ -67,12 +68,8 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan1_id)
         host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan2_id)
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = []
-        for host in [host1, host2]:
-            configuration.test_wide_devices.extend([host.vlan0,
-                host.vlan1, host.vlan2])
-        configuration.test_wide_devices.append(host1.team0)
+        config = super().test_wide_configuration()
+        config.track_device(host1.team0)
 
         vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
         vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6)
@@ -82,23 +79,23 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         vlan2_ipv6_addr = interface_addresses(self.params.vlan2_ipv6)
 
         for host in [host1, host2]:
-            host.vlan0.ip_add(next(vlan0_ipv4_addr))
-            host.vlan1.ip_add(next(vlan1_ipv4_addr))
-            host.vlan2.ip_add(next(vlan2_ipv4_addr))
-            host.vlan0.ip_add(next(vlan0_ipv6_addr))
-            host.vlan1.ip_add(next(vlan1_ipv6_addr))
-            host.vlan2.ip_add(next(vlan2_ipv6_addr))
+            config.configure_and_track_ip(host.vlan0, next(vlan0_ipv4_addr))
+            config.configure_and_track_ip(host.vlan1, next(vlan1_ipv4_addr))
+            config.configure_and_track_ip(host.vlan2, next(vlan2_ipv4_addr))
+            config.configure_and_track_ip(host.vlan0, next(vlan0_ipv6_addr))
+            config.configure_and_track_ip(host.vlan1, next(vlan1_ipv6_addr))
+            config.configure_and_track_ip(host.vlan2, next(vlan2_ipv6_addr))
 
         for dev in [host1.eth0, host1.eth1, host1.team0, host1.vlan0,
             host1.vlan1, host1.vlan2, host2.eth0, host2.vlan0, host2.vlan1,
             host2.vlan2]:
             dev.up()
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         host1, host2 = self.matched.host1, self.matched.host2
         desc = super().generate_test_wide_description(config)
         desc += [
@@ -106,14 +103,14 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices if isinstance(dev,
+                for dev in config.configured_devices if isinstance(dev,
                     Vlan)
             ]),
             "\n".join([
                 "Configured {}.{}.vlan_id = {}".format(
                     dev.host.hostid, dev.name, dev.vlan_id
                 )
-                for dev in config.test_wide_devices if isinstance(dev,
+                for dev in config.configured_devices if isinstance(dev,
                     Vlan)
             ]),
             "\n".join([
@@ -121,7 +118,7 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
                     dev.host.hostid, dev.name,
                     '.'.join([dev.host.hostid, dev.realdev.name])
                 )
-                for dev in config.test_wide_devices if isinstance(dev,
+                for dev in config.configured_devices if isinstance(dev,
                     Vlan)
             ]),
             "Configured {}.{}.slaves = {}".format(
@@ -137,8 +134,6 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
         return desc
 
     def test_wide_deconfiguration(self, config):
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/VlansRecipe.py
+++ b/lnst/Recipes/ENRT/VlansRecipe.py
@@ -145,10 +145,6 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        ""  # overriding the parent docstring
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         """
         The ping endpoints for this recipe are the matching VLAN tunnel

--- a/lnst/Recipes/ENRT/VlansRecipe.py
+++ b/lnst/Recipes/ENRT/VlansRecipe.py
@@ -2,6 +2,7 @@ from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6Networ
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin)
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -92,11 +93,7 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         host2.vlan1 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan1_id)
         host2.vlan2 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan2_id)
 
-        configuration = super().test_wide_configuration()
-        configuration.test_wide_devices = []
-        for host in [host1, host2]:
-            configuration.test_wide_devices.extend([host.vlan0, host.vlan1,
-                host.vlan2])
+        config = super().test_wide_configuration()
 
         vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
         vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6)
@@ -106,53 +103,50 @@ class VlansRecipe(VlanPingEvaluatorMixin,
         vlan2_ipv6_addr = interface_addresses(self.params.vlan2_ipv6)
 
         for host in [host1, host2]:
-            host.vlan0.ip_add(next(vlan0_ipv4_addr))
-            host.vlan1.ip_add(next(vlan1_ipv4_addr))
-            host.vlan2.ip_add(next(vlan2_ipv4_addr))
-            host.vlan0.ip_add(next(vlan0_ipv6_addr))
-            host.vlan1.ip_add(next(vlan1_ipv6_addr))
-            host.vlan2.ip_add(next(vlan2_ipv6_addr))
+            config.configure_and_track_ip(host.vlan0, next(vlan0_ipv4_addr))
+            config.configure_and_track_ip(host.vlan1, next(vlan1_ipv4_addr))
+            config.configure_and_track_ip(host.vlan2, next(vlan2_ipv4_addr))
+            config.configure_and_track_ip(host.vlan0, next(vlan0_ipv6_addr))
+            config.configure_and_track_ip(host.vlan1, next(vlan1_ipv6_addr))
+            config.configure_and_track_ip(host.vlan2, next(vlan2_ipv6_addr))
             for dev in [host.eth0, host.vlan0, host.vlan1, host.vlan2]:
                 dev.up_and_wait()
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
+        self.wait_tentative_ips(config.configured_devices)
 
-        return configuration
+        return config
 
-    def generate_test_wide_description(self, config):
+    def generate_test_wide_description(self, config: EnrtConfiguration):
         """
         Test wide description is extended with the configured VLAN tunnels
         and their IP addresses
         """
-        host1, host2 = self.matched.host1, self.matched.host2
         desc = super().generate_test_wide_description(config)
         desc += [
             "\n".join([
                 "Configured {}.{}.ips = {}".format(
                     dev.host.hostid, dev.name, dev.ips
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.vlan_id = {}".format(
                     dev.host.hostid, dev.name, dev.vlan_id
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ]),
             "\n".join([
                 "Configured {}.{}.realdev = {}".format(
                     dev.host.hostid, dev.name,
                     '.'.join([dev.host.hostid, dev.realdev.name])
                 )
-                for dev in config.test_wide_devices
+                for dev in config.configured_devices
             ])
         ]
         return desc
 
     def test_wide_deconfiguration(self, config):
         ""  # overriding the parent docstring
-        del config.test_wide_devices
-
         super().test_wide_deconfiguration(config)
 
     def generate_ping_endpoints(self, config):

--- a/lnst/Recipes/ENRT/VlansRecipe.py
+++ b/lnst/Recipes/ENRT/VlansRecipe.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
 from lnst.Common.Parameters import Param, IntParam, IPv4NetworkParam, IPv6NetworkParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -162,18 +165,14 @@ class VlansRecipe(VlanPingEvaluatorMixin,
                 PingEndpoints(host1.vlan1, host2.vlan1),
                 PingEndpoints(host1.vlan2, host2.vlan2)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the VLAN tunnel endpoints with
         VLAN id from parameter vlan0_id (by default: 10):
 
         host1.vlan0 and host2.vlan0
-
-        Returned as::
-
-            [(self.matched.host1.vlan0, self.matched.host2.vlan0)]
         """
-        return [(self.matched.host1.vlan0, self.matched.host2.vlan0)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.vlan0, self.matched.host2.vlan0))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
@@ -7,7 +7,7 @@ from lnst.Common.IpAddress import (
     Ip6Address,
     interface_addresses,
 )
-from lnst.Devices import VxlanDevice, LoopbackDevice
+from lnst.Devices import VxlanDevice, LoopbackDevice, RemoteDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Common.Parameters import (
@@ -18,6 +18,7 @@ from lnst.Common.Parameters import (
     IPv6NetworkParam,
 )
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -86,7 +87,7 @@ class VxlanGpeTunnelRecipe(
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
@@ -96,16 +97,18 @@ class VxlanGpeTunnelRecipe(
         ipv6_addr = interface_addresses(self.params.net_ipv6)
         for device in [host1.eth0, host2.eth0]:
             if self.params.carrier_ipversion == "ipv4":
-                device.ip_add(next(ipv4_addr))
+                config.configure_and_track_ip(device, next(ipv4_addr))
             else:
-                device.ip_add(next(ipv6_addr))
+                config.configure_and_track_ip(device, next(ipv6_addr))
             device.up()
-            configuration.test_wide_devices.append(device)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-        configuration.tunnel_endpoints = (host1.eth0, host2.eth0)
+        return (host1.eth0, host2.eth0)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The Vxlan tunnel devices are created with external flag specified
         so that the encapsulation can be defined externally by routes.
@@ -119,16 +122,12 @@ class VxlanGpeTunnelRecipe(
         the loopback devices of the matched hosts.
 
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        if self.params.carrier_ipversion == "ipv4":
-            ip_filter = {"family": AF_INET}
-        else:
-            ip_filter = {"family": AF_INET6, "is_link_local": False}
 
-        endpoint1_ip = endpoint1.ips_filter(**ip_filter)[0]
-        endpoint2_ip = endpoint2.ips_filter(**ip_filter)[0]
+        endpoint1_ip = config.ips_for_device(endpoint1)[0]
+        endpoint2_ip = config.ips_for_device(endpoint2)[0]
 
         m1_dummy_ip = ipaddress("172.16.10.1/32")
         m1_dummy_ip6 = ipaddress("fc00:a::1/128")
@@ -141,14 +140,14 @@ class VxlanGpeTunnelRecipe(
         m2.lo = LoopbackDevice()
 
         # A
-        m1.lo.ip_add(m1_dummy_ip)
-        m1.lo.ip_add(m1_dummy_ip6)
+        config.configure_and_track_ip(m1.lo, m1_dummy_ip)
+        config.configure_and_track_ip(m1.lo, m1_dummy_ip6)
         m1.vxlan_tunnel.mtu = 1400
         m1.vxlan_tunnel.up()
 
         # B
-        m2.lo.ip_add(m2_dummy_ip)
-        m2.lo.ip_add(m2_dummy_ip6)
+        config.configure_and_track_ip(m2.lo, m2_dummy_ip)
+        config.configure_and_track_ip(m2.lo, m2_dummy_ip6)
         m2.vxlan_tunnel.mtu = 1400
         m2.vxlan_tunnel.up()
 
@@ -175,8 +174,7 @@ class VxlanGpeTunnelRecipe(
             )
         )
 
-        configuration.tunnel_devices.extend([m1.vxlan_tunnel, m2.vxlan_tunnel])
-        self.wait_tentative_ips([m1.lo, m2.lo])
+        return (m1.vxlan_tunnel, m2.vxlan_tunnel)
 
     def generate_ping_endpoints(self, config):
         """
@@ -229,7 +227,7 @@ class VxlanGpeTunnelRecipe(
 
         return pa_config
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration):
         """
         The perf endpoints for this recipe are the loopback devices that
         are configured with IP addresses of the tunnelled networks.

--- a/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanGpeTunnelRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
@@ -19,6 +20,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -227,16 +230,12 @@ class VxlanGpeTunnelRecipe(
 
         return pa_config
 
-    def generate_perf_endpoints(self, config: EnrtConfiguration):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the loopback devices that
         are configured with IP addresses of the tunnelled networks.
-
-        Returned as::
-
-            [(self.matched.host1.lo, self.matched.host2.lo)]
         """
-        return [(self.matched.host1.lo, self.matched.host2.lo)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.lo, self.matched.host2.lo))]
 
     @property
     def offload_nics(self):

--- a/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
@@ -7,7 +7,7 @@ from lnst.Common.IpAddress import (
     Ip6Address,
     interface_addresses,
 )
-from lnst.Devices import VxlanDevice, LoopbackDevice
+from lnst.Devices import VxlanDevice, LoopbackDevice, RemoteDevice
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.RecipeCommon.PacketAssert import PacketAssertConf
 from lnst.Common.Parameters import (
@@ -18,6 +18,7 @@ from lnst.Common.Parameters import (
     IPv6NetworkParam,
 )
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -86,7 +87,7 @@ class VxlanLwtTunnelRecipe(
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def configure_underlying_network(self, configuration):
+    def configure_underlying_network(self, config: EnrtConfiguration) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The underlying network for the tunnel consists of the Ethernet
         devices on the matched hosts.
@@ -96,16 +97,18 @@ class VxlanLwtTunnelRecipe(
         ipv6_addr = interface_addresses(self.params.net_ipv6)
         for device in [host1.eth0, host2.eth0]:
             if self.params.carrier_ipversion == "ipv4":
-                device.ip_add(next(ipv4_addr))
+                config.configure_and_track_ip(device, next(ipv4_addr))
             else:
-                device.ip_add(next(ipv6_addr))
+                config.configure_and_track_ip(device, next(ipv6_addr))
             device.up()
-            configuration.test_wide_devices.append(device)
 
-        self.wait_tentative_ips(configuration.test_wide_devices)
-        configuration.tunnel_endpoints = (host1.eth0, host2.eth0)
+        return (host1.eth0, host2.eth0)
 
-    def create_tunnel(self, configuration):
+    def create_tunnel(
+        self,
+        config: EnrtConfiguration,
+        tunnel_endpoints: tuple[RemoteDevice, RemoteDevice],
+    ) -> tuple[RemoteDevice, RemoteDevice]:
         """
         The Vxlan tunnel devices are created with external flag specified
         so that the encapsulation can be defined externally by routes.
@@ -116,16 +119,12 @@ class VxlanLwtTunnelRecipe(
         IPv4 and IPv6 addresses of the tunneled networks are configured on
         the loopback devices of the matched hosts.
         """
-        endpoint1, endpoint2 = configuration.tunnel_endpoints
+        endpoint1, endpoint2 = tunnel_endpoints
         m1 = endpoint1.netns
         m2 = endpoint2.netns
-        if self.params.carrier_ipversion == "ipv4":
-            ip_filter = {"family": AF_INET}
-        else:
-            ip_filter = {"family": AF_INET6, "is_link_local": False}
 
-        endpoint1_ip = endpoint1.ips_filter(**ip_filter)[0]
-        endpoint2_ip = endpoint2.ips_filter(**ip_filter)[0]
+        endpoint1_ip = config.ips_for_device(endpoint1)[0]
+        endpoint2_ip = config.ips_for_device(endpoint2)[0]
 
         m1_dummy_ip = ipaddress("172.16.10.1/32")
         m1_dummy_ip6 = ipaddress("fc00:a::1/128")
@@ -138,14 +137,14 @@ class VxlanLwtTunnelRecipe(
         m2.lo = LoopbackDevice()
 
         # A
-        m1.lo.ip_add(m1_dummy_ip)
-        m1.lo.ip_add(m1_dummy_ip6)
+        config.configure_and_track_ip(m1.lo, m1_dummy_ip)
+        config.configure_and_track_ip(m1.lo, m1_dummy_ip6)
         m1.vxlan_tunnel.mtu = 1400
         m1.vxlan_tunnel.up()
 
         # B
-        m2.lo.ip_add(m2_dummy_ip)
-        m2.lo.ip_add(m2_dummy_ip6)
+        config.configure_and_track_ip(m2.lo, m2_dummy_ip)
+        config.configure_and_track_ip(m2.lo, m2_dummy_ip6)
         m2.vxlan_tunnel.mtu = 1400
         m2.vxlan_tunnel.up()
 
@@ -172,8 +171,7 @@ class VxlanLwtTunnelRecipe(
             )
         )
 
-        configuration.tunnel_devices.extend([m1.vxlan_tunnel, m2.vxlan_tunnel])
-        self.wait_tentative_ips([m1.lo, m2.lo])
+        return (m1.vxlan_tunnel, m2.vxlan_tunnel)
 
     def generate_ping_endpoints(self, config):
         """
@@ -186,7 +184,7 @@ class VxlanLwtTunnelRecipe(
         """
         return [PingEndpoints(self.matched.host1.lo, self.matched.host2.lo)]
 
-    def generate_perf_endpoints(self, config):
+    def generate_perf_endpoints(self, config: EnrtConfiguration):
         """
         The perf endpoints for this recipe are the loopback devices that
         are configured with IP addresses of the tunnelled networks.

--- a/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanLwtTunnelRecipe.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.IpAddress import (
     AF_INET,
@@ -19,6 +20,8 @@ from lnst.Common.Parameters import (
 )
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
     OffloadSubConfigMixin,
 )
@@ -184,16 +187,12 @@ class VxlanLwtTunnelRecipe(
         """
         return [PingEndpoints(self.matched.host1.lo, self.matched.host2.lo)]
 
-    def generate_perf_endpoints(self, config: EnrtConfiguration):
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
         """
         The perf endpoints for this recipe are the loopback devices that
         are configured with IP addresses of the tunnelled networks.
-
-        Returned as::
-
-            [(self.matched.host1.lo, self.matched.host2.lo)]
         """
-        return [(self.matched.host1.lo, self.matched.host2.lo)]
+        return [ip_endpoint_pairs(config, (self.matched.host1.lo, self.matched.host2.lo))]
 
     def get_packet_assert_config(self, ping_config):
         """

--- a/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
@@ -96,9 +96,6 @@ class VxlanMulticastRecipe(CommonHWSubConfigMixin, VirtualEnrtRecipe):
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)

--- a/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
@@ -1,8 +1,11 @@
+from collections.abc import Collection
 from itertools import permutations
 from socket import AF_INET
 from lnst.Common.IpAddress import ipaddress, interface_addresses
 from lnst.Common.Parameters import IpParam, IPv4NetworkParam
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.VirtualEnrtRecipe import VirtualEnrtRecipe
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -104,10 +107,8 @@ class VxlanMulticastRecipe(CommonHWSubConfigMixin, VirtualEnrtRecipe):
         return [ PingEndpoints(dev_permutation[0], dev_permutation[1]) for
                 dev_permutation in dev_permutations ]
 
-    def generate_perf_endpoints(self, config):
-        host1, host2, guest1 = (self.matched.host1, self.matched.host2,
-            self.matched.guest1)
-        return [(self.matched.host1.vxlan0, self.matched.host2.vxlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.vxlan0, self.matched.host2.vxlan0))]
 
     @property
     def mtu_hw_config_dev_list(self):

--- a/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
@@ -49,14 +49,12 @@ class VxlanMulticastRecipe(CommonHWSubConfigMixin, VirtualEnrtRecipe):
         config = super().test_wide_configuration()
 
         for i, (machine, dev) in enumerate([(host1, host1.br0),
-            (guest1, guest1.eth0), (host2, host2.eth0)]):
+            (guest1, guest1.eth0), (host2, host2.eth0)], 1):
             config.configure_and_track_ip(dev, next(ipv4_addr))
             dev.ip_add(next(ipv4_addr))
             machine.vxlan0.realdev = dev
-            config.configure_and_track_ip(machine.vxlan0, ipaddress(vxlan_net_addr + "." + str(i+1)
-                + "/24"))
-            config.configure_and_track_ip(machine.vxlan0, ipaddress(vxlan_net_addr6 + "::" +
-                str(i+1) + "/64"))
+            config.configure_and_track_ip(machine.vxlan0, ipaddress(f"{vxlan_net_addr}.{i}/24"))
+            config.configure_and_track_ip(machine.vxlan0, ipaddress(f"{vxlan_net_addr6}::{i}/64"))
 
         for dev in [host1.eth0, host2.eth0, guest1.eth0, host1.tap0,
                     host1.br0, host1.vxlan0, host2.vxlan0, guest1.vxlan0]:

--- a/lnst/Recipes/ENRT/VxlanOvsTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanOvsTunnelRecipe.py
@@ -104,13 +104,13 @@ class VxlanOvsTunnelRecipe(
         m1 = endpoint1.netns
         m2 = endpoint2.netns
 
-        for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)]):
+        for i, (host, endpoint) in enumerate([(m1, endpoint2), (m2, endpoint1)], 1):
             host.br0 = OvsBridgeDevice()
             host.int0 = host.br0.port_add(
                 interface_options={"type": "internal", "ofport_request": 5}
             )
-            config.configure_and_track_ip(host.int0, ipaddress("192.168.200." + str(i + 1) + "/24"))
-            config.configure_and_track_ip(host.int0, ipaddress("fc00::" + str(i + 1) + "/64"))
+            config.configure_and_track_ip(host.int0, ipaddress(f"192.168.200.{i}/24"))
+            config.configure_and_track_ip(host.int0, ipaddress(f"fc00::{i}/64"))
 
             remote_ip = config.ips_for_device(endpoint)[0]
             host.br0.tunnel_add(

--- a/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
@@ -88,9 +88,6 @@ class VxlanRemoteRecipe(
         ]
         return desc
 
-    def test_wide_deconfiguration(self, config):
-        super().test_wide_deconfiguration(config)
-
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host1.vxlan0, self.matched.host2.vxlan0)]
 

--- a/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
 from lnst.Common.IpAddress import ipaddress, interface_addresses
 from lnst.Common.Parameters import IPv4NetworkParam
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
@@ -91,8 +94,8 @@ class VxlanRemoteRecipe(
     def generate_ping_endpoints(self, config):
         return [PingEndpoints(self.matched.host1.vxlan0, self.matched.host2.vxlan0)]
 
-    def generate_perf_endpoints(self, config):
-        return [(self.matched.host1.vxlan0, self.matched.host2.vxlan0)]
+    def generate_perf_endpoints(self, config: EnrtConfiguration) -> list[Collection[EndpointPair[IPEndpoint]]]:
+        return [ip_endpoint_pairs(config, (self.matched.host1.vxlan0, self.matched.host2.vxlan0))]
 
     @property
     def mtu_hw_config_dev_list(self):

--- a/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
@@ -44,12 +44,10 @@ class VxlanRemoteRecipe(
         config.configure_and_track_ip(host2.eth0, host2_ip)
         host2.vxlan0 = VxlanDevice(vxlan_id='1', remote=host1_ip)
 
-        for i, host in enumerate([host1, host2]):
+        for i, host in enumerate([host1, host2], 1):
             host.vxlan0.realdev = host.eth0
-            config.configure_and_track_ip(host.vxlan0, ipaddress(vxlan_net_addr + "." + str(i+1) +
-                "/24"))
-            config.configure_and_track_ip(host.vxlan0, ipaddress(vxlan_net_addr6 + "::" + str(i+1)
-                + "/64"))
+            config.configure_and_track_ip(host.vxlan0, ipaddress(f"{vxlan_net_addr}.{i}/24"))
+            config.configure_and_track_ip(host.vxlan0, ipaddress(f"{vxlan_net_addr6}::{i}/64"))
 
         for host in [host1, host2]:
             host.eth0.up_and_wait()

--- a/lnst/Recipes/ENRT/helpers.py
+++ b/lnst/Recipes/ENRT/helpers.py
@@ -1,0 +1,31 @@
+from collections.abc import Collection
+import itertools
+
+from lnst.Common.IpAddress import Ip4Address, Ip6Address
+from lnst.Devices import RemoteDevice
+from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
+
+
+def ip_endpoint_pairs(
+    config: EnrtConfiguration, *device_pairs: tuple[RemoteDevice, RemoteDevice]
+) -> Collection[EndpointPair[IPEndpoint]]:
+    """Helper function for use in generate_perf_endpoints method.
+
+    Generates a sequential endpoint pair list for each input device pair.
+    """
+    endpoint_pairs = []
+    for dev1, dev2 in device_pairs:
+        for ip_type in [Ip4Address, Ip6Address]:
+            dev1_ips = [ip for ip in config.ips_for_device(dev1) if isinstance(ip, ip_type)]
+            dev2_ips = [ip for ip in config.ips_for_device(dev2) if isinstance(ip, ip_type)]
+
+            for ip1, ip2 in itertools.product(dev1_ips, dev2_ips):
+                endpoint_pairs.append(
+                    EndpointPair(
+                        IPEndpoint(dev1, ip1),
+                        IPEndpoint(dev2, ip2),
+                    )
+                )
+
+    return endpoint_pairs


### PR DESCRIPTION
### Description
Make `generate_perf_endpoints` return resolved IP addresses instead of just devices.

### Tests
`kernel-full` test group in J:8289303

### Reviews
@LNST-project/lnst-developers 

Closes: #210 