### PR TITLE
Reorganize Iperf error reporting

### DIFF
--- a/lnst/Agent/Job.py
+++ b/lnst/Agent/Job.py
@@ -96,7 +96,7 @@ class Job(object):
 
         os.setpgrp()
         signal.signal(signal.SIGHUP, signal.SIG_DFL)
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.default_int_handler)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
         self._log_ctl.disable_logging()


### PR DESCRIPTION
### Description
Improve iperf reporting and reorganize the code a bit.

### Tests
`J:8583736` - second recipeset contains debug logs.

### Reviews
@jtluka 

Closes: #201 
