### PR TITLE
Tests.XDPBench: add logging of xdp-bench cmd

### DIFF
--- a/lnst/Tests/XDPBench.py
+++ b/lnst/Tests/XDPBench.py
@@ -126,8 +126,8 @@ class XDPBench(BaseTestModule):
         self._res_data = []
 
     def run(self):
-        logging.debug("Starting xdp-bench")
         command = self._prepare_command()
+        logging.debug(f"Starting xdp-bench: `{command}`")
 
         bench = Popen(command, stdout=PIPE)
         output_parser = XDPBenchOutputParser(bench)


### PR DESCRIPTION
### Description
Just for the sake of completeness we should be able to see xdp-bench command that is being executed as it calls Popen and currently isn't logged.

### Tests
None required, simple change

### Reviews


Closes: #
