### PR TITLE
Support for vf testing in enrt

### DIFF
--- a/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaremetalEnrtRecipe.py
@@ -1,4 +1,5 @@
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
+from lnst.Recipes.ENRT.UseVfsMixin import UseVfsMixin
 from lnst.Recipes.ENRT.PerfTestMixins import CommonPerfTestTweakMixin
 from lnst.Recipes.ENRT.ConfigMixins.DisableTurboboostMixin import (
     DisableTurboboostMixin,
@@ -55,6 +56,7 @@ class BaremetalEnrtCommonMixins(
 
 
 class BaremetalEnrtRecipe(
+    UseVfsMixin,
     BaremetalEnrtCommonMixins,
     BaremetalEnrtMeasurementGenerators,
     BaseEnrtRecipe,

--- a/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
@@ -1,7 +1,4 @@
 from collections.abc import Collection
-from dataclasses import dataclass
-from itertools import zip_longest
-from typing import Optional
 
 from lnst.Common.Parameters import (
     Param,
@@ -11,11 +8,11 @@ from lnst.Common.Parameters import (
 from lnst.Common.IpAddress import interface_addresses
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.NetNamespace import NetNamespace
-from lnst.Devices import RemoteDevice
 from lnst.RecipeCommon.endpoints import EndpointPair, IPEndpoint
 from lnst.RecipeCommon.Perf.Recipe import RecipeConf
 from lnst.Recipes.ENRT.helpers import ip_endpoint_pairs
 from lnst.Recipes.ENRT.BaremetalEnrtRecipe import BaremetalEnrtRecipe
+from lnst.Recipes.ENRT.SRIOVDevices import SRIOVDevices
 from lnst.RecipeCommon.Ping.PingEndpoints import PingEndpoints
 from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
@@ -24,59 +21,6 @@ from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import (
 from lnst.Recipes.ENRT.ConfigMixins.CommonHWSubConfigMixin import (
     CommonHWSubConfigMixin,
 )
-
-
-@dataclass
-class SRIOVDevices():
-    """
-    The class takes care of
-    1. creating the vfs
-    2. accessing the vfs by index or using next()
-    3. accessing the vf representors by index or using next()
-    3. accessing vf/vf representor pairs by index or using next()
-
-    For example:
-    ```
-    host.eth0.eswitch_mode = "switchdev"
-    sriov_devices = SRIOVDevices(host.eth0, 2)
-
-    vfs = sriov_devices.vfs # all vf devices
-    vf_representors = sriov_devices.vf_reps # all vf representors
-
-    vf0, vf_rep0 = sriov_devices[0] # vf/vf_rep of first virtual function
-    vf1, vf_rep1 = sriov_devices[1] # vf/vf_rep of second virtual function
-
-    for vf, vf_rep in sriov_devices: # iteration over vf/vf_representor pairs
-        vf.up()
-        vf_rep.up()
-    ```
-    """
-    phys_dev: RemoteDevice
-    vfs: list[RemoteDevice]
-    vf_reps: Optional[list[RemoteDevice]] = None
-
-    def __init__(self, phys_dev: RemoteDevice, number_of_vfs: int = 1):
-        self.phys_dev = phys_dev
-        phys_dev.up_and_wait()
-        self.vfs, self.vf_reps = phys_dev.create_vfs(number_of_vfs)
-
-        for vf_index, vf in enumerate(self.vfs):
-            phys_dev.host.map_device(f"{phys_dev._id}_vf{vf_index}", {"ifname": vf.name})
-
-        for vf_rep_index, vf_rep in enumerate(self.vf_reps):
-            phys_dev.host.map_device(f"{phys_dev._id}_vf_rep{vf_index}", {"ifname": vf_rep.name})
-
-    def __iter__(self):
-        if self.vf_reps:
-            return zip(self.vfs, self.vf_reps, strict=True)
-
-        return zip_longest(self.vfs, [None])
-
-    def __getitem__(self, key):
-        if self.vf_reps:
-            return self.vfs[key], self.vf_reps[key]
-
-        return self.vfs[key], None
 
 
 class BaseSRIOVNetnsTcRecipe(

--- a/lnst/Recipes/ENRT/SRIOVDevices.py
+++ b/lnst/Recipes/ENRT/SRIOVDevices.py
@@ -42,8 +42,9 @@ class SRIOVDevices():
         for vf_index, vf in enumerate(self.vfs):
             phys_dev.host.map_device(f"{phys_dev._id}_vf{vf_index}", {"ifname": vf.name})
 
-        for vf_rep_index, vf_rep in enumerate(self.vf_reps):
-            phys_dev.host.map_device(f"{phys_dev._id}_vf_rep{vf_rep_index}", {"ifname": vf_rep.name})
+        if self.vf_reps is not None:
+            for vf_rep_index, vf_rep in enumerate(self.vf_reps):
+                phys_dev.host.map_device(f"{phys_dev._id}_vf_rep{vf_rep_index}", {"ifname": vf_rep.name})
 
     def __iter__(self):
         if self.vf_reps:

--- a/lnst/Recipes/ENRT/SRIOVDevices.py
+++ b/lnst/Recipes/ENRT/SRIOVDevices.py
@@ -43,7 +43,7 @@ class SRIOVDevices():
             phys_dev.host.map_device(f"{phys_dev._id}_vf{vf_index}", {"ifname": vf.name})
 
         for vf_rep_index, vf_rep in enumerate(self.vf_reps):
-            phys_dev.host.map_device(f"{phys_dev._id}_vf_rep{vf_index}", {"ifname": vf_rep.name})
+            phys_dev.host.map_device(f"{phys_dev._id}_vf_rep{vf_rep_index}", {"ifname": vf_rep.name})
 
     def __iter__(self):
         if self.vf_reps:

--- a/lnst/Recipes/ENRT/SRIOVDevices.py
+++ b/lnst/Recipes/ENRT/SRIOVDevices.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from itertools import zip_longest
+from typing import Optional
+
+from lnst.Devices import RemoteDevice
+
+
+@dataclass
+class SRIOVDevices():
+    """
+    The class takes care of
+    1. creating the vfs
+    2. accessing the vfs by index or using next()
+    3. accessing the vf representors by index or using next()
+    3. accessing vf/vf representor pairs by index or using next()
+
+    For example:
+    ```
+    host.eth0.eswitch_mode = "switchdev"
+    sriov_devices = SRIOVDevices(host.eth0, 2)
+
+    vfs = sriov_devices.vfs # all vf devices
+    vf_representors = sriov_devices.vf_reps # all vf representors
+
+    vf0, vf_rep0 = sriov_devices[0] # vf/vf_rep of first virtual function
+    vf1, vf_rep1 = sriov_devices[1] # vf/vf_rep of second virtual function
+
+    for vf, vf_rep in sriov_devices: # iteration over vf/vf_representor pairs
+        vf.up()
+        vf_rep.up()
+    ```
+    """
+    phys_dev: RemoteDevice
+    vfs: list[RemoteDevice]
+    vf_reps: Optional[list[RemoteDevice]] = None
+
+    def __init__(self, phys_dev: RemoteDevice, number_of_vfs: int = 1):
+        self.phys_dev = phys_dev
+        phys_dev.up_and_wait()
+        self.vfs, self.vf_reps = phys_dev.create_vfs(number_of_vfs)
+
+        for vf_index, vf in enumerate(self.vfs):
+            phys_dev.host.map_device(f"{phys_dev._id}_vf{vf_index}", {"ifname": vf.name})
+
+        for vf_rep_index, vf_rep in enumerate(self.vf_reps):
+            phys_dev.host.map_device(f"{phys_dev._id}_vf_rep{vf_index}", {"ifname": vf_rep.name})
+
+    def __iter__(self):
+        if self.vf_reps:
+            return zip(self.vfs, self.vf_reps, strict=True)
+
+        return zip_longest(self.vfs, [None])
+
+    def __getitem__(self, key):
+        if self.vf_reps:
+            return self.vfs[key], self.vf_reps[key]
+
+        return self.vfs[key], None

--- a/lnst/Recipes/ENRT/UseVfsMixin.py
+++ b/lnst/Recipes/ENRT/UseVfsMixin.py
@@ -1,0 +1,52 @@
+from lnst.Common.Parameters import BoolParam
+from lnst.Controller.Requirements import DeviceReq
+from lnst.Recipes.ENRT.SRIOVDevices import SRIOVDevices
+
+
+class UseVfsMixin:
+    """
+    Mixin allows any ENRT recipe to use virtual function (VF) interfaces
+    instead of physical interfaces defined by DeviceReq requirements.
+
+    VF interfaces are created automatically and DeviceReq handles are replaced
+    with VF Device instances. This allows user to interact with the network
+    interfaces without additional changes to the code of recipe.
+
+    There are some limitations, for example pause frames cannot be configured
+    since the VF do not support these.
+    """
+
+    use_vfs = BoolParam(default=False)
+
+    def test_wide_configuration(self):
+        config = super().test_wide_configuration()
+
+        if not self.params.use_vfs:
+            return config
+
+        config.vf_config = {}
+        for host_key, host_req in self.req:
+            dev_names = [key for key, value in host_req if isinstance(value, DeviceReq)]
+            host = getattr(self.matched, host_key)
+
+            # remap_pfs_to_vfs
+            for dev_name in dev_names:
+                dev = getattr(host, dev_name)
+                sriov_devices = SRIOVDevices(dev, 1)
+                vf_dev = sriov_devices.vfs[0]
+                host.map_device(dev_name, {"ifname": vf_dev.name})
+
+                host_config = config.vf_config.setdefault(host, [])
+                host_config.append(sriov_devices)
+
+        return config
+
+    def test_wide_deconfiguration(self, config):
+        if self.params.use_vfs:
+            for host, sriov_devices_list in config.vf_config.items():
+                for sriov_devices in sriov_devices_list:
+                    vf_dev = sriov_devices.vfs[0]
+                    host.map_device(vf_dev._id, {"ifname": sriov_devices.phys_dev.name})
+                    sriov_devices.phys_dev.delete_vfs()
+
+        super().test_wide_deconfiguration(config)


### PR DESCRIPTION
### Description

This adds new mixin that can be used in ENRT recipes to use VFs of the NICs (PFs) defined by DeviceReq recipe requirements instead of PFs. This is configurable through a bool parameter without need of any additional changes to the original recipe. 

### Tests

* J:9685753 use_vfs=True ice/i40e/
* J:9685754 use_vfs=False
* TODO: run SRIOV* test set as this fixes some bugs
* TODO: run a vlan, bond and other types of BaremetalEnrtRecipes

### Reviews

@olichtne @enhaut 