### PR TITLE
always deconfigure ENRT, multiple container nics in one network

### DIFF
--- a/.github/lnst_setup.sh
+++ b/.github/lnst_setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+echo Set up system requirements
+
+sudo apt-get update
+sudo apt-get install podman -y
+sudo systemctl enable --now podman.socket
+curl -sSL https://install.python-poetry.org | python3 - --version 1.3.1
+
+echo Set up Podman network requirements
+
+sudo sysctl -w net.ipv4.ip_forward=1
+sudo sysctl net.ipv4.conf.all.forwarding=1
+sudo iptables -P FORWARD ACCEPT
+sudo sysctl -p
+
+echo Install LNST
+
+sudo apt-get install -y iputils-* \
+ethtool \
+gcc \
+python-dev \
+libxml2-dev \
+libxslt-dev \
+qemu-kvm \
+libvirt-daemon-system \
+libvirt-clients \
+bridge-utils \
+libvirt-dev \
+libnl-3-200 \
+libnl-route-3-dev \
+git \
+libnl-3-dev
+export PATH="/root/.local/bin:$PATH"
+poetry install -E "containers"
+
+echo Build LNST agents image
+sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile

--- a/.github/lnst_setup.sh
+++ b/.github/lnst_setup.sh
@@ -5,7 +5,7 @@ echo Set up system requirements
 sudo apt-get update
 sudo apt-get install podman -y
 sudo systemctl enable --now podman.socket
-curl -sSL https://install.python-poetry.org | python3 - --version 1.3.1
+curl -sSL https://install.python-poetry.org | python3 - --version 1.4.2
 
 echo Set up Podman network requirements
 
@@ -19,7 +19,7 @@ echo Install LNST
 sudo apt-get install -y iputils-* \
 ethtool \
 gcc \
-python-dev \
+python3-dev \
 libxml2-dev \
 libxslt-dev \
 qemu-kvm \

--- a/.github/runner.py
+++ b/.github/runner.py
@@ -28,7 +28,7 @@ ctl = Controller(
     podman_uri=podman_uri,
     image=image_name,
     debug=1,
-    network_plugin="cni",
+    network_plugin="custom_lnst",
 )
 
 recipe_instance = HelloWorldRecipe()

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -1,0 +1,115 @@
+import inspect
+import logging
+
+from lnst.Controller import Controller
+from lnst.Controller.ContainerPoolManager import ContainerPoolManager
+from lnst.Controller.MachineMapper import ContainerMapper
+from lnst.Recipes.ENRT.BaseEnrtRecipe import BaseEnrtRecipe
+from lnst.Recipes.ENRT.BondingMixin import BondingMixin
+from lnst.Recipes.ENRT.BaseSRIOVNetnsTcRecipe import BaseSRIOVNetnsTcRecipe
+from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import OffloadSubConfigMixin
+
+import lnst.Recipes.ENRT as enrt_recipes
+
+podman_uri = "unix:///run/podman/podman.sock"
+image_name = "lnst"
+
+params_base = dict(
+    perf_tests=['tcp_stream'],
+    perf_duration=5,
+    perf_iterations=2,
+    perf_warmup_duration=0,
+    ping_count=1,
+    perf_test_simulation=True,
+)
+
+i = 0
+recipe_results = {}
+for recipe_name in dir(enrt_recipes):
+    if recipe_name in ["BaseEnrtRecipe", "BaseTunnelRecipe", "BaseLACPRecipe", "DellLACPRecipe", "BaseSRIOVNetnsTcRecipe"]:
+        continue
+    elif "Ovs" in recipe_name or "OvS" in recipe_name:
+        # ovs can't run without systemd service so containers don't work correctly
+        continue
+    elif recipe_name == "SimpleNetworkTunableRecipe":
+        # veth doesn't support hash functions
+        continue
+    elif "Team" in recipe_name:
+        # teaming has some unexplained issues right now
+        # TODO check?
+        continue
+    elif recipe_name in ["L2TPTunnelRecipe"]:
+        continue
+
+    recipe = getattr(enrt_recipes, recipe_name)
+
+    if not (inspect.isclass(recipe) and issubclass(recipe, BaseEnrtRecipe)):
+        continue
+    elif issubclass(recipe, BaseSRIOVNetnsTcRecipe):
+        # veth doesn't support sriov
+        continue
+
+    i += 1
+
+    params = params_base.copy()
+
+    if issubclass(recipe, BondingMixin) or recipe_name in[ "GreTunnelOverBondRecipe", "LinuxBridgeOverBondRecipe", "TeamVsBondRecipe", "VirtualBridgeVlansOverBondRecipe", "VlansOverBondRecipe"]:
+        params["bonding_mode"] = "active-backup"
+        params["miimon_value"] = 5
+    elif issubclass(recipe, enrt_recipes.TeamRecipe) or issubclass(recipe, enrt_recipes.DoubleTeamRecipe):
+        params["runner_name"] = "activebackup"
+    elif recipe_name.startswith("CT"):
+        del params["perf_tests"]
+        if "CTFulltableInsertionRateRecipe" in recipe_name:
+            params["long_lived_conns"] = 10000
+    elif recipe_name == "SoftwareRDMARecipe":
+        del params["perf_tests"]
+    elif recipe_name == "ShortLivedConnectionsRecipe":
+        del params["perf_tests"]
+
+    if recipe_name in ["GeneveLwtTunnelRecipe", "GreLwtTunnelRecipe", "L2TPTunnelRecipe", "VxlanLwtTunnelRecipe", "GeneveTunnelRecipe", "VxlanGpeTunnelRecipe"]:
+        params["carrier_ipversion"] = "ipv4"
+
+    if recipe_name in ["SitTunnelRecipe", "IpIpTunnelRecipe"]:
+        params["tunnel_mode"] = "any"
+    if recipe_name in ["Ip6TnlTunnelRecipe"]:
+        params["tunnel_mode"] = "ip6ip6"
+
+    if recipe_name == "SoftwareRDMARecipe":
+        params["software_rdma_type"] = "rxe"
+
+    if recipe_name in ["XDPDropRecipe", "XDPTxRecipe"]:
+        params["multi_dev_interrupt_config"] = {
+            "host1": {"eth0": {"cpus": [0], "cpu_policy": "round-robin"}},
+            "host2": {"eth0": {"cpus": [0], "cpu_policy": "round-robin"}},
+        }
+        params["perf_tool_cpu"] = [0]
+
+    if issubclass(recipe, OffloadSubConfigMixin):
+        params['offload_combinations'] = []
+
+    try:
+        recipe_instance = recipe(**params)
+
+        print(f"-----------------------------{recipe_name} {i}START---------------------------")
+        ctl = Controller(
+            poolMgr=ContainerPoolManager,
+            mapper=ContainerMapper,
+            podman_uri=podman_uri,
+            image=image_name,
+            debug=1,
+            network_plugin="custom_lnst"
+        )
+        ctl.run(recipe_instance)
+
+        overall_result = all([run.overall_result for run in recipe_instance.runs])
+        recipe_results[recipe_name] = "PASS" if overall_result else "FAIL"
+    except Exception as e:
+        logging.exception(f"Recipe {recipe_name} crashed with exception.")
+        recipe_results[recipe_name] = f"EXCEPTION: {e}"
+
+print("Recipe run results:")
+for recipe_name, result in recipe_results.items():
+    print(recipe_name, result)
+
+exit(any(result.startswith("EXCEPTION") for result in recipe_results.values()))

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   FunctionalTest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Python
@@ -29,7 +29,7 @@ jobs:
         sudo "$venv_path"/bin/python3 .github/runner.py
 
   ENRT_All_Test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Python
@@ -50,7 +50,7 @@ jobs:
         sudo "$venv_path"/bin/python3 .github/runner_all_enrt.py
 
   ImportsCheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install pylint3
+          sudo apt-get install pylint
 
       - name: Imports check
         run: |

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -19,43 +19,8 @@ jobs:
     - name: Source branch checkout
       uses: actions/checkout@v2
 
-    - name: Set up system requirements
-      run: |
-        sudo apt-get update
-        sudo apt-get install podman -y
-        sudo systemctl enable --now podman.socket
-        curl -sSL https://install.python-poetry.org | python3 - --version 1.3.1
-
-    - name: Set up Podman network requirements
-      run: |
-        sudo sysctl -w net.ipv4.ip_forward=1
-        sudo sysctl net.ipv4.conf.all.forwarding=1
-        sudo iptables -P FORWARD ACCEPT
-        sudo sysctl -p
-
-    - name: Install LNST
-      run: |
-        sudo apt-get install -y iputils-* \
-        ethtool \
-        gcc \
-        python-dev \
-        libxml2-dev \
-        libxslt-dev \
-        qemu-kvm \
-        libvirt-daemon-system \
-        libvirt-clients \
-        bridge-utils \
-        libvirt-dev \
-        libnl-3-200 \
-        libnl-route-3-dev \
-        git \
-        libnl-3-dev
-        export PATH="/root/.local/bin:$PATH"
-        poetry install -E "containers"
-
-    - name: Build LNST agents image
-      run: |
-        sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile
+    - name: LNST Setup
+      run: bash .github/lnst_setup.sh
 
     - name: SimpleNetworkRecipe ping test
       run: |
@@ -75,43 +40,8 @@ jobs:
     - name: Source branch checkout
       uses: actions/checkout@v2
 
-    - name: Set up system requirements
-      run: |
-        sudo apt-get update
-        sudo apt-get install podman -y
-        sudo systemctl enable --now podman.socket
-        curl -sSL https://install.python-poetry.org | python3 - --version 1.3.1
-
-    - name: Set up Podman network requirements
-      run: |
-        sudo sysctl -w net.ipv4.ip_forward=1
-        sudo sysctl net.ipv4.conf.all.forwarding=1
-        sudo iptables -P FORWARD ACCEPT
-        sudo sysctl -p
-
-    - name: Install LNST
-      run: |
-        sudo apt-get install -y iputils-* \
-        ethtool \
-        gcc \
-        python-dev \
-        libxml2-dev \
-        libxslt-dev \
-        qemu-kvm \
-        libvirt-daemon-system \
-        libvirt-clients \
-        bridge-utils \
-        libvirt-dev \
-        libnl-3-200 \
-        libnl-route-3-dev \
-        git \
-        libnl-3-dev
-        export PATH="/root/.local/bin:$PATH"
-        poetry install -E "containers"
-
-    - name: Build LNST agents image
-      run: |
-        sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile
+    - name: LNST Setup
+      run: bash .github/lnst_setup.sh
 
     - name: Run all ENRT recipes
       run: |

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -63,6 +63,62 @@ jobs:
         venv_path=$(poetry env info -p)
         sudo "$venv_path"/bin/python3 .github/runner.py
 
+  ENRT_All_Test:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.9"
+
+    - name: Source branch checkout
+      uses: actions/checkout@v2
+
+    - name: Set up system requirements
+      run: |
+        sudo apt-get update
+        sudo apt-get install podman -y
+        sudo systemctl enable --now podman.socket
+        curl -sSL https://install.python-poetry.org | python3 - --version 1.3.1
+
+    - name: Set up Podman network requirements
+      run: |
+        sudo sysctl -w net.ipv4.ip_forward=1
+        sudo sysctl net.ipv4.conf.all.forwarding=1
+        sudo iptables -P FORWARD ACCEPT
+        sudo sysctl -p
+
+    - name: Install LNST
+      run: |
+        sudo apt-get install -y iputils-* \
+        ethtool \
+        gcc \
+        python-dev \
+        libxml2-dev \
+        libxslt-dev \
+        qemu-kvm \
+        libvirt-daemon-system \
+        libvirt-clients \
+        bridge-utils \
+        libvirt-dev \
+        libnl-3-200 \
+        libnl-route-3-dev \
+        git \
+        libnl-3-dev
+        export PATH="/root/.local/bin:$PATH"
+        poetry install -E "containers"
+
+    - name: Build LNST agents image
+      run: |
+        sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile
+
+    - name: Run all ENRT recipes
+      run: |
+        export PATH="/root/.local/bin:$PATH"
+        venv_path=$(poetry env info -p)
+        sudo "$venv_path"/bin/python3 .github/runner_all_enrt.py
+
   ImportsCheck:
     runs-on: ubuntu-20.04
     steps:

--- a/container_files/agent/Dockerfile
+++ b/container_files/agent/Dockerfile
@@ -21,9 +21,10 @@ RUN dnf install -y initscripts \
     libnl3-devel \
     nftables \
     openvswitch \
-    teamd &&  \
+    teamd \
+    kernel-tools &&  \
     curl -sSL https://install.python-poetry.org |  \
-    python3 - --version 1.3.1
+    python3 - --version 1.4.2
 
 COPY . /lnst
 RUN cd /lnst/container_files/agent && chmod +x install.sh && sh install.sh

--- a/container_files/agent/Dockerfile
+++ b/container_files/agent/Dockerfile
@@ -18,7 +18,10 @@ RUN dnf install -y initscripts \
     perf \
     perftest \
     tcpdump \
-    libnl3-devel &&  \
+    libnl3-devel \
+    nftables \
+    openvswitch \
+    teamd &&  \
     curl -sSL https://install.python-poetry.org |  \
     python3 - --version 1.3.1
 

--- a/container_files/controller/Dockerfile
+++ b/container_files/controller/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y initscripts \
     git \
     libnl3-devel &&  \
     curl -sSL https://install.python-poetry.org |  \
-    python3 - --version 1.8.3
+    python3 - --version 1.4.2
 
 RUN mkdir -p /root/.lnst
 COPY . /lnst

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -45,12 +45,33 @@ The first requirement is **Podman**, follow installation steps on
 `official Podman installation page <https://podman.io/getting-started/installation>`_.
 
 
-Configure Podman to use CNI
-+++++++++++++++++++++++++++
+Container Networking
+--------------------
 
-If you use Podman 4.0+ you need to change default network backend from `netavark` to `CNI` as LNST supports CNI
-only. If your Podman is already running, stop it.
+LNST ContainerPoolManager supports 3 different plugins to generate the networks defined in Recipe Requirements.
 
+The first two plugins are podman native plugins `netavark` and `CNI`.
+
+The final plugin is the recently added `custom_lnst`. This plugin has no
+requirements on your system or it's configuration, it utilizes `ip-route`
+commands to build a network using `veth` and `bridge` interfaces manually. So
+the only requirement here is to run the recipe with root privileges.
+
+To select which plugin is used for networking you can change the value of the
+`network_plugin` argument when creating the `Controller` class:
+
+  .. code-block:: python
+
+    ctl = Controller(
+        poolMgr=ContainerPoolManager,
+        mapper=ContainerMapper,
+        network_plugin="custom_lnst",
+    )
+
+CNI system configuration
+````````````````````````
+
+To use `CNI` you may need to adjust the systemwide container configurations.
 
 1. Remove all the LNST's leftovers from `/etc/cni/net.d/lnst_*.conflist` if you already tried to run LNST
 
@@ -70,11 +91,10 @@ only. If your Podman is already running, stop it.
 
 4. Start your Podman instance
 
-
-Podman API is also required, follow the steps below:
-
 Enabling Podman API service:
 ++++++++++++++++++++++++++++
+
+Podman API is also required, follow the steps below:
 
 .. code-block:: bash
 
@@ -235,4 +255,3 @@ Classes documentation
 `````````````````````
 .. autoclass:: container_files.controller.container_runner.ContainerRunner
     :members:
-

--- a/lnst/Controller/ContainerPoolManager.py
+++ b/lnst/Controller/ContainerPoolManager.py
@@ -41,7 +41,7 @@ class ContainerPoolManager(object):
     :type image: str
 
     :param network_plugin:
-        Podman network plugin, 'cni' or 'netavark', if unset, the network backend is auto-detected
+        Podman network plugin, 'cni', 'netavark' or 'custom_lnst', if unset, the network backend is auto-detected
     :type network_plugin: Optional[str]
     """
 

--- a/lnst/Controller/MachineMapper.py
+++ b/lnst/Controller/MachineMapper.py
@@ -404,7 +404,7 @@ class ContainerMapper(object):
                     "hwaddr": machine_inf["params"]["hwaddr"],
                 }
 
-        for name, network in self._pool_manager.get_networks().items():
-            mapping["networks"][name] = network.name
+        for name in self._pool_manager.get_networks().keys():
+            mapping["networks"][name] = name
 
         yield mapping

--- a/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
@@ -91,6 +91,26 @@ class RDMABandwidthMeasurement(BaseFlowMeasurement):
         self._endpoint_tests.clear()
         return results
 
+    def collect_simulated_results(self) -> list[RDMABandwidthMeasurementResults]:
+        results: list[RDMABandwidthMeasurementResults] = []
+        for endpoint_test in self._endpoint_tests:
+            bandwidth = 0
+            duration = 1
+            result = RDMABandwidthMeasurementResults(
+                measurement=self,
+                measurement_success=True,
+                flow=endpoint_test.flow,
+            )
+            result.bandwidth = PerfInterval(
+                value=0,
+                duration=1,
+                unit="MiB",
+                timestamp=self._start_timestamp,
+            )
+            results.append(result)
+        self._endpoint_tests.clear()
+        return results
+
     def _prepare_endpoint_tests(self) -> list[NetworkFlowTest]:
         return [
             NetworkFlowTest(

--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -161,6 +161,37 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
             results.append(flow_results)
         return results
 
+    def collect_simulated_results(self):
+        test_flows = self._finished_measurements
+        res = []
+        for test_flow in test_flows:
+            flow_results = XDPBenchMeasurementResults(
+                measurement=self,
+                measurement_success=True,
+                flow=test_flow.flow,
+                warmup_duration=test_flow.flow.warmup_duration,
+            )
+            flow_results.generator_results = ParallelPerfResult(
+                [
+                    SequentialPerfResult(
+                        [PerfInterval(0, 1, "packets", time.time())]
+                        * (test_flow.flow.warmup_duration * 2 + test_flow.flow.duration)
+                    )
+                ]
+            )
+
+            flow_results.receiver_results = ParallelPerfResult(
+                [
+                    SequentialPerfResult(
+                        [PerfInterval(0, 1, "packets", time.time())]
+                        * (test_flow.flow.warmup_duration * 2 + test_flow.flow.duration)
+                    )
+                ]
+            )
+
+            res.append(flow_results)
+        return res
+
     def _parse_generator_results(self, job: Job):
         results = ParallelPerfResult()  # container for multiple instances of pktgen
 

--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -413,7 +413,8 @@ class BaseEnrtRecipe(
                     if not self.params.ping_parallel:
                         break
 
-                yield ping_conf_list
+                if ping_conf_list:
+                    yield ping_conf_list
 
     def generate_ping_endpoints(self, config):
         """Generator for ping endpoints

--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -211,20 +211,23 @@ class BaseEnrtRecipe(
 
     @contextmanager
     def _test_wide_context(self):
-        config = self.test_wide_configuration()
-        self.describe_test_wide_configuration(config)
+        config = EnrtConfiguration()
         try:
+            config = self.test_wide_configuration(config)
+            self.describe_test_wide_configuration(config)
             yield config
         finally:
             self.test_wide_deconfiguration(config)
 
-    def test_wide_configuration(self):
-        """Creates an empty :any:`EnrtConfiguration` object
+    def test_wide_configuration(self, config):
+        """Collaboratively builds an :any:`EnrtConfiguration` object
 
         This is again used in potential collaborative inheritance design that
-        may potentially be useful for Enrt recipes. Derived classes will each
-        individually add their own values to the instance created here. This way
-        the complete test wide configuration is tracked in a single object.
+        may potentially be useful for Enrt recipes. The initial empty
+        EnrtConfiguration object is created in the BaseEnrtRecipe
+        _test_wide_context method. Derived classes will each individually add
+        their own values to the instance created here. This way the complete
+        test wide configuration is tracked in a single object.
 
         :return: returns a config object that tracks the applied configuration
             that can be used during testing to inspect the current state and
@@ -234,15 +237,15 @@ class BaseEnrtRecipe(
         Example::
 
             class Derived:
-                def test_wide_configuration():
-                    config = super().test_wide_configuration()
+                def test_wide_configuration(config):
+                    config = super().test_wide_configuration(config)
 
                     # ... configure something
                     config.something = what_was_configured
 
                     return config
         """
-        return EnrtConfiguration()
+        return config
 
     def test_wide_deconfiguration(self, config):
         """Base deconfiguration method.
@@ -311,9 +314,9 @@ class BaseEnrtRecipe(
 
     @contextmanager
     def _sub_context(self, config):
-        self.apply_sub_configuration(config)
-        self.describe_sub_configuration(config)
         try:
+            self.apply_sub_configuration(config)
+            self.describe_sub_configuration(config)
             yield config
         finally:
             self.remove_sub_configuration(config)

--- a/lnst/Recipes/ENRT/BaseLACPRecipe.py
+++ b/lnst/Recipes/ENRT/BaseLACPRecipe.py
@@ -32,14 +32,14 @@ class BaseLACPRecipe(DoubleBondRecipe):
         """
         raise NotImplementedError()
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         This method is almost the same as DoubleBondRecipe.test_wide_configuration,
         however, it configures multiple IP addresses on the bond0 interface as well as
         it calls switch configuration method.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super(DoubleBondRecipe, self).test_wide_configuration()
+        config = super(DoubleBondRecipe, self).test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)

--- a/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
+++ b/lnst/Recipes/ENRT/BaseSRIOVNetnsTcRecipe.py
@@ -85,7 +85,7 @@ class BaseSRIOVNetnsTcRecipe(
     vf_net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     vf_net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves switching the device to switchdev
         mode, adding single VF and mapping the VF, as well as its representor.
@@ -102,7 +102,7 @@ class BaseSRIOVNetnsTcRecipe(
         The derived class can also override :method:`add_network_layers`.
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         # create virtual functions
         for host in [host1, host2]:

--- a/lnst/Recipes/ENRT/BaseTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/BaseTunnelRecipe.py
@@ -30,7 +30,7 @@ class BaseTunnelRecipe(
     * :meth:`get_packet_assert_config`
     """
 
-    def test_wide_configuration(self) -> EnrtConfiguration:
+    def test_wide_configuration(self, config) -> EnrtConfiguration:
         """
         The base class defines common steps to create the test wide
         configuration of a tunnel recipe.
@@ -40,7 +40,7 @@ class BaseTunnelRecipe(
         then the tunnel is created between the specified endpoints in
         :meth:`create_tunnel`.
         """
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
         config.tunnel_endpoints = self.configure_underlying_network(config)
         config.tunnel_devices = self.create_tunnel(config, config.tunnel_endpoints)
         self.wait_tentative_ips(config.configured_devices)

--- a/lnst/Recipes/ENRT/BondRecipe.py
+++ b/lnst/Recipes/ENRT/BondRecipe.py
@@ -65,7 +65,7 @@ class BondRecipe(BondingMixin, PerfReversibleFlowMixin, CommonHWSubConfigMixin, 
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves creating a bonding
         device using the two matched physical devices as slaves on host1.
@@ -78,7 +78,7 @@ class BondRecipe(BondingMixin, PerfReversibleFlowMixin, CommonHWSubConfigMixin, 
         """
 
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         self.create_bond_devices(
             config,

--- a/lnst/Recipes/ENRT/ConfigMixins/LongLivedConnectionsMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/LongLivedConnectionsMixin.py
@@ -47,12 +47,12 @@ class LongLivedConnectionsMixin(BasePerfTestTweakMixin):
     long_lived_conns_net4 = IPv4NetworkParam(default="192.168.102.0/24", mandatory=True)
     long_lived_conns_net6 = IPv6NetworkParam(default="fc01::/64", mandatory=True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
         host1.eth0.keep_addrs_on_down()
         host2.eth0.keep_addrs_on_down()
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
         # L4 can address up to 65535 ports (size of addresable space
         # defined in long_lived_conns_per_ip) Therefore opening connections
         # may require multiple IPs.

--- a/lnst/Recipes/ENRT/DoubleBondRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleBondRecipe.py
@@ -64,9 +64,9 @@ class DoubleBondRecipe(BondingMixin, CommonHWSubConfigMixin, OffloadSubConfigMix
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)

--- a/lnst/Recipes/ENRT/DoubleTeamRecipe.py
+++ b/lnst/Recipes/ENRT/DoubleTeamRecipe.py
@@ -39,9 +39,9 @@ class DoubleTeamRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin,
 
     runner_name = StrParam(mandatory=True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)

--- a/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAeadRecipe.py
@@ -61,7 +61,7 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
     spi_values = ["0x00001000", "0x00001001"]
     ipsec_mode = StrParam(default="transport")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves just adding an IPv4 and
         IPv6 address to the matched eth0 nics on both hosts and route between them.
@@ -72,7 +72,7 @@ class IpsecEspAeadRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
         """
         host1, host2 = self.matched.host1, self.matched.host2
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = {host1: interface_addresses(self.params.net1_ipv4),
                      host2: interface_addresses(self.params.net2_ipv4)}

--- a/lnst/Recipes/ENRT/IpsecEspAhCompRecipe.py
+++ b/lnst/Recipes/ENRT/IpsecEspAhCompRecipe.py
@@ -43,10 +43,10 @@ class IpsecEspAhCompRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe,
 
     spi_values = ["0x00000001", "0x00000002", "0x00000003", "0x00000004"]
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = {host1: interface_addresses(self.params.net1_ipv4),
                      host2: interface_addresses(self.params.net2_ipv4)}

--- a/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeOverBondRecipe.py
@@ -66,7 +66,7 @@ class LinuxBridgeOverBondRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin, B
     bonding_mode = StrParam(mandatory=True)
     miimon_value = IntParam(mandatory=True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves
         * creating a bonding device from the matched NICs
@@ -78,7 +78,7 @@ class LinuxBridgeOverBondRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin, B
         host2.br0 = 192.168.101.2/24 and fc00::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)

--- a/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
@@ -52,7 +52,7 @@ class LinuxBridgeRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin, Baremetal
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves adding the matched
         NICs into a Linux bridge and configuring an IPv4 and IPv6 address
@@ -63,7 +63,7 @@ class LinuxBridgeRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin, Baremetal
         host2.br0 = 192.168.101.2/24 and fc00::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)

--- a/lnst/Recipes/ENRT/MPTCPRecipe.py
+++ b/lnst/Recipes/ENRT/MPTCPRecipe.py
@@ -57,7 +57,7 @@ class MPTCPRecipe(
         for host in hosts:
             host.mptcp = host.init_class(MPTCPManager)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves just adding an IPv4 and
         IPv6 address to the matched eth0 nics on both hosts.
@@ -70,7 +70,7 @@ class MPTCPRecipe(
         host2.eth1 = 192.168.102.2/24 and fc01::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
         config.mptcp_endpoints = [host1.eth1]
         hosts = [host1, host2]
 

--- a/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/NoVirtOvsVxlanRecipe.py
@@ -20,9 +20,9 @@ class NoVirtOvsVxlanRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
 
     net_ipv4 = IPv4NetworkParam(default="192.168.2.0/24")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         host_addr = [next(ipv4_addr), next(ipv4_addr)]

--- a/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
+++ b/lnst/Recipes/ENRT/OvSDPDKBondRecipe.py
@@ -145,7 +145,7 @@ class OvSDPDKBondRecipe(BaseEnrtRecipe):
     cpu_perf_tool = Param(default=StatCPUMeasurement)
     net_perf_tool = Param(default=TRexFlowMeasurement)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves adding an IPv4 and
         IPv6 address to the matched eth0 and eth1 nics on both hosts.
@@ -201,7 +201,7 @@ class OvSDPDKBondRecipe(BaseEnrtRecipe):
                 nics=["vhost0", "vhost1"]),
             bg=True)
 
-        configuration = super().test_wide_configuration()
+        configuration = super().test_wide_configuration(config)
         return configuration
 
     def ovs_dpdk_bridge_configuration(self, host):

--- a/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
+++ b/lnst/Recipes/ENRT/SRIOVNetnsOvSRecipe.py
@@ -84,7 +84,7 @@ class SRIOVNetnsOvSRecipe(
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves switching the device to switchdev
         mode, adding single VF and mapping the VF, as well as its representor.
@@ -98,7 +98,7 @@ class SRIOVNetnsOvSRecipe(
         host2.eth0 = 192.168.101.2/24 and fc00::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)

--- a/lnst/Recipes/ENRT/ShortLivedConnectionsRecipe.py
+++ b/lnst/Recipes/ENRT/ShortLivedConnectionsRecipe.py
@@ -32,10 +32,10 @@ class ShortLivedConnectionsRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
     ip_versions = Param(default=("ipv4",))
     perf_msg_sizes = ListParam(default=[1000, 5000, 7000, 10000, 12000])
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.101.10/24")
         for host in [host1, host2]:

--- a/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleMacsecRecipe.py
@@ -31,9 +31,9 @@ class SimpleMacsecRecipe(CommonHWSubConfigMixin, BaremetalEnrtRecipe):
     keys = ["7a16780284000775d4f0a3c0f0e092c0",
         "3212ef5c4cc5d0e4210b17208e88779e"]
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         config.endpoint1 = host1.eth0
         config.endpoint2 = host2.eth0

--- a/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
+++ b/lnst/Recipes/ENRT/SimpleNetworkRecipe.py
@@ -25,7 +25,7 @@ class BaseSimpleNetworkRecipe(BaseEnrtRecipe):
     net_ipv4 = IPv4NetworkParam(default="192.168.101.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves just adding an IPv4 and
         IPv6 address to the matched eth0 nics on both hosts.
@@ -35,7 +35,7 @@ class BaseSimpleNetworkRecipe(BaseEnrtRecipe):
         host2.eth0 = 192.168.101.2/24 and fc00::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6)

--- a/lnst/Recipes/ENRT/SoftwareRDMARecipe.py
+++ b/lnst/Recipes/ENRT/SoftwareRDMARecipe.py
@@ -25,8 +25,8 @@ class SoftwareRDMARecipe(SimpleNetworkRecipe):
     def device_name(self) -> str:
         return f"{self.params.software_rdma_type}0"
 
-    def test_wide_configuration(self) -> RecipeConf:
-        config = super().test_wide_configuration()
+    def test_wide_configuration(self, config) -> RecipeConf:
+        config = super().test_wide_configuration(config)
         host1, host2 = self.matched.host1, self.matched.host2
 
         # setup RDMA link, emulating InfiniBand on Ethernet

--- a/lnst/Recipes/ENRT/TeamRecipe.py
+++ b/lnst/Recipes/ENRT/TeamRecipe.py
@@ -73,7 +73,7 @@ class TeamRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
 
     runner_name = StrParam(mandatory=True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves creating a team
         device using the two matched physical devices as ports on host1.
@@ -85,7 +85,7 @@ class TeamRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin, OffloadSubConf
         | host2.eth0 = 192.168.10.2/24 and fc00:0:0:1::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         teamd_config = {'runner': {'name': self.params.runner_name}}
         host1.team0 = TeamDevice(config=teamd_config)

--- a/lnst/Recipes/ENRT/TeamVsBondRecipe.py
+++ b/lnst/Recipes/ENRT/TeamVsBondRecipe.py
@@ -45,9 +45,9 @@ class TeamVsBondRecipe(PerfReversibleFlowMixin, CommonHWSubConfigMixin,
     bonding_mode = StrParam(mandatory = True)
     miimon_value = IntParam(mandatory = True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         host1.team0 = TeamDevice(config={'runner': {'name': self.params.runner_name}})
         host2.bond0 = BondDevice(mode=self.params.bonding_mode,

--- a/lnst/Recipes/ENRT/TrafficControlRecipe.py
+++ b/lnst/Recipes/ENRT/TrafficControlRecipe.py
@@ -6,6 +6,7 @@ from lnst.Common.LnstError import LnstError
 from lnst.Common.Parameters import ListParam, StrParam, IntParam, ChoiceParam, BoolParam
 from lnst.Controller import HostReq, DeviceReq, RecipeParam
 from lnst.Controller.Namespace import Namespace
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
 from lnst.RecipeCommon import BaseResultEvaluator
 from lnst.RecipeCommon.Perf.Evaluators.MaxTimeTakenEvaluator import MaxTimeTakenEvaluator
 from lnst.RecipeCommon.Perf.Measurements import StatCPUMeasurement
@@ -48,13 +49,14 @@ class TrafficControlRecipe(PerfRecipe):
 
     @contextmanager
     def _test_wide_context(self):
-        config = self.test_wide_configuration()
+        config = EnrtConfiguration()
         try:
+            config = self.test_wide_configuration(config)
             yield config
         finally:
             self.test_wide_deconfiguration(config)
 
-    def test_wide_configuration(self) -> TcRecipeConfiguration:
+    def test_wide_configuration(self, config) -> TcRecipeConfiguration:
         host = self.matched.host1
         cpu_measurement = StatCPUMeasurement(
             hosts=[host],

--- a/lnst/Recipes/ENRT/UseVfsMixin.py
+++ b/lnst/Recipes/ENRT/UseVfsMixin.py
@@ -27,8 +27,8 @@ class UseVfsMixin:
     use_vfs = BoolParam(default=False)
     vf_trust = ChoiceParam(choices={'on', 'off'})
 
-    def test_wide_configuration(self):
-        config = super().test_wide_configuration()
+    def test_wide_configuration(self, config):
+        config = super().test_wide_configuration(config)
 
         if not self.params.use_vfs:
             return config

--- a/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
+++ b/lnst/Recipes/ENRT/VirtOvsVxlanRecipe.py
@@ -40,7 +40,7 @@ class VirtOvsVxlanRecipe(VlanPingEvaluatorMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.2.0/24")
 
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1, guest2, guest3, guest4 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2,
             self.matched.guest3, self.matched.guest4)
@@ -68,7 +68,7 @@ class VirtOvsVxlanRecipe(VlanPingEvaluatorMixin,
             "output:6")
         flow_entries.append("table=0,priority=100,actions=drop")
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         for host, self_ip, other_ip in zip([host1, host2], host_ips, reversed(host_ips)):
             config.configure_and_track_ip(host.eth0, self_ip)

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestMirroredRecipe.py
@@ -48,7 +48,7 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1, guest2 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2)
 
@@ -64,7 +64,7 @@ class VirtualBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
         guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=self.params.vlan_id)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInGuestRecipe.py
@@ -39,7 +39,7 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
 
@@ -54,7 +54,7 @@ class VirtualBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostMirroredRecipe.py
@@ -48,7 +48,7 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1, guest2 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2)
 
@@ -66,7 +66,7 @@ class VirtualBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id,
             master=host2.br0)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")

--- a/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlanInHostRecipe.py
@@ -43,7 +43,7 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
 
@@ -59,7 +59,7 @@ class VirtualBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
             master=host1.br0)
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4)
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")

--- a/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualBridgeVlansOverBondRecipe.py
@@ -68,7 +68,7 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
     bonding_mode = StrParam(mandatory=True)
     miimon_value = IntParam(mandatory=True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1, guest2, guest3, guest4 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2,
             self.matched.guest3, self.matched.guest4)
@@ -97,7 +97,7 @@ class VirtualBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         host2.vlan1 = VlanDevice(realdev=host2.bond0, vlan_id=self.params.vlan1_id,
             master=host2.br1)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
         vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6, default_start="fc00:0:0:1::2/64", default_skip=2)

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestMirroredRecipe.py
@@ -48,7 +48,7 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         dict(gro="on", gso="on", tso="off", tx="off", rx="on"),
         dict(gro="on", gso="on", tso="on", tx="on", rx="off")))
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1, guest2 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2)
 
@@ -65,7 +65,7 @@ class VirtualOvsBridgeVlanInGuestMirroredRecipe(CommonHWSubConfigMixin,
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
         guest2.vlan0 = VlanDevice(realdev=guest2.eth0, vlan_id=self.params.vlan_id)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.3/24")
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInGuestRecipe.py
@@ -38,7 +38,7 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
 
@@ -53,7 +53,7 @@ class VirtualOvsBridgeVlanInGuestRecipe(CommonHWSubConfigMixin,
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
         guest1.vlan0 = VlanDevice(realdev=guest1.eth0, vlan_id=self.params.vlan_id)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.2/24")
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostMirroredRecipe.py
@@ -42,7 +42,7 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1, guest2 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2)
 
@@ -56,7 +56,7 @@ class VirtualOvsBridgeVlanInHostMirroredRecipe(CommonHWSubConfigMixin,
         guest1.eth0.down()
         guest2.eth0.down()
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.3/24")
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::3/64")

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlanInHostRecipe.py
@@ -38,7 +38,7 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
     net_ipv4 = IPv4NetworkParam(default="192.168.10.0/24")
     net_ipv6 = IPv6NetworkParam(default="fc00:0:0:1::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
 
@@ -53,7 +53,7 @@ class VirtualOvsBridgeVlanInHostRecipe(CommonHWSubConfigMixin,
 
         host2.vlan0 = VlanDevice(realdev=host2.eth0, vlan_id=self.params.vlan_id)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         ipv4_addr = interface_addresses(self.params.net_ipv4, default_start="192.168.10.2/24")
         ipv6_addr = interface_addresses(self.params.net_ipv6, default_start="fc00:0:0:1::2/64")

--- a/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualOvsBridgeVlansOverBondRecipe.py
@@ -66,7 +66,7 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
     bonding_mode = StrParam(mandatory = True)
     miimon_value = IntParam(mandatory = True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1, guest2, guest3, guest4 = (self.matched.host1,
             self.matched.host2, self.matched.guest1, self.matched.guest2,
             self.matched.guest3, self.matched.guest4)
@@ -88,7 +88,7 @@ class VirtualOvsBridgeVlansOverBondRecipe(VlanPingEvaluatorMixin,
         guest3.eth0.down()
         guest4.eth0.down()
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         vlan0_ipv4_addr = interface_addresses(self.params.vlan0_ipv4)
         vlan0_ipv6_addr = interface_addresses(self.params.vlan0_ipv6)

--- a/lnst/Recipes/ENRT/VlansOverBondRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverBondRecipe.py
@@ -82,7 +82,7 @@ class VlansOverBondRecipe(BondingMixin, PerfReversibleFlowMixin, VlanPingEvaluat
     vlan2_ipv4 = IPv4NetworkParam(default="192.168.30.0/24")
     vlan2_ipv6 = IPv6NetworkParam(default="fc00:0:0:3::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves creating one bonding
         device on the first host. This device bonds two NICs matched by the
@@ -104,7 +104,7 @@ class VlansOverBondRecipe(BondingMixin, PerfReversibleFlowMixin, VlanPingEvaluat
         | host2.vlan2 = 192.168.30.2/24 and fc00:0:0:3::2/64
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         self.create_bond_devices(
             config,

--- a/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
+++ b/lnst/Recipes/ENRT/VlansOverTeamRecipe.py
@@ -56,9 +56,9 @@ class VlansOverTeamRecipe(PerfReversibleFlowMixin, VlanPingEvaluatorMixin,
 
     runner_name = StrParam(mandatory = True)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         host1.team0 = TeamDevice(config={'runner': {'name': self.params.runner_name}})
         for dev in [host1.eth0, host1.eth1]:

--- a/lnst/Recipes/ENRT/VlansRecipe.py
+++ b/lnst/Recipes/ENRT/VlansRecipe.py
@@ -66,7 +66,7 @@ class VlansRecipe(VlanPingEvaluatorMixin,
     vlan2_ipv4 = IPv4NetworkParam(default="192.168.30.0/24")
     vlan2_ipv6 = IPv6NetworkParam(default="fc00:0:0:3::/64")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         """
         Test wide configuration for this recipe involves creating three
         VLAN (802.1Q) tunnels on top of the matched host's NIC with vlan
@@ -85,7 +85,7 @@ class VlansRecipe(VlanPingEvaluatorMixin,
 
         """
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         host1.eth0.down()
         host2.eth0.down()

--- a/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanMulticastRecipe.py
@@ -27,7 +27,7 @@ class VxlanMulticastRecipe(CommonHWSubConfigMixin, VirtualEnrtRecipe):
     net_ipv4 = IPv4NetworkParam(default="192.168.0.0/24")
     vxlan_group_ip = IpParam(default="239.1.1.1", multicast=True, family=AF_INET)
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2, guest1 = (self.matched.host1, self.matched.host2,
             self.matched.guest1)
 
@@ -46,7 +46,7 @@ class VxlanMulticastRecipe(CommonHWSubConfigMixin, VirtualEnrtRecipe):
         for machine in [guest1, host2]:
             machine.vxlan0 = VxlanDevice(vxlan_id=1, realdev=machine.eth0, group=self.params.vxlan_group_ip)
 
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         for i, (machine, dev) in enumerate([(host1, host1.br0),
             (guest1, guest1.eth0), (host2, host2.eth0)], 1):

--- a/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
+++ b/lnst/Recipes/ENRT/VxlanRemoteRecipe.py
@@ -26,9 +26,9 @@ class VxlanRemoteRecipe(
 
     net_ipv4 = IPv4NetworkParam(default="192.168.0.0/24")
 
-    def test_wide_configuration(self):
+    def test_wide_configuration(self, config):
         host1, host2 = self.matched.host1, self.matched.host2
-        config = super().test_wide_configuration()
+        config = super().test_wide_configuration(config)
 
         for host in [host1, host2]:
             host.eth0.down()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ psutil = "^5.9.4"
 requests = "^2.30.0"
 
 urllib3 = "<2"
+wheel = "^0.45.1"
 
 [tool.poetry.extras]
 virt = ["libvirt-python"]


### PR DESCRIPTION
### Description
This started as a fix for DELL switch configuration for bonding - sometimes when the recipe crashes during configuration, the deconfiguration isn't called correctly and this leaves the switch in a configured state that breaks followup recipes.

I then continued working on how to test this and wanted to simply run a "functional check of all ENRT recipes" in CI... and to do that I need support of a container being connected to the same network multiple times. So I extended the ContainerPoolManager to manually create a bridged network with veths connected into the containers.

### Tests
CI tests at least, but these need to be implemented

I'll also followup by testing in production.

### Reviews
(Please add a list of reviewers that should check the validity and sanity of
this merge request before it's accepted. Use the `@username` syntax. If you
don't know who to mention just link `@all`.)

Closes: #
