### PR TITLE
Devices/Device.py: update the regex for ethtool coalesce settings

### DIFF
--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -765,7 +765,7 @@ class Device(object, metaclass=DeviceMeta):
         settings = {}
         output, _ = exec_cmd("ethtool -c %s" % self.name, die_on_err=False)
 
-        regex = re.compile("^([a-z-]+): (n/a|\d+)$")
+        regex = re.compile("^([a-z-]+):\s+(n/a|\d+)$")
 
         for line in output.split('\n'):
             if not (m := regex.match(line)):


### PR DESCRIPTION
### Description

Recently the formatting of the ethtool output changed, where the values are now aligned and may contain multiple spaces.

Fixes following exception when rx-usecs setting is restored:
```
2023-11-20 07:21:21       (localhost)        -    INFO: Result: PASS, What: Setting Device attribute host1.eth0.coalescing_rx_usecs = None, previous value = None
2023-11-20 07:21:21           (host1)        -   ERROR: Command "ethtool -C ens7f0np0 rx-usecs None" execution failed (exited with 1)
2023-11-20 07:21:21       (localhost)        -   ERROR: Recipe execution terminated by unexpected exception

LNST Controller crashed with an exception:
Traceback (most recent call last):
  File "/mnt/tests/prod.ci-vm.lnst.hosted.psi.rdu2.redhat.com/data-server-content/gitlab-tasks/beaker-lnst-tasks/master.tar.gz/lnst/test-runner/./do-my-test", line 35, in main
    ctl.run(recipe, multimatch=bool(params.get("MULTIMATCH", False)))
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Controller/Controller.py", line 172, in run
    recipe.test()
  File "/root/rhextensions-lnst/lnst/RHExtensions/RHRecipeMixin.py", line 107, in test
    super(RHRecipeMixin, self).test()
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/BaseEnrtRecipe.py", line 210, in test
    self.do_tests(recipe_config)
  File "/usr/lib64/python3.9/contextlib.py", line 126, in __exit__
    next(self.gen)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/BaseEnrtRecipe.py", line 319, in _sub_context
    self.remove_sub_configuration(config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/BaseHWConfigMixin.py", line 9, in remove_sub_configuration
    self.hw_deconfig(config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/DevRxHashFunctionConfigMixin.py", line 42, in hw_deconfig
    super().hw_deconfig(config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/DevNfcRxFlowHashConfigMixin.py", line 43, in hw_deconfig
    super().hw_deconfig(config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/DevQueuesConfigMixin.py", line 51, in hw_deconfig
    super().hw_deconfig(config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/PauseFramesHWConfigMixin.py", line 44, in hw_deconfig
    super().hw_deconfig(config)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/MultiCoalescingHWConfigMixin.py", line 57, in hw_deconfig
    self._deconfigure_dev_attribute(
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Recipes/ENRT/ConfigMixins/BaseHWConfigMixin.py", line 47, in _deconfigure_dev_attribute
    setattr(dev, attr_name, value)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Devices/RemoteDevice.py", line 160, in __setattr__
    return self._machine.remote_device_setattr(self.ifindex, name, value, netns=self.netns)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Controller/Machine.py", line 188, in remote_device_setattr
    res = self.rpc_call("dev_setattr", index, attr_name, value, netns=netns)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Controller/Machine.py", line 320, in rpc_call
    return self._msg_dispatcher.send_message(self, msg)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Controller/MessageDispatcher.py", line 127, in send_message
    self._process_message(msg)
  File "/root/virtualenvs/rhextensions-lnst-Xo1BSm3a-py3.9/lib/python3.9/site-packages/lnst/Controller/MessageDispatcher.py", line 224, in _process_message
    raise message[1]["Exception"]
lnst.Common.DeviceError.DeviceFeatureNotSupported: Not allowed to modify coalescence settings rx-usecs for ens7f0np0.
```

### Tests

Before: J:8572065
```
2023-11-20 07:21:21       (localhost)        -    INFO: Result: PASS, What: Setting Device attribute host1.eth0.coalescing_rx_usecs = None, previous value = None
```

After: J:8572215
```
2023-11-20 07:45:48       (localhost)        -    INFO: Result: PASS, What: Setting Device attribute host1.eth0.coalescing_rx_usecs = 3, previous value = 16
```

### Reviews

None required, this is a hotfix.