### PR TITLE
Remove driver param defaults

### DIFF
--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -142,7 +142,7 @@ class BaseEnrtRecipe(
     :type perf_evaluation_strategy: :any:`StrParam` (default "all")
     """
 
-    driver = StrParam(default="ixgbe")
+    driver = StrParam()
 
     #common test parameters
     ip_versions = Param(default=("ipv4", "ipv6"))

--- a/lnst/Recipes/ENRT/PingFloodRecipe.py
+++ b/lnst/Recipes/ENRT/PingFloodRecipe.py
@@ -4,7 +4,7 @@ from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.RecipeCommon.Ping.Recipe import PingConf, PingTestAndEvaluate
 
 class PingFloodRecipe(PingTestAndEvaluate):
-    driver = StrParam(default='ixgbe')
+    driver = StrParam()
     host1 = HostReq()
     host1.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))
 


### PR DESCRIPTION
### Description
This allows us to leave out the driver and make mapper match NICs with any driver param.

Keeping driver default in `TrafficControlRecipe` makes sense, because not every NIC supports steering.

### Tests
Not tested.

### Reviews
@LNST-project/lnst-developers 