### PR TITLE
JsonRunSummaryFormatter: Wrap attr_set values in repr

### DIFF
--- a/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
+++ b/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
@@ -85,8 +85,8 @@ class JsonRunSummaryFormatter(RunSummaryFormatter):
                     "action": "attr_set",
                     "attr": {
                         "name": result.attr_name,
-                        "value": result.value,
-                        "old_value": result.old_value,
+                        "value": repr(result.value),
+                        "old_value": repr(result.old_value),
                     },
                 }
             else:


### PR DESCRIPTION
### Description
Sometimes non-formattable values (such as `Device` objects) are set.

This wasn't caught earlier, because I wasn't testing with recipes which would actually set device attributes to other devices.

### Tests
Not much, but should work.

### Reviews
@olichtne 