### PR TITLE
Recipes/SRIOVNetnsOvSRecipe.py: deconfigure ovs bridge before resetti…

### DIFF
--- a/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
@@ -160,7 +160,14 @@ class SRIOVNetnsOvSRecipe(
         Finally virtual function is deleted.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, host in enumerate([host1, host2]):
+
+        for host in [host1, host2]:
+            for dev in [host.eth0, host.vf_representor_eth0, host.br0]:
+                dev.down()
+
+            host.br0.port_del(host.eth0)
+            host.br0.port_del(host.vf_representor_eth0)
+
             host.run(f"echo 0 > /sys/class/net/{host.eth0.name}/device/sriov_numvfs")
             time.sleep(2)
             host.run(f"devlink dev eswitch set pci/{host.eth0.bus_info} mode legacy")

--- a/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
@@ -103,7 +103,7 @@ class SRIOVNetnsOvSRecipe(
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)
 
-        for i, host in enumerate([host1, host2]):
+        for host in [host1, host2]:
             host.run("systemctl enable openvswitch")
             host.run("systemctl start openvswitch")
             host.run("ovs-vsctl set Open_vSwitch . other_config:hw-offload=true")
@@ -138,7 +138,7 @@ class SRIOVNetnsOvSRecipe(
     def generate_test_wide_description(self, config: EnrtConfiguration):
         desc = super().generate_test_wide_description(config)
         host1, host2 = self.matched.host1, self.matched.host2
-        for i, host in enumerate([host1, host2]):
+        for host in [host1, host2]:
             desc += [
                 f"Configured {host.hostid}.{host.eth0.name}.driver = switchdev\n"
                 f"Created virtual function on {host.hostid}.{host.eth0.name} = {host.newns.vf_eth0.name}\n"


### PR DESCRIPTION
…ng switchdev mode

### Description

On a setup with Nvidia CX6DX NIC we hit an issue when switchdev mode of the NIC could not be set back to legacy mode.

After some testing, the issue was resolved after the switchdev mode was reset after the ovs bridge device was brought down and ports removed from the switch. Previously this was done after reset of switchdev.

Logically, the steps of deconfiguration should match the configuration steps, in reversed order.

### Tests

Already tested in J:8877925

### Reviews

@Axonis 