### PR TITLE
LACP: rollback vlan setting, fix perf endpoints generation

### DIFF
--- a/lnst/Recipes/ENRT/BaseLACPRecipe.py
+++ b/lnst/Recipes/ENRT/BaseLACPRecipe.py
@@ -5,6 +5,7 @@ from lnst.Common.Parameters import (
 )
 from lnst.Devices import BondDevice
 from lnst.Common.IpAddress import interface_addresses
+from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.DoubleBondRecipe import DoubleBondRecipe
 
 
@@ -74,3 +75,7 @@ class BaseLACPRecipe(DoubleBondRecipe):
         self.test_wide_switch_deconfiguration()
 
         super().test_wide_deconfiguration(config)
+
+    def generate_perf_endpoints(self, config):
+        return [ip_endpoint_pairs(config, (self.matched.host1.bond0, self.matched.host2.bond0), combination_func=zip)]
+

--- a/lnst/Recipes/ENRT/ConfigMixins/BaseRESTConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/BaseRESTConfigMixin.py
@@ -38,4 +38,4 @@ class BaseRESTConfigMixin:
 
         logging.debug("API response: %s", response.content)
 
-        return response.content
+        return response

--- a/lnst/Recipes/ENRT/DellLACPRecipe.py
+++ b/lnst/Recipes/ENRT/DellLACPRecipe.py
@@ -1,9 +1,42 @@
+import logging
+import requests
+
 from lnst.Recipes.ENRT.BaseLACPRecipe import BaseLACPRecipe
 from lnst.Recipes.ENRT.ConfigMixins.BaseRESTConfigMixin import BaseRESTConfigMixin
 
 
 class DellLACPRecipe(BaseRESTConfigMixin, BaseLACPRecipe):
+    def __init__(self, *args, **kwargs):
+        self._vlan_connections = {}  # structure: {"INTERFACE1": ["vlan10", "vlan20", ...]}
+
+        super().__init__(*args, **kwargs)
+
+    def get_interface_vlans(self, interfaces: list[str]):
+        vlans = {interface: [] for interface in interfaces}
+
+        infs = self.api_request(
+            "get", "/restconf/data/ietf-interfaces:interfaces/interface"
+        ).json()
+
+        for sw_inf in infs["ietf-interfaces:interface"]:
+            if (
+                sw_inf["type"].lower() != "iana-if-type:l2vlan"
+                or sw_inf["name"].lower() == "vlan1"
+            ):
+                # ^^ vlan1 is default vlan. Each inf is connected to it, this cannot be changed.
+                continue
+
+            for interface in interfaces:
+                if interface in sw_inf["dell-interface:tagged-ports"]:
+                    vlans[interface].append(sw_inf["name"])
+
+        return vlans
+
     def test_wide_switch_configuration(self):
+        self._vlan_connections = self.get_interface_vlans([interface for interfaces in self.params.topology.values() for interface in interfaces])
+
+        logging.info(f"Interface/VLAN connections: {self._vlan_connections}")
+
         for bond, interfaces in self.params.topology.items():
             interfaces = [
                 {"name": interface, "lacp-mode": self.params.lacp_mode}
@@ -16,10 +49,7 @@ class DellLACPRecipe(BaseRESTConfigMixin, BaseLACPRecipe):
                 response_code=204,
                 json={
                     "ietf-interfaces:interface": [
-                        {
-                            "name": bond,
-                            "dell-interface:member-ports": interfaces
-                        }
+                        {"name": bond, "dell-interface:member-ports": interfaces}
                     ]
                 },
             )
@@ -31,7 +61,24 @@ class DellLACPRecipe(BaseRESTConfigMixin, BaseLACPRecipe):
                     "delete",
                     f"/restconf/data/ietf-interfaces:interfaces/interface/{bond}",
                     response_code=204,
-                    json={
-                        "dell-interface:member-ports": [{"name": interface}]
-                    }
+                    json={"dell-interface:member-ports": [{"name": interface}]},
                 )
+
+        for interface, vlans in self._vlan_connections.items():
+            self.api_request(
+                "put",
+                f"/restconf/data/ietf-interfaces:interfaces/interface/{requests.utils.quote(interface, safe='')}/dell-interface{requests.utils.quote(':')}mode",
+                response_code=204,
+                json={"dell-interface:mode": "MODE_L2HYBRID"},
+            )
+            logging.info(f"Interface {interface} set to MODE_L2HYBRID")
+
+            for vlan in vlans:
+                self.api_request(
+                    "put",
+                    f"/restconf/data/ietf-interfaces:interfaces/interface/{vlan}/dell-interface{requests.utils.quote(':')}tagged-ports",
+                    response_code=204,
+                    json={"dell-interface:tagged-ports": [interface]},
+                )
+                logging.info(f"Vlan {vlan} added to interface {interface}")
+

--- a/lnst/Recipes/ENRT/helpers.py
+++ b/lnst/Recipes/ENRT/helpers.py
@@ -8,7 +8,9 @@ from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 
 
 def ip_endpoint_pairs(
-    config: EnrtConfiguration, *device_pairs: tuple[RemoteDevice, RemoteDevice]
+    config: EnrtConfiguration,
+    *device_pairs: tuple[RemoteDevice, RemoteDevice],
+    combination_func: callable = itertools.product
 ) -> Collection[EndpointPair[IPEndpoint]]:
     """Helper function for use in generate_perf_endpoints method.
 
@@ -20,7 +22,7 @@ def ip_endpoint_pairs(
             dev1_ips = [ip for ip in config.ips_for_device(dev1) if isinstance(ip, ip_type)]
             dev2_ips = [ip for ip in config.ips_for_device(dev2) if isinstance(ip, ip_type)]
 
-            for ip1, ip2 in itertools.product(dev1_ips, dev2_ips):
+            for ip1, ip2 in combination_func(dev1_ips, dev2_ips):
                 endpoint_pairs.append(
                     EndpointPair(
                         IPEndpoint(dev1, ip1),


### PR DESCRIPTION
_marking this as a draft, i want to discuss my approach of assigning ports back to the VLANs with dell support. Documentation didn't help :)_

### Description
This MR includes:

* fix for rollbacking VLAN settings on Dell switches - Assigning port to a channel group has side effect of disconnecting
it from all the VLANS. Those are not automatically restored after
removing port from channel group.

* perf endpoint generation fix - UDP over LACP requires lots of parallel perf processes. However, due to
generating IP perf endpoints by doing a product on source and dest IPs
recipe generated A WAY more processes (all IPs+ports to all IPS+ports)
than expected.

(see commit messages for further explanation)

### Tests
Rollback tests:  
* manually verified on switch side
* LACP recipes interleaved with VLAN tests`J:8926338`

Endpoints generation fix:  
* `J:8932918` just a functional test of UDP test, without changes the recipe got aborted due to machine freeze




### Reviews
@jtluka 
