### PR TITLE
XDPDropRecipe: fixed missing module-wide import

### DIFF
--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -109,6 +109,7 @@ from lnst.Recipes.ENRT.TrafficControlRecipe import TrafficControlRecipe
 from lnst.Recipes.ENRT.BaseLACPRecipe import BaseLACPRecipe
 from lnst.Recipes.ENRT.DellLACPRecipe import DellLACPRecipe
 from lnst.Recipes.ENRT.SoftwareRDMARecipe import SoftwareRDMARecipe
+from lnst.Recipes.ENRT.XDPDropRecipe import XDPDropRecipe
 
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
 from lnst.Recipes.ENRT.BaseTunnelRecipe import BaseTunnelRecipe


### PR DESCRIPTION
### Description
During commits cleanup I've done for https://github.com/LNST-project/lnst/pull/310 I somehow removed module-wide `XDPDropRecipe` import. So our downstream projects that depend on this way of imports are unable to work with the new recipe.

  
### Tests
not really needed. But test job that includes those changes doesn't raise an import exception (`J:8254315`).
Test job without changes `J:8253862`

