### PR TITLE
PerfMeasurements: add ability to simulate measurements

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/BaseMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseMeasurement.py
@@ -17,11 +17,20 @@ class BaseMeasurement(object):
     def start(self):
         raise NotImplementedError()
 
+    def simulate_start(self):
+        return self.start()
+
     def finish(self):
         raise NotImplementedError()
 
+    def simulate_finish(self):
+        return self.finish()
+
     def collect_results(self):
         raise NotImplementedError()
+
+    def collect_simulated_results(self):
+        return self.collect_results()
 
     @classmethod
     def report_results(cls, recipe, results):

--- a/lnst/RecipeCommon/Perf/Recipe.py
+++ b/lnst/RecipeCommon/Perf/Recipe.py
@@ -24,15 +24,21 @@ class RecipeConf(object):
         measurements: List[BaseMeasurement],
         iterations: int,
         parent_recipe_config: Any = None,
+        simulate_measurements: bool = False,
     ):
         self._measurements = measurements
         self._evaluators = dict()
         self._iterations = iterations
         self._parent_recipe_config = parent_recipe_config
+        self._simulate_measurements = simulate_measurements
 
     @property
     def measurements(self):
         return self._measurements
+
+    @property
+    def simulate_measurements(self):
+        return self._simulate_measurements
 
     @property
     def evaluators(self):
@@ -167,11 +173,23 @@ class Recipe(
 
         try:
             for measurement in recipe_conf.measurements:
-                measurement.start()
+                if recipe_conf.simulate_measurements:
+                    logging.info(f"Simulating start of measurement {measurement}")
+                    measurement.simulate_start()
+                else:
+                    measurement.start()
             for measurement in reversed(recipe_conf.measurements):
-                measurement.finish()
+                if recipe_conf.simulate_measurements:
+                    logging.info(f"Simulating finish of measurement {measurement}")
+                    measurement.simulate_finish()
+                else:
+                    measurement.finish()
             for measurement in recipe_conf.measurements:
-                measurement_results = measurement.collect_results()
+                if recipe_conf.simulate_measurements:
+                    logging.info(f"Simulating result collection of measurement {measurement}")
+                    measurement_results = measurement.collect_simulated_results()
+                else:
+                    measurement_results = measurement.collect_results()
                 results.add_measurement_results(
                     measurement, measurement_results
                 )

--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -165,6 +165,12 @@ class BaseEnrtRecipe(
         specify how many times should each performance measurement be repeated
         to generate cumulative results which can be statistically analyzed.
     :type perf_iterations: :any:`IntParam` (default 5)
+
+    :param perf_test_simulation:
+        Parameter that will switch the performance testing into a simulation
+        mode only - no measurements will actually be started and they'll simply
+        generate 0 value measurement results as if they ran
+    :type perf_test_simulation: :any:`BoolParam` (default False)
     """
 
     driver = StrParam()
@@ -181,6 +187,7 @@ class BaseEnrtRecipe(
 
     # generic perf test params
     perf_iterations = IntParam(default=5)
+    perf_test_simulation = BoolParam(default=False)
 
     def test(self):
         """Main test loop shared by all the Enrt recipes
@@ -440,6 +447,7 @@ class BaseEnrtRecipe(
                 measurements=measurements,
                 iterations=self.params.perf_iterations,
                 parent_recipe_config=copy.deepcopy(config),
+                simulate_measurements=self.params.perf_test_simulation,
             )
             self.register_perf_evaluators(perf_conf)
 

--- a/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
+++ b/lnst/Recipes/ENRT/OvS_DPDK_PvP.py
@@ -6,7 +6,7 @@ from lnst.Recipes.ENRT.BasePvPRecipe import BasePvPTestConf, BasePvPRecipe
 from lnst.Recipes.ENRT.BasePvPRecipe import VirtioDevice, VirtioType
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Common.Logs import log_exc_traceback
-from lnst.Common.Parameters import IntParam, Param, StrParam, IPv4NetworkParam
+from lnst.Common.Parameters import IntParam, Param, StrParam, IPv4NetworkParam, BoolParam
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Tests.TestPMD import TestPMD
 
@@ -63,6 +63,8 @@ class OvSDPDKPvPRecipe(BasePvPRecipe):
 
     #doesn't do anything for now...
     perf_streams = IntParam(default=1)
+
+    perf_test_simulation = BoolParam(default=False)
 
     def test(self):
         self.check_dependencies()
@@ -173,6 +175,7 @@ class OvSDPDKPvPRecipe(BasePvPRecipe):
                 flows_measurement,
             ],
             iterations=self.params.perf_iterations,
+            simulate_measurements=self.params.perf_test_simulation,
         )
         perf_conf.register_evaluators(cpu_measurement, self.cpu_perf_evaluators)
         perf_conf.register_evaluators(flows_measurement, self.net_perf_evaluators)

--- a/lnst/Recipes/ENRT/TrafficControlRecipe.py
+++ b/lnst/Recipes/ENRT/TrafficControlRecipe.py
@@ -3,7 +3,7 @@ import time
 from contextlib import contextmanager
 
 from lnst.Common.LnstError import LnstError
-from lnst.Common.Parameters import ListParam, StrParam, IntParam, ChoiceParam
+from lnst.Common.Parameters import ListParam, StrParam, IntParam, ChoiceParam, BoolParam
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.Namespace import Namespace
 from lnst.RecipeCommon import BaseResultEvaluator
@@ -40,6 +40,8 @@ class TrafficControlRecipe(PerfRecipe):
         default="off",
     )
 
+    perf_test_simulation = BoolParam(default=False)
+
     def test(self):
         with self._test_wide_context() as config:
             self.do_tc_test_perf_recipe(config)
@@ -67,6 +69,7 @@ class TrafficControlRecipe(PerfRecipe):
         config = TcRecipeConfiguration(
            measurements=[cpu_measurement, measurement],
            iterations=1,
+           simulate_measurements=self.params.perf_test_simulation,
        )
         config.register_evaluators(measurement, self.tc_run_evaluators)
 


### PR DESCRIPTION
### Description
The "bottom" measurements - meaning the most core measurement in a list of measurements that we may run can now be "simulated".

This means that instead of actually running the measurement tools/commands we instead run the following command:

    echo simulated start

And instead of returning real measurement results we return the same structure of data with a single 0 value perf interval.

Combining this we can now run all of our ENRT recipes in a "simulation" that preserves the number of commands per test recipe run and should return results compatible with all of our tooling with just the basic 0 value.

The cpu measurement simulation does actually call the real measurement, this is because this isn't a "bottom/core" measurement and is instead designed to always wrap some other measurement.

### Tests
I want to use this to generate baseline to threshold mapping for all of the tests and machines that we currently use so i'll link those jobs to here once i have confirmed everything works.

### Reviews
(Please add a list of reviewers that should check the validity and sanity of
this merge request before it's accepted. Use the `@username` syntax. If you
don't know who to mention just link `@all`.)

Closes: #
