### PR TITLE
External.TRex.UDPSimple: use src/dst mac and ip addresses

### DIFF
--- a/lnst/External/TRex/UDPSimple.py
+++ b/lnst/External/TRex/UDPSimple.py
@@ -23,8 +23,8 @@ class UDPSimple(object):
 
     def create_stream (self, **kwargs):
         # Use port's configured mac and ip addresses
-        L2 = Ether()
-        L3 = IP()
+        L2 = Ether(src=kwargs["src_mac"], dst=kwargs["dst_mac"])
+        L3 = IP(src=kwargs["src_ip"], dst=kwargs["dst_ip"])
         L4 = UDP()
 
         size = kwargs.get("msg_size", 64)


### PR DESCRIPTION
### Description
The default trex packet stream generator didn't correctly use the provided source and destination ip and mac addresses.

This wasn't noticed until now because the test is typically run in a lab where multiple machine pairs were isolated from eachother.

This however isn't MANDATORY and so to avoid conflicts on a shared network we should respect the provided values.

### Tests
(Please provide a list of tests that prove that the pull
request doesn't break the stable state of the master branch. This should
include test runs with valid results for all of critical workflows.)

### Reviews
(Please add a list of reviewers that should check the validity and sanity of
this merge request before it's accepted. Use the `@username` syntax. If you
don't know who to mention just link `@all`.)

Closes: #
