### PR TITLE
JsonRunSummaryFormatter: format all results

### DIFF
--- a/lnst/RecipeCommon/Perf/Evaluators/BaselineEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/BaselineEvaluator.py
@@ -78,6 +78,7 @@ class BaselineEvaluator(BaseResultEvaluator):
             comparisons.extend(
                 [
                     {
+                        "measurement_type": result.measurement.__class__.__name__,
                         "current_result": result,
                         "baseline_result": baseline,
                         "comparison_result": metric.result,


### PR DESCRIPTION
### Description
We can format all results, because all have a failure value and description that's json serializable. The data just isn't known if the result type is not known so it can't be formatted.