### PR TITLE
Fix RDMA measurement data reporting

### DIFF
--- a/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
+++ b/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
@@ -120,6 +120,10 @@ class JsonRunSummaryFormatter(RunSummaryFormatter):
             elif result.measurement_type == "linuxperf":
                 # linuxperf measurement just generates files
                 measurement_data = {}
+            elif result.measurement_type == "rdma-bandwidth":
+                measurement_data = {
+                    "bandwidth": result.data["bandwidth"].average,
+                }
             else:
                 logging.warning(f"unhandled measurement result type: {result.measurement_type}")
                 measurement_data = None

--- a/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
@@ -138,4 +138,9 @@ class RDMABandwidthMeasurement(BaseFlowMeasurement):
         aggregated_results: list[AggregatedRDMABandwidthMeasurementResults],
     ) -> None:
         for aggregated_result in aggregated_results:
-            recipe.add_custom_result(MeasurementResult("rdma-bandwidth", description=aggregated_result.describe()))
+            measurement_result = MeasurementResult(
+                "rdma-bandwidth",
+                description=aggregated_result.describe(),
+                data={"bandwidth": aggregated_result.bandwidth}
+            )
+            recipe.add_custom_result(measurement_result)


### PR DESCRIPTION
### Description
Report rdma bandwidth data in a measurement result along its description. Also include rdma-bandwidth measurement formatting in JsonRunSummaryFormatter.

### Tests
Ran locally, produced rdma-bandwidth measurement result with actual data.