### PR TITLE
Devices/Device.py: Fix for broken cleanup() with missing tc tool

### DIFF
--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -422,8 +422,11 @@ class Device(object, metaclass=DeviceMeta):
 
         self.down()
         self.ip_flush()
-        self._clear_tc_qdisc()
-        self._clear_tc_filters()
+        try:
+            self._clear_tc_qdisc()
+            self._clear_tc_filters()
+        except ExecCmdFail:
+            pass
 
         self.restore_original_data()
 


### PR DESCRIPTION
If no tc utility is present on the agent system, exec_cmd() raises an exception. If uncaught, the previous address flush request will also not complete. The address remaining in place will cause an EEXIST error upon next test run, requiring manual intervention to resolve the situation.

Fixes: 49e523d5aef46 ("Slave: Add basic support for tc.")