### PR TITLE
ovs dpdk fixes for mellanox

### DIFF
--- a/lnst/External/TRex/TRexLib.py
+++ b/lnst/External/TRex/TRexLib.py
@@ -171,7 +171,7 @@ class TRexSrv:
             os.chdir(self.params.trex_dir)
             server = subprocess.Popen(
                     [os.path.join(self.params.trex_dir, "t-rex-64"),
-                        "--cfg", cfg_file.name, "-i"],
+                        "--cfg", cfg_file.name, "-i", "--no-ofed-check"],
                     stdin=open('/dev/null'), stdout=open('/dev/null','w'),
                     stderr=subprocess.PIPE, close_fds=True)
 

--- a/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
+++ b/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
@@ -205,9 +205,10 @@ class OvSDPDKPvPRecipe(BasePvPRecipe):
             log_exc_traceback()
 
         try:
-            for nic in config.generator.nics:
-                config.generator.host.run(
-                    "driverctl unset-override {}".format(nic.bus_info))
+            if self.params.driverctl_override:
+                for nic in config.generator.nics:
+                    config.generator.host.run(
+                        "driverctl unset-override {}".format(nic.bus_info))
 
             config.generator.host.run("service irqbalance start")
         except:


### PR DESCRIPTION
### Description

Current implementation of Ovs_DPDK_PvP recipe works only for ixgbe/intel nics. Using the same setup with Mellanox cards requires sligh adjustments that include:
* no `driverctl set-override`
* use `--no-ofed-check` for TRex, the ofed utils are not required for this

### Tests

Tested on i40e and mlx5_core NICs.

### Reviews
