### PR TITLE
HOTFIX Devices/Device.py: report unsupported feature for switchdev corner case

### DIFF
--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -935,7 +935,7 @@ class Device(object, metaclass=DeviceMeta):
         try:
             return m.group(1)
         except AttributeError:
-            raise DeviceError(f"Could not parse device {self.name} eswitch mode")
+            raise DeviceFeatureNotSupported(f"Could not parse device {self.name} eswitch mode")
 
     @eswitch_mode.setter
     def eswitch_mode(self, mode):


### PR DESCRIPTION
In some cases a query of switchdev info on a device could return an empty string. When this happens the code expects either legacy or switchdev mode in the output, otherwise a DeviceError is raised.

The DeviceError causes termination of the machine's device cleanup process and some devices may be left without deconfiguration.

Since this case should not be considered as a critical issue a DeviceFeatureNotSupported is raised instead that is accepted during the deconfiguration.

### Description
(Please provide an overall description of what your Merge request is trying to
do.)

### Tests
(Please provide a list of tests that prove that the pull
request doesn't break the stable state of the master branch. This should
include test runs with valid results for all of critical workflows.)

### Reviews
(Please add a list of reviewers that should check the validity and sanity of
this merge request before it's accepted. Use the `@username` syntax. If you
don't know who to mention just link `@all`.)

Closes: #
