### PR TITLE
Added XDP tx recipe

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -27,13 +27,26 @@ from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import BaseFlowMeas
 
 
 class XDPBenchMeasurement(BaseFlowMeasurement):
-    def __init__(self, flows: list[Flow], xdp_command: str, recipe_conf=None):
+    def __init__(
+        self,
+        flows: list[Flow],
+        xdp_command: str,
+        xdp_mode: str,
+        xdp_load_mode: str = None,
+        xdp_packet_operation: str = None,
+        xdp_remote_action: str = None,
+        recipe_conf=None,
+    ):
         super().__init__(recipe_conf)
         self._flows = flows
         self._running_measurements = []
         self._finished_measurements = []
 
         self.command = xdp_command
+        self.mode = xdp_mode
+        self.load_mode = xdp_load_mode
+        self.packet_operation = xdp_packet_operation
+        self.remote_action = xdp_remote_action
 
     def version(self):
         return 1.0
@@ -65,6 +78,10 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
     def _prepare_server(self, flow: Flow):
         params = {
             "command": self.command,
+            "xdp_mode": self.mode,
+            "load_mode": self.load_mode,
+            "packet_operation": self.packet_operation,
+            "remote_action": self.remote_action,
             "interface": flow.receiver_nic,
             "duration": flow.duration + flow.warmup_duration * 2,
         }

--- a/lnst/Recipes/ENRT/MeasurementGenerators/XDPFlowMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/XDPFlowMeasurementGenerator.py
@@ -4,11 +4,25 @@ from lnst.Recipes.ENRT.MeasurementGenerators.BaseFlowMeasurementGenerator import
     BaseFlowMeasurementGenerator,
 )
 
-from lnst.Tests.XDPBench import XDP_BENCH_COMMANDS
+from lnst.Tests.XDPBench import (
+    XDP_BENCH_COMMANDS,
+    XDP_MODES,
+    XDP_LOAD_MODES,
+    XDP_PACKET_OPERATIONS,
+    XDP_REMOTE_ACTIONS,
+)
 
 
 class XDPFlowMeasurementGenerator(BaseFlowMeasurementGenerator):
     xdp_command = ChoiceParam(type=StrParam, choices=XDP_BENCH_COMMANDS)
+    xdp_mode = ChoiceParam(type=StrParam, choices=XDP_MODES, default="native")
+    xdp_load_mode = ChoiceParam(type=StrParam, choices=XDP_LOAD_MODES, default="")
+    xdp_packet_operation = ChoiceParam(
+        type=StrParam, choices=XDP_PACKET_OPERATIONS, default=""
+    )
+    xdp_remote_action = ChoiceParam(
+        type=StrParam, choices=XDP_REMOTE_ACTIONS, default=""
+    )
 
     @property
     def net_perf_tool_class(self):
@@ -25,7 +39,15 @@ class XDPFlowMeasurementGenerator(BaseFlowMeasurementGenerator):
         [1] https://github.com/LNST-project/lnst/pull/310#discussion_r1305763175
         """
         def XDPBenchMeasurement_partial(*args, **kwargs):
-            return XDPBenchMeasurement(*args, self.params.xdp_command, **kwargs)
+            return XDPBenchMeasurement(
+                *args,
+                self.params.xdp_command,
+                self.params.xdp_mode,
+                self.params.xdp_load_mode,
+                self.params.xdp_packet_operation,
+                self.params.xdp_remote_action,
+                **kwargs
+            )
 
         return XDPBenchMeasurement_partial
 

--- a/lnst/Recipes/ENRT/XDPTxRecipe.py
+++ b/lnst/Recipes/ENRT/XDPTxRecipe.py
@@ -1,0 +1,17 @@
+from lnst.Common.Parameters import ConstParam
+from lnst.Recipes.ENRT.ConfigMixins.MultiDevInterruptHWConfigMixin import (
+    MultiDevInterruptHWConfigMixin,
+)
+from lnst.Recipes.ENRT.SimpleNetworkRecipe import SimpleNetworkRecipe
+from lnst.Recipes.ENRT.MeasurementGenerators.XDPFlowMeasurementGenerator import (
+    XDPFlowMeasurementGenerator,
+)
+
+
+class XDPTxRecipe(
+    XDPFlowMeasurementGenerator, MultiDevInterruptHWConfigMixin, SimpleNetworkRecipe
+):
+    xdp_command = ConstParam(value="tx")
+    # NOTE: Receiver's IRQs needs to be pinned to single CPU (due to test stability)
+    # Generator needs to reach line rate, therefore its' IRQ CPUs should not be limited.
+    # Simply use `multi_dev_interrupt_config` with single host.

--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -112,6 +112,7 @@ from lnst.Recipes.ENRT.BaseLACPRecipe import BaseLACPRecipe
 from lnst.Recipes.ENRT.DellLACPRecipe import DellLACPRecipe
 from lnst.Recipes.ENRT.SoftwareRDMARecipe import SoftwareRDMARecipe
 from lnst.Recipes.ENRT.XDPDropRecipe import XDPDropRecipe
+from lnst.Recipes.ENRT.XDPTxRecipe import XDPTxRecipe
 from lnst.Recipes.ENRT.CTInsertionRateNftablesRecipe import CTInsertionRateNftablesRecipe
 from .CTFulltableInsertionRateRecipe import CTFulltableInsertionRateRecipe
 from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe

--- a/lnst/Tests/XDPBench.py
+++ b/lnst/Tests/XDPBench.py
@@ -63,7 +63,7 @@ class XDPBenchOutputParser:
         return results
 
     def _parse_line(self, line: str) -> tuple:
-        match = re.search(r"Summary\s+([\d,]+)\srx/s\s+([\d,]+)\serr/s?", line)
+        match = re.search(r"Summary\s+([\d,]+)\srx/s\s+([\d,]+)\serr(,drop)?/s?", line)
 
         if not match:  # skip summary line at the end + corrupted lines
             raise ValueError("Invalid line format")

--- a/lnst/Tests/XDPBench.py
+++ b/lnst/Tests/XDPBench.py
@@ -85,6 +85,11 @@ XDP_BENCH_COMMANDS = (
     "redirect-multi",
 )
 
+XDP_MODES = ("native", "skb")
+XDP_LOAD_MODES = ("dpa", "load-bytes", "")
+XDP_PACKET_OPERATIONS = ("no-touch", "read-data", "parse-ip", "swap-macs", "")
+XDP_REMOTE_ACTIONS = ("disabled", "drop", "pass", "redirect", "")
+
 
 class XDPBench(BaseTestModule):
     """
@@ -108,15 +113,13 @@ class XDPBench(BaseTestModule):
     interval = IntParam(default=1)
 
     redirect_device = DeviceParam()
-    xdp_mode = ChoiceParam(type=StrParam, choices=("native", "skb"), default="native")
-    load_mode = ChoiceParam(type=StrParam, choices=("dpa", "load-bytes"))
+    xdp_mode = ChoiceParam(type=StrParam, choices=XDP_MODES, default="native")
+    load_mode = ChoiceParam(type=StrParam, choices=XDP_LOAD_MODES)
     packet_operation = ChoiceParam(
-        type=StrParam, choices=("no-touch", "read-data", "parse-ip", "swap-macs")
-    )
+        type=StrParam, choices=XDP_PACKET_OPERATIONS)
     qsize = IntParam()
     remote_action = ChoiceParam(
-        type=StrParam, choices=("disabled", "drop", "pass", "redirect")
-    )
+        type=StrParam, choices=XDP_REMOTE_ACTIONS)
 
     # NOTE: order and names of params above matters. xdp-bench accepts params in that way
     duration = IntParam(default=60, mandatory=True)
@@ -146,6 +149,9 @@ class XDPBench(BaseTestModule):
     def _prepare_arguments(self):
         args = []
         for param, value in self.params:
+            if value == "":
+                continue  # skip empty (default) values
+
             if param == "duration":
                 continue  # not a xdp-bench argument
 


### PR DESCRIPTION
### Description
* exported parameters of `XDPBench` test tool to measurement
* added XDP tx test
  The test measures how fast the CPU can read an incoming packet, swap MACs and send it back using the same NIC. It's basically hairpinning

### Tests

Functional test ox xdp drop + xdp tx recipes in `J:10038813`

