### PR TITLE
ContainerPoolManager: add netavark support

### DIFF
--- a/.github/runner.py
+++ b/.github/runner.py
@@ -28,6 +28,7 @@ ctl = Controller(
     podman_uri=podman_uri,
     image=image_name,
     debug=1,
+    network_plugin="cni",
 )
 
 recipe_instance = HelloWorldRecipe()


### PR DESCRIPTION
### Description

With podman5+ the CNI network backend support is removed, with netavark being the default network plugin.

This adds support for netavark network backend and changes the ContainerPoolManager to use it as default.

The CNI backend support is kept and user can force LNST to use it by `ContainerPoolManager(network_plugin='cni')`.

### Tests

Tested on Fedora40 with podman-5.2.2-1.fc40.x86_64

### Reviews

@olichtne @enhaut 