### PR TITLE
Dependencies linux

### DIFF
--- a/lnst/Common/NetUtils.py
+++ b/lnst/Common/NetUtils.py
@@ -13,7 +13,6 @@ rpazdera@redhat.com (Radek Pazdera)
 import re
 import socket
 import subprocess
-from pyroute2 import IPRoute
 
 
 def normalize_hwaddr(hwaddr):
@@ -24,6 +23,7 @@ def normalize_hwaddr(hwaddr):
 
 
 def scan_netdevs():
+    from pyroute2 import IPRoute
     scan = []
 
     with IPRoute() as ipr:

--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -12,8 +12,6 @@ olichtne@redhat.com (Ondrej Lichtner)
 """
 
 import re
-import ethtool
-import pyroute2
 import logging
 import pprint
 import time
@@ -55,6 +53,10 @@ class Device(object, metaclass=DeviceMeta):
     """
 
     def __init__(self, if_manager):
+        import ethtool
+        import pyroute2
+        global ethtool
+        global pyroute2
         self.ifindex = None
         self._nl_msg = None
         self._devlink = None

--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -16,7 +16,6 @@ import logging
 import pprint
 import time
 from abc import ABCMeta
-from pyroute2.netlink.rtnl import ifinfmsg
 from lnst.Common.Logs import log_exc_traceback
 from lnst.Common.ExecCmd import exec_cmd, ExecCmdFail
 from lnst.Common.DeviceError import DeviceError, DeviceDeleted, DeviceDisabled
@@ -25,10 +24,6 @@ from lnst.Common.DeviceError import DeviceFeatureNotSupported
 from lnst.Common.IpAddress import ipaddress, AF_INET
 from lnst.Common.HWAddress import hwaddress
 from lnst.Common.Utils import wait_for_condition
-
-from pyroute2.netlink.rtnl import RTM_NEWLINK
-from pyroute2.netlink.rtnl import RTM_NEWADDR
-from pyroute2.netlink.rtnl import RTM_DELADDR
 
 TOGGLE_STATE_TIMEOUT = 15 + 3  # as a reserve
 
@@ -57,6 +52,16 @@ class Device(object, metaclass=DeviceMeta):
         import pyroute2
         global ethtool
         global pyroute2
+
+        from pyroute2.netlink.rtnl import ifinfmsg
+        from pyroute2.netlink.rtnl import RTM_NEWLINK
+        from pyroute2.netlink.rtnl import RTM_NEWADDR
+        from pyroute2.netlink.rtnl import RTM_DELADDR
+        global ifinfmsg
+        global RTM_NEWLINK
+        global RTM_NEWADDR
+        global RTM_DELADDR
+
         self.ifindex = None
         self._nl_msg = None
         self._devlink = None

--- a/lnst/Devices/L2TPSessionDevice.py
+++ b/lnst/Devices/L2TPSessionDevice.py
@@ -10,8 +10,6 @@ __author__ = """
 jtluka@redhat.com (Jan Tluka)
 """
 
-from pyroute2.netlink import NetlinkError
-from pyroute2.netlink.generic.l2tp import L2tp
 from lnst.Common.DeviceError import DeviceError, DeviceConfigError
 from lnst.Devices.Device import Device
 
@@ -55,6 +53,11 @@ class L2TPSessionDevice(Device):
     _mandatory_opts = ["tunnel_id", "session_id", "peer_session_id"]
 
     def __init__(self, ifmanager, *args, **kwargs):
+        from pyroute2.netlink import NetlinkError
+        from pyroute2.netlink.generic.l2tp import L2tp
+        global NetlinkError
+        global L2tp
+
         self._name = None
         for i in self._mandatory_opts:
             if i not in kwargs:

--- a/lnst/RecipeCommon/L2TPManager.py
+++ b/lnst/RecipeCommon/L2TPManager.py
@@ -13,8 +13,6 @@ jtluka@redhat.com (Jan Tluka)
 """
 
 import logging
-from pyroute2.netlink import NetlinkError
-from pyroute2.netlink.generic.l2tp import L2tp
 from lnst.Common.LnstError import LnstError
 
 
@@ -84,6 +82,8 @@ class L2TPManager:
                 )
     """
     def __init__(self):
+        from pyroute2.netlink import NetlinkError
+        from pyroute2.netlink.generic.l2tp import L2tp
         self._tunnels = []
 
         try:

--- a/lnst/RecipeCommon/MPTCPManager.py
+++ b/lnst/RecipeCommon/MPTCPManager.py
@@ -1,7 +1,6 @@
 from enum import IntFlag
 from typing import Dict, List
 
-from pyroute2 import MPTCP
 from socket import AF_INET, AF_INET6
 from lnst.Common.IpAddress import ipaddress, BaseIpAddress
 
@@ -78,6 +77,8 @@ class MPTCPEndpoint:
 
 class MPTCPManager:
     def __init__(self):
+        from pyroute2 import MPTCP
+
         self._mptcp = MPTCP()
         self._endpoints = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ include = ["schema-am.rng", "install/*", "lnst-ctl.conf"]
 [tool.poetry.dependencies]
 python = "^3.9"
 lxml = "*"
-ethtool = "*"
-pyroute2 = "*"
+ethtool = {version = "*", platform = 'linux'}
+pyroute2 = {version = "*", platform = 'linux'}
 
 libvirt-python = {version = "*", optional = true }
 podman = {version = "*", optional = true }


### PR DESCRIPTION
### Description
Using LNST as dependency when you only require PerfResult structure / importing LRC files it is not required to be installing and using ethtool / pyroute2 dependencies, which are netlink specific - meaning linux specific. 

There are multiple LNST users and developers that are not actively using Linux distros and it would simplify working with LNST as dependency.

### Tests
8351283

### Reviews
@LNST-project/lnst-developers 

Closes: #331 
