### PR TITLE
UseVfsMixin: add vf_trust parameter

### DIFF
--- a/docs/source/bonding_mixin.rst
+++ b/docs/source/bonding_mixin.rst
@@ -1,0 +1,6 @@
+BondingMixin
+^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: lnst.Recipes.ENRT.BondingMixin.BondingMixin
+    :members:
+    :show-inheritance:

--- a/docs/source/config_mixin_classes/use_vfs_mixin.rst
+++ b/docs/source/config_mixin_classes/use_vfs_mixin.rst
@@ -1,0 +1,6 @@
+UseVfsMixin
+================
+
+.. autoclass:: lnst.Recipes.ENRT.UseVfsMixin.UseVfsMixin
+    :members:
+    :show-inheritance:

--- a/docs/source/config_mixins.rst
+++ b/docs/source/config_mixins.rst
@@ -15,3 +15,4 @@ ENRT Config Mixins
     config_mixin_classes/perf_reverse_mixin.rst
     config_mixin_classes/disable_turboboost_mixin.rst
     config_mixin_classes/disable_idlestates_mixin.rst
+    config_mixin_classes/use_vfs_mixin.rst

--- a/docs/source/specific_scenarios.rst
+++ b/docs/source/specific_scenarios.rst
@@ -7,6 +7,7 @@ Specific ENRT scenarios
     team_recipe
     vlans_recipe
     vlans_over_bond_recipe
+    ipsec_esp_aead_recipe
     gre_tunnel_recipe
     gre_lwt_tunnel_recipe
     gre_ovs_tunnel_recipe

--- a/lnst/Recipes/ENRT/BondRecipe.py
+++ b/lnst/Recipes/ENRT/BondRecipe.py
@@ -218,3 +218,7 @@ class BondRecipe(BondingMixin, PerfReversibleFlowMixin, CommonHWSubConfigMixin, 
         """
         return [self.matched.host1.eth0, self.matched.host1.eth1,
             self.matched.host2.eth0]
+
+    @property
+    def vf_trust_dev_list(self):
+        return [self.matched.host1.eth0, self.matched.host1.eth1]

--- a/lnst/Recipes/ENRT/BondingMixin.py
+++ b/lnst/Recipes/ENRT/BondingMixin.py
@@ -1,0 +1,124 @@
+from lnst.Common.Parameters import (
+    IntParam,
+    StrParam,
+    ChoiceParam,
+)
+from lnst.Devices import RemoteDevice, BondDevice
+from lnst.Controller.Recipe import RecipeError
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
+
+
+class BondingMixin:
+    """
+    The recipe mixin provides additional recipe parameters to configure the
+    bonding device.
+
+        :param bonding_mode:
+            (mandatory test parameter) the bonding mode to be configured on
+            the bond0 device.
+        :param miimon_value:
+            (mandatory test parameter) the miimon interval to be configured
+            on the bond0 device.
+        :param fail_over_mac:
+            the fail_over_mac mode to be configured on the bond0 device.
+    """
+    bonding_mode = StrParam(mandatory=True)
+    miimon_value = IntParam(mandatory=True)
+    fail_over_mac = ChoiceParam(
+        StrParam, choices={"none", "active", "follow"}, default="none"
+    )
+
+    def create_bond_devices(
+        self,
+        config: EnrtConfiguration,
+        bond_devices_specs: dict[str: dict[str: list[RemoteDevice]]] = {}
+    ) -> None:
+        """
+        The derived class should call:
+
+        .. code-block:: none
+
+            config = super().test_wide_configuration()
+            self.create_bond_devices(
+                config,
+                {
+                    "host1": {
+                        "bond0": [host1.nic1, host1.nic2]
+                    },
+                    "host2": {
+                        "bond0": [host2.nic1, host2.nic2]
+                    }
+                }
+            )
+
+        That would create bonding devices accessible by `host1.bond0` and `host2.bond0`.
+
+        `host1.bond0` would be created with ports `host1.nic1` and `host1.nic2` and
+        `host2.bond0` with ports `host2.nic1` and `host2.nic2`.
+        """
+        device_params = dict(
+            mode=self.params.bonding_mode,
+            miimon=self.params.miimon_value,
+        )
+
+        if self.params.bonding_mode in ["active-backup", "1"]:
+            device_params["fail_over_mac"] = self.params.fail_over_mac
+
+        config.bonding_config = {}
+        for host_str, spec in bond_devices_specs.items():
+            for bond_dev_name, bonded_devices in spec.items():
+                try:
+                    host = getattr(self.matched, host_str)
+                except AttributeError:
+                    raise RecipeError(
+                        f"Bond device specification contains unknown host {host_str}"
+                    )
+
+                if any([dev.host.hostid != host_str for dev in bonded_devices]):
+                    raise RecipeError(
+                        f"Attempt to create bond device on host {host_str} with some ports that are not available on the host, ports: {bonded_devices}"
+                    )
+
+                setattr(host, bond_dev_name, BondDevice(**device_params))
+                bond_device = getattr(host, bond_dev_name)
+                for dev in bonded_devices:
+                    dev.down()
+                    bond_device.slave_add(dev)
+
+                config.bonding_config.setdefault("bond_devices", []).append(bond_device)
+
+    def test_wide_deconfiguration(self, config):
+        config.bonding_config.clear()
+
+    def generate_test_wide_description(self, config: EnrtConfiguration):
+        desc = super().generate_test_wide_description(config)
+        bond_devices = config.bonding_config["bond_devices"]
+        for dev in bond_devices:
+            desc += [
+                "\n".join(
+                    [
+                        "Configured {}.{}.ports = {}".format(
+                            dev.host.hostid, dev.name,
+                            ['.'.join([dev.host.hostid, port.name])
+                             for port in dev.slaves]
+                        )
+                    ],
+                ),
+                "Configured {}.{}.mode = {}".format(
+                    dev.host.hostid, dev.name,
+                    dev.mode
+                ),
+                "Configured {}.{}.miimon = {}".format(
+                    dev.host.hostid, dev.name,
+                    dev.miimon
+                ),
+            ]
+
+            if dev.mode == 1:
+                desc += [
+                    "Configured {}.{}.fail_over_mac = {}".format(
+                        dev.host.hostid, dev.name, dev.fail_over_mac
+                    )
+                ]
+
+        return desc

--- a/lnst/Recipes/ENRT/DoubleBondRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleBondRecipe.py
@@ -129,3 +129,8 @@ class DoubleBondRecipe(BondingMixin, CommonHWSubConfigMixin, OffloadSubConfigMix
     def parallel_stream_qdisc_hw_config_dev_list(self):
         host1, host2 = self.matched.host1, self.matched.host2
         return [host1.eth0, host1.eth1, host2.eth0, host2.eth1]
+
+    @property
+    def vf_trust_dev_list(self):
+        host1, host2 = self.matched.host1, self.matched.host2
+        return [host1.eth0, host1.eth1, host2.eth0, host2.eth1]

--- a/lnst/Recipes/ENRT/UseVfsMixin.py
+++ b/lnst/Recipes/ENRT/UseVfsMixin.py
@@ -1,6 +1,7 @@
-from lnst.Common.Parameters import BoolParam
+from lnst.Common.Parameters import BoolParam, ChoiceParam
 from lnst.Controller.Requirements import DeviceReq
 from lnst.Recipes.ENRT.SRIOVDevices import SRIOVDevices
+from lnst.Devices import RemoteDevice
 
 
 class UseVfsMixin:
@@ -12,11 +13,19 @@ class UseVfsMixin:
     with VF Device instances. This allows user to interact with the network
     interfaces without additional changes to the code of recipe.
 
+    Mixin provides two parameters:
+
+    :param use_vfs:
+        main boolean parameter to enable or disable (default) use of VFs
+    :param vf_trust:
+        (optional) set the trust parameter of the used VFs, 'on' or 'off'
+
     There are some limitations, for example pause frames cannot be configured
     since the VF do not support these.
     """
 
     use_vfs = BoolParam(default=False)
+    vf_trust = ChoiceParam(choices={'on', 'off'})
 
     def test_wide_configuration(self):
         config = super().test_wide_configuration()
@@ -33,11 +42,22 @@ class UseVfsMixin:
             for dev_name in dev_names:
                 dev = getattr(host, dev_name)
                 sriov_devices = SRIOVDevices(dev, 1)
+
                 vf_dev = sriov_devices.vfs[0]
                 host.map_device(dev_name, {"ifname": vf_dev.name})
 
-                host_config = config.vf_config.setdefault(host, [])
-                host_config.append(sriov_devices)
+                host_vf_config = config.vf_config.setdefault(host, [])
+                host_vf_config.append(sriov_devices)
+
+        if self.params.get("vf_trust"):
+            for vf_dev in self.vf_trust_dev_list:
+                vf_phys_dev = [
+                    sriov_devices.phys_dev
+                    for sriov_devices_list in config.vf_config.values()
+                    for sriov_devices in sriov_devices_list
+                    if vf_dev in sriov_devices.vfs][0]
+
+                vf_phys_dev.vf_trust = {0: self.params.vf_trust}
 
         return config
 
@@ -49,6 +69,8 @@ class UseVfsMixin:
                     host.map_device(vf_dev._id, {"ifname": sriov_devices.phys_dev.name})
                     sriov_devices.phys_dev.delete_vfs()
 
+        config.vf_config = {}
+
         super().test_wide_deconfiguration(config)
 
     def generate_test_wide_description(self, config):
@@ -56,10 +78,19 @@ class UseVfsMixin:
 
         if self.params.use_vfs:
             description += [
-                f"Using vf device {vf_dev.name} of pf {sriov_devices.phys_dev.name} for DeviceReq {host.hostid}.{vf_dev._id}"
+                f"Using vf device {vf_dev.name} of pf {sriov_devices.phys_dev.name} for DeviceReq {host.hostid}.{vf_dev._id}" + (f" trusted={sriov_devices.phys_dev.vf_trust[0]}" if vf_dev in self.vf_trust_dev_list and sriov_devices.phys_dev.vf_trust.get(0) else "")
                 for host, sriov_devices_list in config.vf_config.items()
                 for sriov_devices in sriov_devices_list
                 for vf_dev in sriov_devices.vfs
             ]
 
         return description
+
+    @property
+    def vf_trust_dev_list(self) -> list[RemoteDevice]:
+        """
+        The property defines a list of devices for which the :py:attr:`vf_trust` setting
+        should be applied. The mixin will automatically resolve the VF devices
+        specified in the list to physical device and virtual function.
+        """
+        return []

--- a/lnst/Recipes/ENRT/VlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverBondRecipe.py
@@ -285,3 +285,7 @@ class VlansOverBondRecipe(BondingMixin, PerfReversibleFlowMixin, VlanPingEvaluat
         """
         host1, host2 = self.matched.host1, self.matched.host2
         return [host1.eth0, host1.eth1, host2.eth0]
+
+    @property
+    def vf_trust_dev_list(self):
+        return [self.matched.host1.eth0, self.matched.host1.eth1]


### PR DESCRIPTION
### Description

This replaces original messed up PR https://github.com/LNST-project/lnst/pull/379

This adds vf_trust parameter to UseVfsMixin. The Device class is extended with vf_trust() method.
Tests

This also updates BondRecipe, VlansOverBondRecipe and DoubleBondRecipe with fail_over_mac. To avoid code duplication I refactored these classes to us new BondingMixin class that adds the common bonding recipe parameters and provides a method to create the bonding devices.

J:10034309

Reviews

@olichtne