### PR TITLE
Fix veth device move

### DIFF
--- a/lnst/Agent/InterfaceManager.py
+++ b/lnst/Agent/InterfaceManager.py
@@ -247,6 +247,7 @@ class InterfaceManager(object):
         except KeyError as e:
             raise DeviceConfigError("%s is a mandatory argument" % e)
         remapped_device._bulk_enabled = False
+        remapped_device._nl_link_update = {}
         remapped_device.ifindex = ifindex
         self.replace_dev(ifindex, remapped_device)
         self.rescan_devices()

--- a/lnst/Controller/Machine.py
+++ b/lnst/Controller/Machine.py
@@ -135,8 +135,11 @@ class Machine(object):
         dev_args = dev._dev_args
         dev_kwargs = dev._dev_kwargs
 
-        if dev.peer_name:
-            dev_kwargs['peer_name'] = dev.peer_name
+        try:
+            if dev.peer_name:
+                dev_kwargs['peer_name'] = dev.peer_name
+        except AttributeError:
+            pass
 
         self.rpc_call("remap_device",
                 dev.ifindex,

--- a/lnst/Controller/Machine.py
+++ b/lnst/Controller/Machine.py
@@ -135,6 +135,9 @@ class Machine(object):
         dev_args = dev._dev_args
         dev_kwargs = dev._dev_kwargs
 
+        if dev.peer_name:
+            dev_kwargs['peer_name'] = dev.peer_name
+
         self.rpc_call("remap_device",
                 dev.ifindex,
                 clsname=dev_clsname,


### PR DESCRIPTION
### Description

Resolves an issue when moving a veth device to a namespace. The device will
have _nl_link_update populated with data from generic Device creation (device
appears in the namespace). This data may cause issues for certain device
operations like setting the link up.

To avoid this, clearing the _nl_link_update while remapping the device
solves the issue.

Fixes #367

### Tests

Tested with the reproducer from the issue both in container setup and normal setup.

I scheduled test run in RH labs that include a single run of each recipe type, beaker job id J:9261245

### Reviews

@olichtne 