### PR TITLE
VF/Switchdev abstraction

### DIFF
--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -57,6 +57,21 @@ def sriov_capable(func):
 
     return wrapper
 
+def switchdev_capable(func):
+    """
+    Decorator for Device class methods that checks whether the Device can be
+    used in switchdev mode.
+    """
+    def wrapper(self, *args, **kwargs):
+        try:
+            _ = self.eswitch_mode
+        except DeviceFeatureNotSupported:
+            raise
+
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
 class Device(object, metaclass=DeviceMeta):
     """The base Device class
 
@@ -904,6 +919,38 @@ class Device(object, metaclass=DeviceMeta):
         if (rx_val, tx_val) != (None, None):
             self._write_pause_frames(rx_val, tx_val)
 
+    @property
+    def eswitch_mode(self):
+        try:
+            # TODO: do this through device._devlink?
+            stdout, _ = exec_cmd(f"devlink dev eswitch show pci/{self.bus_info}")
+        except ExecCmdFail as e:
+            if e.get_stderr().find("Operation not supported") > -1 or e.get_stderr().find("No such device"):
+                raise DeviceFeatureNotSupported(f"Device {self.name} not compatible with switchdev")
+            else:
+                raise DeviceError(
+                    f"Error while querying device {self.name} eswitch mode:\n{e.get_stderr()}"
+                )
+
+        m = re.search("mode (legacy|switchdev)", stdout)
+        try:
+            return m.group(1)
+        except AttributeError:
+            raise DeviceError(f"Could not parse device {self.name} eswitch mode")
+
+    @eswitch_mode.setter
+    def eswitch_mode(self, mode):
+        if self.eswitch_mode == mode:
+            return
+
+        try:
+            # TODO: do this through device._devlink?
+            exec_cmd(f"devlink dev eswitch set pci/{self.bus_info} mode {mode}")
+        except ExecCmdFail as e:
+            raise DeviceError(
+                f"Error while setting device {self.name} eswitch mode:\n{e.get_stderr()}"
+            )
+
     @sriov_capable
     def create_vfs(self, number_of_vfs=1):
         try:
@@ -920,7 +967,23 @@ class Device(object, metaclass=DeviceMeta):
         for vf_dev in (vf_devices := self._get_vf_devices()):
             vf_dev._enable()
 
-        return vf_devices
+        try:
+            eswitch_mode = self.eswitch_mode
+        except DeviceFeatureNotSupported:
+            return vf_devices, None
+
+        if eswitch_mode == "switchdev":
+            # wait for representor devices to appear on the netlink
+            if not self._wait_for_vf_rep_devices(number_of_vfs, 10):
+                raise DeviceError(f"Error while waiting for vf_reps for {self.name}")
+
+            for vf_rep_dev in (vf_rep_devices := self._get_vf_rep_devices()):
+                vf_rep_dev._enable()
+
+            return vf_devices, vf_rep_devices
+
+        # for any other cases, just return vf devices
+        return vf_devices, None
 
     def _wait_for_vf_devices(self, vfs_count, timeout):
         if timeout > 0:
@@ -942,6 +1005,29 @@ class Device(object, metaclass=DeviceMeta):
             raise
 
         logging.info(f"vfs on PF {self.name} successfully created")
+
+        return True
+
+    def _wait_for_vf_rep_devices(self, vfs_count, timeout):
+        if timeout > 0:
+            logging.info(f"Waiting for vf_rep(s) creation on PF {self.name} for {timeout} seconds")
+        elif timeout == 0:
+            logging.info(f"Waiting for vf_rep(s) creation on PF {self.name}")
+
+        def condition():
+            return all(
+                [
+                    self._vf_rep_is_ready(vf_index) for vf_index in range(0, vfs_count)
+                ]
+            )
+
+        try:
+            wait_for_condition(condition, timeout=timeout)
+        except TimeoutError:
+            logging.info(f"Timeout while waiting for vf_reps creation on PF {self.name}")
+            raise
+
+        logging.info(f"vf_reps on PF {self.name} successfully created")
 
         return True
 
@@ -967,10 +1053,31 @@ class Device(object, metaclass=DeviceMeta):
 
         return True
 
+    def _vf_rep_is_ready(self, vf_index):
+        logging.debug(f"Waiting for {self.name} vf_representor with index {vf_index}")
+
+        # search for vf representor
+        vf_rep_device = self._get_vf_representor(vf_index)
+
+        if not vf_rep_device:
+            logging.debug(f"vf representor {vf_index} for {self.name} not ready")
+            return False
+
+        logging.debug(f"vf representor {vf_index} for {self.name} ready")
+
+        return True
+
     @sriov_capable
     def _get_vf_devices(self):
         return [
             self._get_vf(vf_index)
+            for vf_index in range(self._get_vf_count())
+        ]
+
+    @switchdev_capable
+    def _get_vf_rep_devices(self):
+        return [
+            self._get_vf_representor(vf_index)
             for vf_index in range(self._get_vf_count())
         ]
 
@@ -979,6 +1086,38 @@ class Device(object, metaclass=DeviceMeta):
         stdout, _ = exec_cmd(f"cat /sys/class/net/{self.name}/device/sriov_numvfs")
 
         return int(stdout)
+
+    def _get_vf_representor(self, vf_index: int):
+        pf_number = int(self.phys_port_name[1:])
+
+        vf_rep_device_phys_port_name = f"pf{pf_number}vf{vf_index}"
+        all_devices = self._if_manager.get_devices()
+
+        """
+        netlink message content for vf representor devices
+        1st message
+        ('IFLA_PHYS_PORT_NAME', 'pf0vf0'),
+        ('IFLA_PHYS_SWITCH_ID', '10:f7:d5:fe:ff:1a:3d:e4'),
+        ('IFLA_PARENT_DEV_BUS_NAME', 'pci')
+        ('IFLA_PARENT_DEV_NAME', '0000:01:00.0') is same as PF device
+
+        2nd message, contains alternative device name derived from the PF device
+        ('IFLA_PHYS_PORT_NAME', 'pf0vf0'),
+        ('IFLA_PROP_LIST', {'attrs': [('IFLA_ALT_IFNAME', 'enp1s0f0npf0vf0')]}, 32768),
+        ('IFLA_PARENT_DEV_NAME', '0000:01:00.0'),
+        """
+        vf_reps_match = [
+            dev for dev in all_devices if (
+                dev.phys_port_name == vf_rep_device_phys_port_name and
+                dev.parent_dev_bus_name == self.parent_dev_bus_name and
+                dev.parent_dev_name == self.parent_dev_name
+            )
+        ]
+
+        try:
+            return vf_reps_match[0]
+        except IndexError:
+            return None
 
     def _get_vf(self, vf_index: int):
         all_devices = self._if_manager.get_devices()
@@ -1007,6 +1146,18 @@ class Device(object, metaclass=DeviceMeta):
             return vfs_match[0]
         except IndexError:
             return None
+
+    @property
+    def phys_port_name(self):
+        return self._nl_msg.get("IFLA_PHYS_PORT_NAME")
+
+    @property
+    def parent_dev_bus_name(self):
+        return self._nl_msg.get("IFLA_PARENT_DEV_BUS_NAME")
+
+    @property
+    def parent_dev_name(self):
+        return self._nl_msg.get("IFLA_PARENT_DEV_NAME")
 
     @property
     def alt_if_names(self):

--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -1136,7 +1136,7 @@ class Device(object, metaclass=DeviceMeta):
                 any(
                     [
                         pf_dev_name.find(vf_dev_name.rsplit(f"v{vf_index}")[0]) != -1
-                        for vf_dev_name, pf_dev_name in product(dev.alt_if_names, self.alt_if_names)
+                        for vf_dev_name, pf_dev_name in product(dev.alt_if_names + [dev.name], self.alt_if_names + [self.name])
                     ]
                 )
             )

--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -663,8 +663,7 @@ class Device(object, metaclass=DeviceMeta):
         try:
             return ethtool.get_businfo(self.name)
         except IOError as e:
-            log_exc_traceback()
-            return ""
+            raise DeviceFeatureNotSupported(f"No bus info for {self.name}")
 
     def ip_add(self, addr, peer=None):
         """add an ip address

--- a/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
@@ -1,5 +1,8 @@
 from collections.abc import Collection
 import time
+from dataclasses import dataclass
+from itertools import zip_longest
+from typing import Optional
 
 from lnst.Common.Parameters import (
     Param,
@@ -10,6 +13,7 @@ from lnst.Common.Parameters import (
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.NetNamespace import NetNamespace
+from lnst.Devices import RemoteDevice
 from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
 from lnst.RecipeCommon.Perf.Recipe import RecipeConf
 from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
@@ -22,6 +26,54 @@ from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
     CommonHWSubConfigMixin,
 )
+
+
+@dataclass
+class SRIOVDevices():
+    """
+    The class takes care of
+    1. creating the vfs
+    2. accessing the vfs by index or using next()
+    3. accessing the vf representors by index or using next()
+    3. accessing vf/vf representor pairs by index or using next()
+
+    For example:
+    ```
+    host.eth0.eswitch_mode = "switchdev"
+    sriov_devices = SRIOVDevices(host.eth0, 2)
+
+    vfs = sriov_devices.vfs # all vf devices
+    vf_representors = sriov_devices.vf_reps # all vf representors
+
+    vf0, vf_rep0 = sriov_devices[0] # vf/vf_rep of first virtual function
+    vf1, vf_rep1 = sriov_devices[1] # vf/vf_rep of second virtual function
+
+    for vf, vf_rep in sriov_devices: # iteration over vf/vf_representor pairs
+        vf.up()
+        vf_rep.up()
+    ```
+    """
+    phys_dev: RemoteDevice
+    vfs: list[RemoteDevice]
+    vf_reps: Optional[list[RemoteDevice]] = None
+
+    def __init__(self, phys_dev: RemoteDevice, number_of_vfs: int = 1):
+        self.phys_dev = phys_dev
+        phys_dev.up_and_wait()
+        self.vfs, self.vf_reps = phys_dev.create_vfs(number_of_vfs)
+
+    def __iter__(self):
+        if self.vf_reps:
+            return zip(self.vfs, self.vf_reps, strict=True)
+
+        return zip_longest(self.vfs, [None])
+
+    def __getitem__(self, key):
+        if self.vf_reps:
+            return self.vfs[key], self.vf_reps[key]
+
+        return self.vfs[key], None
+
 
 class BaseSRIOVNetnsTcRecipe(
     CommonHWSubConfigMixin, OffloadSubConfigMixin, BaremetalEnrtRecipe

--- a/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
@@ -60,6 +60,12 @@ class SRIOVDevices():
         phys_dev.up_and_wait()
         self.vfs, self.vf_reps = phys_dev.create_vfs(number_of_vfs)
 
+        for vf_index, vf in enumerate(self.vfs):
+            phys_dev.host.map_device(f"{phys_dev._id}_vf{vf_index}", {"ifname": vf.name})
+
+        for vf_rep_index, vf_rep in enumerate(self.vf_reps):
+            phys_dev.host.map_device(f"{phys_dev._id}_vf_rep{vf_index}", {"ifname": vf_rep.name})
+
     def __iter__(self):
         if self.vf_reps:
             return zip(self.vfs, self.vf_reps, strict=True)

--- a/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from lnst.Common.Parameters import (
     Param,
-    StrParam,
     IPv4NetworkParam,
     IPv6NetworkParam,
 )
@@ -126,8 +125,6 @@ class BaseSRIOVNetnsTcRecipe(
     With specific kernel parameter `biosdevname=1` we can expect default suffix on
     VF to be created to be `_n`, where n is the index of VF created.
     """
-    vf_suffix = StrParam(default="_0")
-
     offload_combinations = Param(default=(
         dict(gro="on", gso="on", tso="on", tx="on", rx="on"),
         dict(gro="off", gso="on", tso="on", tx="on", rx="on"),

--- a/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsTcRecipe.py
@@ -37,102 +37,105 @@ class SRIOVNetnsTcRecipe(BaseSRIOVNetnsTcRecipe):
 
         config.ingress_devices = []
         for host in [host1, host2]:
-            host.run(f"tc qdisc add dev {host.vf_representor_eth0.name} ingress")
+            host.run(f"tc qdisc add dev {host.sriov_devices.vf_reps[0].name} ingress")
             host.run(f"tc qdisc add dev {host.eth0.name} ingress")
-            config.ingress_devices.extend([host.vf_representor_eth0, host.eth0])
+            config.ingress_devices.extend([host.sriov_devices.vf_reps[0], host.eth0])
+
+        host1_vf_dev, host1_vf_rep_dev = host1.sriov_devices[0]
+        host2_vf_dev, host2_vf_rep_dev = host2.sriov_devices[0]
 
         host1.run(f"tc filter add dev {host1.eth0.name} "
                   f"protocol ip ingress flower skip_sw "
-                  f"src_mac {host2.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host1.newns.vf_eth0.hwaddr} "
-                  f"action mirred egress redirect dev {host1.vf_representor_eth0.name}")
+                  f"src_mac {host2_vf_dev.hwaddr} "
+                  f"dst_mac {host1_vf_dev.hwaddr} "
+                  f"action mirred egress redirect dev {host1_vf_rep_dev.name}")
 
         host1.run(f"tc filter add dev {host1.eth0.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host2.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host1.newns.vf_eth0.hwaddr} "
-                  f"action mirred egress redirect dev {host1.vf_representor_eth0.name}")
+                  f"src_mac {host2_vf_dev.hwaddr} "
+                  f"dst_mac {host1_vf_dev.hwaddr} "
+                  f"action mirred egress redirect dev {host1_vf_rep_dev.name}")
 
         host1.run(f"tc filter add dev {host1.eth0.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host2.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host2_vf_dev.hwaddr} "
                   f"dst_mac FF:FF:FF:FF:FF:FF "
-                  f"action mirred egress redirect dev {host1.vf_representor_eth0.name}")
+                  f"action mirred egress redirect dev {host1_vf_rep_dev.name}")
 
-        host1.run(f"tc filter add dev {host1.vf_representor_eth0.name} "
+        host1.run(f"tc filter add dev {host1_vf_rep_dev.name} "
                   f"protocol ip ingress flower skip_sw "
-                  f"src_mac {host1.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host2.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host1_vf_dev.hwaddr} "
+                  f"dst_mac {host2_vf_dev.hwaddr} "
                   f"action mirred egress redirect dev {host1.eth0.name}")
 
-        host1.run(f"tc filter add dev {host1.vf_representor_eth0.name} "
+        host1.run(f"tc filter add dev {host1_vf_rep_dev.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host1.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host2.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host1_vf_dev.hwaddr} "
+                  f"dst_mac {host2_vf_dev.hwaddr} "
                   f"action mirred egress redirect dev {host1.eth0.name}")
 
-        host1.run(f"tc filter add dev {host1.vf_representor_eth0.name} "
+        host1.run(f"tc filter add dev {host1_vf_rep_dev.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host1.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host1_vf_dev.hwaddr} "
                   f"dst_mac FF:FF:FF:FF:FF:FF "
                   f"action mirred egress redirect dev {host1.eth0.name}")
 
         host2.run(f"tc filter add dev {host2.eth0.name} "
                   f"protocol ip ingress flower skip_sw "
-                  f"src_mac {host1.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host2.newns.vf_eth0.hwaddr} "
-                  f"action mirred egress redirect dev {host2.vf_representor_eth0.name}")
+                  f"src_mac {host1_vf_dev.hwaddr} "
+                  f"dst_mac {host2_vf_dev.hwaddr} "
+                  f"action mirred egress redirect dev {host2_vf_rep_dev.name}")
 
         host2.run(f"tc filter add dev {host2.eth0.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host1.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host2.newns.vf_eth0.hwaddr} "
-                  f"action mirred egress redirect dev {host2.vf_representor_eth0.name}")
+                  f"src_mac {host1_vf_dev.hwaddr} "
+                  f"dst_mac {host2_vf_dev.hwaddr} "
+                  f"action mirred egress redirect dev {host2_vf_rep_dev.name}")
 
         host2.run(f"tc filter add dev {host2.eth0.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host1.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host1_vf_dev.hwaddr} "
                   f"dst_mac FF:FF:FF:FF:FF:FF "
-                  f"action mirred egress redirect dev {host2.vf_representor_eth0.name}")
+                  f"action mirred egress redirect dev {host2_vf_rep_dev.name}")
 
-        host2.run(f"tc filter add dev {host2.vf_representor_eth0.name} "
+        host2.run(f"tc filter add dev {host2_vf_rep_dev.name} "
                   f"protocol ip ingress flower skip_sw "
-                  f"src_mac {host2.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host1.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host2_vf_dev.hwaddr} "
+                  f"dst_mac {host1_vf_dev.hwaddr} "
                   f"action mirred egress redirect dev {host2.eth0.name}")
 
-        host2.run(f"tc filter add dev {host2.vf_representor_eth0.name} "
+        host2.run(f"tc filter add dev {host2_vf_rep_dev.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host2.newns.vf_eth0.hwaddr} "
-                  f"dst_mac {host1.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host2_vf_dev.hwaddr} "
+                  f"dst_mac {host1_vf_dev.hwaddr} "
                   f"action mirred egress redirect dev {host2.eth0.name}")
 
-        host2.run(f"tc filter add dev {host2.vf_representor_eth0.name} "
+        host2.run(f"tc filter add dev {host2_vf_rep_dev.name} "
                   f"protocol arp ingress flower "
-                  f"src_mac {host2.newns.vf_eth0.hwaddr} "
+                  f"src_mac {host2_vf_dev.hwaddr} "
                   f"dst_mac FF:FF:FF:FF:FF:FF "
                   f"action mirred egress redirect dev {host2.eth0.name}")
 
     @property
     def pause_frames_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def offload_nics(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def mtu_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def coalescing_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def dev_interrupt_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def parallel_stream_qdisc_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]

--- a/lnst/Recipes/ENRT/SRIOVNetnsVxlanTcRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsVxlanTcRecipe.py
@@ -64,7 +64,7 @@ class SRIOVNetnsVxlanTcRecipe(
                 dst_port=4789,
             )
 
-            for dev in [host.newns.vf_eth0, host.vf_representor_eth0]:
+            for dev in host.sriov_devices[0]:
                 # TODO: support IPv6, set to 1430
                 dev.mtu = 1450
 
@@ -81,30 +81,34 @@ class SRIOVNetnsVxlanTcRecipe(
         config.ingress_devices = []
         # tc configuration
         for host in [host1, host2]:
+            vf_representor = host.sriov_devices.vf_reps[0]
             host.run(f"tc qdisc add dev {host.eth0.name} ingress")
-            host.run(f"tc qdisc add dev {host.vf_representor_eth0.name} ingress")
+            host.run(f"tc qdisc add dev {vf_representor.name} ingress")
             host.run(f"tc qdisc add dev {host.vxlan10.name} ingress")
-            config.ingress_devices.extend([host.eth0, host.vf_representor_eth0, host.vxlan10])
+            config.ingress_devices.extend([host.eth0, vf_representor, host.vxlan10])
+
+        host1_vf_dev, host1_vf_rep_dev = host1.sriov_devices[0]
+        host2_vf_dev, host2_vf_rep_dev = host2.sriov_devices[0]
 
         # encap rules
         # host1
         host1.run(
-            f"tc filter add dev {host1.vf_representor_eth0.name} protocol ip ingress prio 1 "
-            f"flower src_mac {host1.newns.vf_eth0.hwaddr} dst_mac {host2.newns.vf_eth0.hwaddr} "
+            f"tc filter add dev {host1_vf_rep_dev.name} protocol ip ingress prio 1 "
+            f"flower src_mac {host1_vf_dev.hwaddr} dst_mac {host2_vf_dev.hwaddr} "
             f"action tunnel_key set src_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} dst_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} "
             f"dst_port 4789 id 10 "
             f"action mirred egress redirect dev {host1.vxlan10.name} "
         )
         host1.run(
-            f"tc filter add dev {host1.vf_representor_eth0.name} protocol arp ingress prio 2 "
-            f"flower src_mac {host1.newns.vf_eth0.hwaddr} dst_mac {host2.newns.vf_eth0.hwaddr} "
+            f"tc filter add dev {host1_vf_rep_dev.name} protocol arp ingress prio 2 "
+            f"flower src_mac {host1_vf_dev.hwaddr} dst_mac {host2_vf_dev.hwaddr} "
             f"action tunnel_key set src_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} dst_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} "
             f"dst_port 4789 id 10 "
             f"action mirred egress redirect dev {host1.vxlan10.name} "
         )
         host1.run(
-            f"tc filter add dev {host1.vf_representor_eth0.name} protocol arp ingress prio 3 "
-            f"flower src_mac {host1.newns.vf_eth0.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
+            f"tc filter add dev {host1_vf_rep_dev.name} protocol arp ingress prio 3 "
+            f"flower src_mac {host1_vf_dev.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
             f"action tunnel_key set src_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} dst_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} "
             f"dst_port 4789 id 10 "
             f"action mirred egress redirect dev {host1.vxlan10.name} "
@@ -112,22 +116,22 @@ class SRIOVNetnsVxlanTcRecipe(
 
         # host2
         host2.run(
-            f"tc filter add dev {host2.vf_representor_eth0.name} protocol ip ingress prio 1  "
-            f"flower src_mac {host2.newns.vf_eth0.hwaddr} dst_mac {host1.newns.vf_eth0.hwaddr}  "
+            f"tc filter add dev {host2_vf_rep_dev.name} protocol ip ingress prio 1  "
+            f"flower src_mac {host2_vf_dev.hwaddr} dst_mac {host1_vf_dev.hwaddr}  "
             f"action tunnel_key set src_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} dst_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} "
             f"dst_port 4789 id 10 "
             f"action mirred egress redirect dev {host2.vxlan10.name} "
         )
         host2.run(
-            f"tc filter add dev {host2.vf_representor_eth0.name} protocol arp ingress prio 2 "
-            f"flower src_mac {host2.newns.vf_eth0.hwaddr} dst_mac {host1.newns.vf_eth0.hwaddr} "
+            f"tc filter add dev {host2_vf_rep_dev.name} protocol arp ingress prio 2 "
+            f"flower src_mac {host2_vf_dev.hwaddr} dst_mac {host1_vf_dev.hwaddr} "
             f"action tunnel_key set src_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} dst_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} "
             f"dst_port 4789 id 10 "
             f"action mirred egress redirect dev {host2.vxlan10.name} "
         )
         host2.run(
-            f"tc filter add dev {host2.vf_representor_eth0.name} protocol arp ingress prio 3 "
-            f"flower src_mac {host2.newns.vf_eth0.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
+            f"tc filter add dev {host2_vf_rep_dev.name} protocol arp ingress prio 3 "
+            f"flower src_mac {host2_vf_dev.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
             f"action tunnel_key set src_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} dst_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} "
             f"dst_port 4789 id 10 "
             f"action mirred egress redirect dev {host2.vxlan10.name} "
@@ -137,79 +141,79 @@ class SRIOVNetnsVxlanTcRecipe(
         # host1
         host1.run(
             f"tc filter add dev {host1.vxlan10.name} protocol ip ingress prio 1 "
-            f"flower src_mac {host2.newns.vf_eth0.hwaddr} dst_mac {host1.newns.vf_eth0.hwaddr} "
+            f"flower src_mac {host2_vf_dev.hwaddr} dst_mac {host1_vf_dev.hwaddr} "
             f"enc_src_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} enc_dst_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} "
             f"enc_dst_port 4789 enc_key_id 10 "
             f"action tunnel_key unset "
-            f"action mirred egress redirect dev {host1.vf_representor_eth0.name} "
+            f"action mirred egress redirect dev {host1_vf_rep_dev.name} "
         )
         host1.run(
             f"tc filter add dev {host1.vxlan10.name} protocol arp ingress prio 2 "
-            f"flower src_mac {host2.newns.vf_eth0.hwaddr} dst_mac {host1.newns.vf_eth0.hwaddr} "
+            f"flower src_mac {host2_vf_dev.hwaddr} dst_mac {host1_vf_dev.hwaddr} "
             f"enc_src_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} enc_dst_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} "
             f"enc_dst_port 4789 enc_key_id 10 "
             f"action tunnel_key unset "
-            f"action mirred egress redirect dev {host1.vf_representor_eth0.name} "
+            f"action mirred egress redirect dev {host1_vf_rep_dev.name} "
         )
         host1.run(
             f"tc filter add dev {host1.vxlan10.name} protocol arp ingress prio 3 "
-            f"flower src_mac {host2.newns.vf_eth0.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
+            f"flower src_mac {host2_vf_dev.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
             f"enc_src_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} enc_dst_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} "
             f"enc_dst_port 4789 enc_key_id 10 "
             f"action tunnel_key unset "
-            f"action mirred egress redirect dev {host1.vf_representor_eth0.name} "
+            f"action mirred egress redirect dev {host1_vf_rep_dev.name} "
         )
 
         # host2
         host2.run(
             f"tc filter add dev {host2.vxlan10.name} protocol ip ingress prio 1 "
-            f"flower src_mac {host1.newns.vf_eth0.hwaddr} dst_mac {host2.newns.vf_eth0.hwaddr} "
+            f"flower src_mac {host1_vf_dev.hwaddr} dst_mac {host2_vf_dev.hwaddr} "
             f"enc_src_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} enc_dst_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} "
             f"enc_dst_port 4789 enc_key_id 10 "
             f"action tunnel_key unset "
-            f"action mirred egress redirect dev {host2.vf_representor_eth0.name} "
+            f"action mirred egress redirect dev {host2_vf_rep_dev.name} "
         )
         host2.run(
             f"tc filter add dev {host2.vxlan10.name} protocol arp ingress prio 2 "
-            f"flower src_mac {host1.newns.vf_eth0.hwaddr} dst_mac {host2.newns.vf_eth0.hwaddr} "
+            f"flower src_mac {host1_vf_dev.hwaddr} dst_mac {host2_vf_dev.hwaddr} "
             f"enc_src_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} enc_dst_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} "
             f"enc_dst_port 4789 enc_key_id 10 "
             f"action tunnel_key unset "
-            f"action mirred egress redirect dev {host2.vf_representor_eth0.name} "
+            f"action mirred egress redirect dev {host2_vf_rep_dev.name} "
         )
         host2.run(
             f"tc filter add dev {host2.vxlan10.name} protocol arp ingress prio 3 "
-            f"flower src_mac {host1.newns.vf_eth0.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
+            f"flower src_mac {host1_vf_dev.hwaddr} dst_mac ff:ff:ff:ff:ff:ff "
             f"enc_src_ip {config.ips_for_device(host1.eth0, family=AF_INET)[0]} enc_dst_ip {config.ips_for_device(host2.eth0, family=AF_INET)[0]} "
             f"enc_dst_port 4789 enc_key_id 10 "
             f"action tunnel_key unset "
-            f"action mirred egress redirect dev {host2.vf_representor_eth0.name} "
+            f"action mirred egress redirect dev {host2_vf_rep_dev.name} "
         )
 
     @property
     def dump_tc_rules_devices(self):
-        return [dev for host in self.matched for dev in [host.vxlan10, host.vf_representor_eth0]]
+        return [dev for host in self.matched for dev in [host.vxlan10, host.sriov_devices.vf_reps[0]]]
 
     @property
     def pause_frames_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def offload_nics(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def mtu_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def coalescing_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def dev_interrupt_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]
 
     @property
     def parallel_stream_qdisc_hw_config_dev_list(self):
-        return [self.matched.host1.newns.vf_eth0, self.matched.host2.newns.vf_eth0]
+        return [self.matched.host1.sriov_devices.vfs[0], self.matched.host2.sriov_devices.vfs[0]]


### PR DESCRIPTION
### Description

This MR extends the Device class with methods and properties required to configure and use vfs of an ethernet device in switchdev mode.

User would typically configure the device as follows (see also the change to BaseSRIOVNetnsTcRecipe):
```python
class SwitchdevRecipe(BaseRecipe):
    host1 = HostReq()
    host1.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))

    host2 = HostReq()
    host2.eth0 = DeviceReq(label="net1", driver=RecipeParam("driver"))

    def run(self):
        host1, host2 = self.matched.host1, self.matched.host2

        # create virtual functions
        for host in [host1, host2]:
            host.eth0.eswitch_mode = "switchdev"
            host.eth0.create_vfs(1)
            vf_device = host.eth0.vf_devices[0]
            vf_rep_device = host.eth0.vf_rep_devices[0]

            host.map_device("vf_representor_eth0", {"ifname": vf_rep_device.name})

            host.run(f"ethtool -K {host.vf_representor_eth0.name} hw-tc-offload on")
            host.run(f"ethtool -K {host.eth0.name} hw-tc-offload on")
```

Known issues:
* for i40e NICs, the code does not work as there are no representors by the NIC design
* for bnxt_en NICs, the code does not work on RHEL distros due to missing patch `[PATCH net-next v2] bnxt_en: Allow to set switchdev mode without existing VFs`

### Tests

J:8572626 J:8572625 J:8572624 J:8572623

### Reviews

@olichtne @Axonis 

Closes: #345  #344 