### PR TITLE
Format run exception as its own result

### DIFF
--- a/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
+++ b/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
@@ -94,11 +94,14 @@ class JsonRunSummaryFormatter(RunSummaryFormatter):
                 "measurement_type": result.measurement_type,
                 "data": measurement_data,
             }
-        elif isinstance(result, Result) and result.data is None:
-            return ret | {
-                "type": "unknown",
-                "description": result.description,
-            }
+        elif isinstance(result, Result):
+            if result.data is None:
+                return ret | {
+                    "type": "unknown",
+                    "description": result.description,
+                }
+            else:
+                logging.warning(f"unhandled recipe result type: {repr(result)} with data of type {type(result.data)}")
         else:
             logging.warning(f"unhandled recipe result type: {repr(result)}")
             return None

--- a/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
+++ b/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
@@ -13,14 +13,22 @@ class JsonRunSummaryFormatter(RunSummaryFormatter):
         self.pretty = pretty
 
     def format_run(self, run: RecipeRun) -> str:
-        measurement_results = [
+        recipe_results = [
             transformed
             for result in run.results
             if (transformed := self._transform_result(result)) is not None
         ]
 
+        if exc := run.exception:
+            exception_result = {
+                "result": "FAIL",
+                "type": "exception",
+                "message": str(exc),
+            }
+            recipe_results.append(exception_result)
+
         return json.dumps(
-            measurement_results,
+            recipe_results,
             indent=4 if self.pretty else None,
         )
 


### PR DESCRIPTION
### Description
We want to know from the json-formatted run results to know that an exception happened during a recipe run. One way would be to change the format of the output to something like `{"exception_happened": false, "results": [...]}`. Another option is to format the exception as its own custom result with a type `"exception"`.

I don't feel strongly about the decision I made, I think semantically they are equivallent, but this one doesn't unnecessarily indent all the other results. On top of that, why can't an exception be a result? It's not a thing that's somehow related to the whole run. It's just the reason-result that terminated it.

### Tests
Tested locally as part of an effort to use json results instead of lrcs. I however did not test this on a run with an actual exception I don't think.

### Reviews
@LNST-project/lnst-developers 