### PR TITLE
Fix iperf no connection and PerfResult warmup timestamp calculation

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
@@ -209,7 +209,7 @@ class IperfFlowMeasurement(BaseFlowMeasurement):
     def _parse_job_streams(self, job):
         result = ParallelPerfResult()
         if not job.passed:
-            result.append(PerfInterval(0, 0, "bits", time.time()))
+            result.append(SequentialPerfResult([PerfInterval(0, 1, "bits", time.time())]))
         else:
             for i in job.result["data"]["end"]["streams"]:
                 result.append(SequentialPerfResult())

--- a/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
@@ -225,7 +225,7 @@ class IperfFlowMeasurement(BaseFlowMeasurement):
 
     def _parse_job_cpu(self, job):
         if not job.passed:
-            return PerfInterval(0, 0, "cpu_percent", time.time())
+            return PerfInterval(0, 1, "cpu_percent", time.time())
         else:
             cpu_percent = job.result["data"]["end"]["cpu_utilization_percent"]["host_total"]
             job_start = job.result["data"]["start"]["timestamp"]["timesecs"]

--- a/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
@@ -200,8 +200,8 @@ class NeperFlowMeasurement(BaseFlowMeasurement):
         cpu_results = SequentialPerfResult()
 
         if not job.passed:
-            results.append(PerfInterval(0, 0, "transactions", time.time()))
-            cpu_results.append(PerfInterval(0, 0, "cpu_percent", time.time()))
+            results.append(PerfInterval(0, 1, "transactions", time.time()))
+            cpu_results.append(PerfInterval(0, 1, "cpu_percent", time.time()))
         elif job.what.is_crr_server():
             # Neper doesn't support server stats for tcp_crr due to memory issues.
             # Use perf_interval of 0.

--- a/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
@@ -84,33 +84,11 @@ class FlowMeasurementResults(BaseMeasurementResults):
 
     @property
     def warmup_end(self):
-        if self.warmup_duration == 0:
-            return self.start_timestamp
-
-        return max(
-            [
-                parallel[self.warmup_duration - 1].end_timestamp
-                for parallel in (
-                    *self.generator_results,
-                    *self.receiver_results,
-                )
-            ]
-        )
+        return self.start_timestamp+self.warmup_duration
 
     @property
     def warmdown_start(self):
-        if self.warmup_duration == 0:
-            return self.end_timestamp
-
-        return min(
-            [
-                parallel[-self.warmup_duration].start_timestamp
-                for parallel in (
-                    *self.generator_results,
-                    *self.receiver_results,
-                )
-            ]
-        )
+        return self.end_timestamp-self.warmup_duration
 
     def time_slice(self, start, end):
         result_copy = FlowMeasurementResults(

--- a/lnst/RecipeCommon/Perf/Measurements/Results/NeperFlowMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/NeperFlowMeasurementResults.py
@@ -12,7 +12,7 @@ class NeperFlowMeasurementResults(FlowMeasurementResults):
 
         return max(
             [
-                parallel[self.warmup_duration - 1].end_timestamp
+                parallel.start_timestamp + self.warmup_duration
                 for parallel in self.generator_results
             ]
         )
@@ -27,7 +27,7 @@ class NeperFlowMeasurementResults(FlowMeasurementResults):
 
         return min(
             [
-                parallel[-self.warmup_duration].start_timestamp
+                parallel.end_timestamp - self.warmup_duration
                 for parallel in self.generator_results
             ]
         )

--- a/lnst/RecipeCommon/Perf/Measurements/TRexFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TRexFlowMeasurement.py
@@ -173,10 +173,10 @@ class TRexFlowMeasurement(BaseFlowMeasurement):
 
         if not job.passed:
             timestamp = time.time()
-            results.generator_results.append(PerfInterval(0, 0, "packets", timestamp))
-            results.generator_cpu_stats.append(PerfInterval(0, 0, "cpu_percent", timestamp))
-            results.receiver_results.append(PerfInterval(0, 0, "packets", timestamp))
-            results.receiver_cpu_stats.append(PerfInterval(0, 0, "cpu_percent", timestamp))
+            results.generator_results.append(PerfInterval(0, 1, "packets", timestamp))
+            results.generator_cpu_stats.append(PerfInterval(0, 1, "cpu_percent", timestamp))
+            results.receiver_results.append(PerfInterval(0, 1, "packets", timestamp))
+            results.receiver_cpu_stats.append(PerfInterval(0, 1, "cpu_percent", timestamp))
         else:
             prev_time = job.result["start_time"]
             prev_tx_val = 0


### PR DESCRIPTION
### Description
This should fix the issues we regularly see with lnst crashing with exception when iperf failed to establish a connection. The source of the issue is that the created perf result data structure was slightly different.

While testing this I also found issues with the warmup/warmdown timestamp calculation because the zero created zero iperf measurements don't have a duration long enough to include a warmup/warmdown... this however shouldn't crash the trimming and should instead return another zero measurement.

### Tests
(Please provide a list of tests that prove that the pull
request doesn't break the stable state of the master branch. This should
include test runs with valid results for all of critical workflows.)

### Reviews
@jtluka @enhaut @Axonis 

Closes: #
