### PR TITLE
Add CPU pinning to TrafficControlRecipe

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
@@ -24,16 +24,7 @@ class TcRunInstance:
         self._num_rules = num_rules
         self._instance_id = instance_id
         self._batchfile_path: PathLike = None
-        self._instance_job: Job = None
         self.validate()
-
-    @property
-    def instance_job(self):
-        return self._instance_job
-
-    @instance_job.setter
-    def instance_job(self, job: Job):
-        self._instance_job = job
 
     @property
     def batchfile_path(self):

--- a/lnst/Recipes/ENRT/TrafficControlRecipe.py
+++ b/lnst/Recipes/ENRT/TrafficControlRecipe.py
@@ -3,7 +3,7 @@ import time
 from contextlib import contextmanager
 
 from lnst.Common.LnstError import LnstError
-from lnst.Common.Parameters import StrParam, IntParam, ChoiceParam
+from lnst.Common.Parameters import ListParam, StrParam, IntParam, ChoiceParam
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.Namespace import Namespace
 from lnst.RecipeCommon import BaseResultEvaluator
@@ -31,6 +31,8 @@ class TrafficControlRecipe(PerfRecipe):
 
     num_rules = IntParam(default=1000)
     parallel_instances = IntParam(default=4)
+    cpu_bind = ListParam(type=IntParam())
+    cpu_bind_policy = ChoiceParam(type=StrParam, choices={"all", "round-robin"}, default="round-robin")
 
     steering_mode = ChoiceParam(
         type=StrParam,
@@ -56,9 +58,11 @@ class TrafficControlRecipe(PerfRecipe):
             hosts=[host],
         )
         measurement = TcRunMeasurement(
-            host.eth0,
-            self.params.parallel_instances,
-            self.params.num_rules,
+            device=host.eth0,
+            num_instances=self.params.parallel_instances,
+            rules_per_instance=self.params.num_rules,
+            cpu_bind=self.params.cpu_bind,
+            cpu_bind_policy=self.params.cpu_bind_policy,
         )
         config = TcRecipeConfiguration(
            measurements=[cpu_measurement, measurement],

--- a/lnst/Recipes/ENRT/TrafficControlRecipe.py
+++ b/lnst/Recipes/ENRT/TrafficControlRecipe.py
@@ -8,6 +8,7 @@ from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.Namespace import Namespace
 from lnst.RecipeCommon import BaseResultEvaluator
 from lnst.RecipeCommon.Perf.Evaluators.MaxTimeTakenEvaluator import MaxTimeTakenEvaluator
+from lnst.RecipeCommon.Perf.Measurements import StatCPUMeasurement
 from lnst.RecipeCommon.Perf.Measurements.TcRunMeasurement import TcRunMeasurement
 from lnst.RecipeCommon.Perf.Recipe import RecipeConf, Recipe as PerfRecipe, RecipeResults
 
@@ -51,13 +52,16 @@ class TrafficControlRecipe(PerfRecipe):
 
     def test_wide_configuration(self) -> TcRecipeConfiguration:
         host = self.matched.host1
+        cpu_measurement = StatCPUMeasurement(
+            hosts=[host],
+        )
         measurement = TcRunMeasurement(
             host.eth0,
             self.params.parallel_instances,
             self.params.num_rules,
         )
         config = TcRecipeConfiguration(
-           measurements=[measurement],
+           measurements=[cpu_measurement, measurement],
            iterations=1,
        )
         config.register_evaluators(measurement, self.tc_run_evaluators)

--- a/lnst/Tests/TrafficControl.py
+++ b/lnst/Tests/TrafficControl.py
@@ -8,7 +8,7 @@ from lnst.Tests.BaseTestModule import BaseTestModule
 
 
 class TrafficControlRunner(BaseTestModule):
-    batchfiles = ListParam(type=StrParam(), required=True)
+    batchfiles = ListParam(type=StrParam(), mandatory=True)
 
     def run(self) -> bool:
         self._res_data = {}

--- a/lnst/Tests/TrafficControl.py
+++ b/lnst/Tests/TrafficControl.py
@@ -1,14 +1,18 @@
+import itertools
 import logging
 import shutil
 import asyncio
 import time
+from typing import Iterator, Optional
 
-from lnst.Common.Parameters import StrParam, ListParam
+from lnst.Common.Parameters import ChoiceParam, IntParam, StrParam, ListParam
 from lnst.Tests.BaseTestModule import BaseTestModule
 
 
 class TrafficControlRunner(BaseTestModule):
     batchfiles = ListParam(type=StrParam(), mandatory=True)
+    cpu_bind = ListParam(type=IntParam())
+    cpu_bind_policy = ChoiceParam(type=StrParam, choices={"all", "round-robin"}, default="round-robin")
 
     def run(self) -> bool:
         self._res_data = {}
@@ -31,18 +35,35 @@ class TrafficControlRunner(BaseTestModule):
 
     async def run_instances(self) -> list[dict]:
         tc_exec = shutil.which("tc")
+        cpu_bind_gen = self._get_cpu_bind_generator()
+
         instances = [
-            self.run_tc(tc_exec, bf)
+            self.run_tc(tc_exec, bf, cpu_bind=next(cpu_bind_gen))
             for bf in self.params.batchfiles
         ]
         results = await asyncio.gather(*instances)
         return results
 
-    async def run_tc(self, tc_exec: str, batchfile: str) -> dict[str]:
+    async def run_tc(
+        self,
+        tc_exec: str,
+        batchfile: str,
+        cpu_bind: Optional[list[int]] = None,
+    ) -> dict[str]:
+        args = [tc_exec, "-b", batchfile]
+        if cpu_bind is not None:
+            args = [
+                "/usr/bin/taskset",
+                "-c",
+                ",".join(map(str, cpu_bind)),
+                *args,
+            ]
+
         start_timestamp = time.time()
         start_time = time.perf_counter()
+        logging.debug(f"Running TC: {args}")
         proc = await asyncio.create_subprocess_exec(
-            tc_exec, "-b", batchfile,
+            *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -57,3 +78,13 @@ class TrafficControlRunner(BaseTestModule):
             stderr=stderr.decode(),
             batchfile=batchfile,
         )
+
+    def _get_cpu_bind_generator(self) -> Iterator[Optional[list[int]]]:
+        cpu_bind = self.params.get("cpu_bind")
+        if not cpu_bind:
+            return itertools.repeat(None)
+
+        policy = self.params.cpu_bind_policy
+        if policy == "round-robin":
+            return ([cpu] for cpu in itertools.cycle(cpu_bind))
+        return itertools.repeat(cpu_bind)


### PR DESCRIPTION
### Description
Previously, the `TrafficControlRecipe` didn't use `StatCPUMeasurement` and didn't allow users to pin CPUs. This now works even with a CPU pinning policy (similar to perf pinning).

### Tests
J:8172306

### Reviews
@jtluka @olichtne 