### PR TITLE
BaseRESTConfigMixin: retrying of API call

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/BaseRESTConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/BaseRESTConfigMixin.py
@@ -1,5 +1,7 @@
+import time
 import logging
 import requests
+from requests.exceptions import RequestException
 
 from lnst.Common.LnstError import LnstError
 from lnst.Common.Parameters import BoolParam, StrParam
@@ -10,6 +12,10 @@ class BaseRESTConfigMixin:
     rest_user = StrParam()
     rest_password = StrParam()
     ssl_verify = BoolParam(default=True, mandatory=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.BASE_DELAY = 1
 
     @staticmethod
     def __get_request_function(method: str):
@@ -28,11 +34,28 @@ class BaseRESTConfigMixin:
 
         return kwargs
 
-    def api_request(self, method: str, endpoint: str, response_code: int = 200, **kwargs) -> bytes:
+    def api_request(self, method: str, endpoint: str, response_code: int = 200, tries: int = 7, **kwargs) -> bytes:
         request = self.__build_request(endpoint, **kwargs)
         req_func = self.__get_request_function(method)
 
-        response = req_func(**request)
+        for i in range(1, tries+1):  # i starts from 1
+            try:
+                response = req_func(**request)
+            except RequestException as e:
+                delay = self.BASE_DELAY * 2 ** i
+
+                logging.error(
+                    f"API request ({i}/{tries}) failed. Retrying in {delay} seconds.",
+                    exc_info=True,
+                )
+
+                time.sleep(delay)
+                continue
+            
+            break  # request was successful
+        else:
+            raise LnstError(f"API request failed after {tries} tries")
+
         if response.status_code != response_code:
             raise LnstError(f"Request failed with status code {response.status_code}")
 


### PR DESCRIPTION
### Description
For various reasons, it may happen that a remote resource is unreachable/doesn't respond with an expected response. Therefore, retry mechanism for API calls tries to send request `tries` times with `1sec` sleep in between.


### Tests
* Beaker job `J:9529957`
* manual tests of retries by changing `/etc/hosts` file to simulate resource is unreachable

