### PR TITLE
UseVfsMixin: add vf_trust parameter

### DIFF
--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -1167,12 +1167,19 @@ class Device(object, metaclass=DeviceMeta):
             return self._nl_msg.get_attr("IFLA_PROP_LIST").get_attrs("IFLA_ALT_IFNAME")
         except:
             return []
-    
+
     def keep_addrs_on_down(self):
         exec_cmd(f"echo 1 > /proc/sys/net/ipv6/conf/{self.name}/keep_addr_on_down")
 
     def remove_addrs_on_down(self):
         exec_cmd(f"echo 0 > /proc/sys/net/ipv6/conf/{self.name}/keep_addr_on_down")
+
+    # TODO: implement through pyroute once supported
+    def vf_trust(self, vf_index: int, trusted: str):
+        if trusted not in ["on", "off"]:
+            raise DeviceConfigError(f"Incorrect value for vf trust: {trusted}")
+
+        exec_cmd(f"ip link set dev {self.name} vf {vf_index} trust {trusted}")
 
     #TODO implement proper Route objects
     #consider the same as with tc?

--- a/lnst/Recipes/ENRT/UseVfsMixin.py
+++ b/lnst/Recipes/ENRT/UseVfsMixin.py
@@ -1,4 +1,4 @@
-from lnst.Common.Parameters import BoolParam
+from lnst.Common.Parameters import BoolParam, ChoiceParam
 from lnst.Controller.Requirements import DeviceReq
 from lnst.Recipes.ENRT.SRIOVDevices import SRIOVDevices
 
@@ -12,11 +12,16 @@ class UseVfsMixin:
     with VF Device instances. This allows user to interact with the network
     interfaces without additional changes to the code of recipe.
 
+    Mixin provides two boolean parameters:
+    * use_vfs - main parameter to enable or disable (default) use of VFs
+    * vf_trust - set the trust parameter of the used VFs, 'on' or 'off' (default)
+
     There are some limitations, for example pause frames cannot be configured
     since the VF do not support these.
     """
 
     use_vfs = BoolParam(default=False)
+    vf_trust = ChoiceParam(choices={'on', 'off'}, default='off')
 
     def test_wide_configuration(self):
         config = super().test_wide_configuration()
@@ -33,6 +38,8 @@ class UseVfsMixin:
             for dev_name in dev_names:
                 dev = getattr(host, dev_name)
                 sriov_devices = SRIOVDevices(dev, 1)
+                dev.vf_trust(0, self.params.vf_trust)
+
                 vf_dev = sriov_devices.vfs[0]
                 host.map_device(dev_name, {"ifname": vf_dev.name})
 
@@ -56,7 +63,7 @@ class UseVfsMixin:
 
         if self.params.use_vfs:
             description += [
-                f"Using vf device {vf_dev.name} of pf {sriov_devices.phys_dev.name} for DeviceReq {host.hostid}.{vf_dev._id}"
+                f"Using vf device {vf_dev.name} of pf {sriov_devices.phys_dev.name} for DeviceReq {host.hostid}.{vf_dev._id} trusted={self.params.vf_trust}"
                 for host, sriov_devices_list in config.vf_config.items()
                 for sriov_devices in sriov_devices_list
                 for vf_dev in sriov_devices.vfs


### PR DESCRIPTION
### Description

This adds `vf_trust` parameter to UseVfsMixin. The Device class is extended with `vf_trust()` method.

### Tests

~~J:9865704~~ J:9939392

Note that sfc driver tests failed because the device does not support vf_trust. I have a separate patch set that fixes that along with different way to achieve same functionality.

### Reviews
@olichtne 

