### PR TITLE
XDPMeasurementResults: fixed describe method return value type

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
@@ -30,7 +30,7 @@ class XDPBenchMeasurementResults(FlowMeasurementResults):
 
         return result_copy
 
-    def describe(self):
+    def describe(self) -> str:
         generator = self.generator_results
         receiver = self.receiver_results
 
@@ -47,4 +47,4 @@ class XDPBenchMeasurementResults(FlowMeasurementResults):
             )
         )
 
-        return desc
+        return "\n".join(desc)

--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -169,7 +169,7 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
         receiver = flow_results.receiver_results
 
         desc = []
-        desc.extend(flow_results.describe())
+        desc.append(flow_results.describe())
 
         recipe_result = ResultType.PASS
         metrics = {"Generator": generator, "Receiver": receiver}


### PR DESCRIPTION
### Description

All other `MeasurementResults.describe()` methods returns already formatted string, so our internal tooling expects string not the list of strings, and therefore it crashes when treating list as a string.

### Tests
Before: `J:8418399`  
After: `J:8433522`


### Reviews
@olichtne @jtluka 
