### PR TITLE
BaseLACPRecipe.test_wide_conf(): call grand parent's test_wide_conf() method

### DIFF
--- a/lnst/Recipes/ENRT/BaseLACPRecipe.py
+++ b/lnst/Recipes/ENRT/BaseLACPRecipe.py
@@ -39,7 +39,7 @@ class BaseLACPRecipe(DoubleBondRecipe):
         it calls switch configuration method.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super(DoubleBondRecipe, self).test_wide_configuration()
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)


### PR DESCRIPTION
### Description  
BaseLACPRecipe reimplements same behaviour as DoubleBondRecipe but adds multiple IPs. Because direct parent also implements bond device setup we need to bypass direct parent's `test_wide_conf()` method to prevent LNST crashing on calling bond device setup twice.


### Tests
Excluding changes: `J:8469701`  
Including changes: `J:8470332`

