### PR TITLE
Fail measurements if any of the jobs returned issues

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/BaseCPUMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseCPUMeasurement.py
@@ -1,4 +1,4 @@
-from lnst.Controller.RecipeResults import MeasurementResult
+from lnst.Controller.RecipeResults import MeasurementResult, ResultType
 from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
 from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
 from lnst.RecipeCommon.Perf.Measurements.Results import AggregatedCPUMeasurementResults
@@ -38,7 +38,18 @@ class BaseCPUMeasurement(BaseMeasurement):
 
         desc = [result.describe() for result in results]
 
-        recipe.add_custom_result(MeasurementResult("cpu", description="\n".join(desc), data=cpu_data))
+        recipe.add_custom_result(
+            MeasurementResult(
+                "cpu",
+                result=(
+                    ResultType.PASS
+                    if all(res.measurement_success for res in results)
+                    else ResultType.FAIL
+                ),
+                description="\n".join(desc),
+                data=cpu_data,
+            )
+        )
 
     def _aggregate_hostcpu_results(self, old, new):
         if (old is not None and

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -169,6 +169,7 @@ class BaseFlowMeasurement(BaseMeasurement):
         for i in range(nr_iterations):
             parallel_result = FlowMeasurementResults(
                     measurement=sample_result.measurement,
+                    measurement_success=all(result.measurement_success for result in results),
                     flow=dummy_flow,
                     warmup_duration=dummy_flow.warmup_duration
             )
@@ -193,6 +194,7 @@ class BaseFlowMeasurement(BaseMeasurement):
         for test_flow in self.flows:
             flow_results = FlowMeasurementResults(
                 measurement=self,
+                measurement_success=True,
                 flow=test_flow,
                 warmup_duration=test_flow.warmup_duration,
             )

--- a/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/BaseFlowMeasurement.py
@@ -97,18 +97,19 @@ class BaseFlowMeasurement(BaseMeasurement):
         desc = []
         desc.append(flow_results.describe())
 
-        recipe_result = ResultType.PASS
         metrics = {"Generator": generator, "Generator process": generator_cpu,
                    "Receiver": receiver, "Receiver process": receiver_cpu}
         for name, result in metrics.items():
             if cls._invalid_flow_duration(result):
-                recipe_result = ResultType.FAIL
                 desc.append("{} has invalid duration!".format(name))
 
         # TODO add flow description
         recipe_result = MeasurementResult(
             "flow",
             description="\n".join(desc),
+            result=(
+                ResultType.PASS if flow_results.measurement_success else ResultType.FAIL
+            ),
             data={
                 "generator_flow_data": generator,
                 "generator_cpu_data": generator_cpu,

--- a/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/IperfFlowMeasurement.py
@@ -118,9 +118,12 @@ class IperfFlowMeasurement(BaseFlowMeasurement):
         results = []
         for test_flow in test_flows:
             flow_results = FlowMeasurementResults(
-                    measurement=self,
-                    flow=test_flow.flow,
-                    warmup_duration=test_flow.flow.warmup_duration
+                measurement=self,
+                measurement_success=(
+                    test_flow.client_job.passed and test_flow.server_job.passed
+                ),
+                flow=test_flow.flow,
+                warmup_duration=test_flow.flow.warmup_duration,
             )
             flow_results.generator_results = self._parse_job_streams(
                     test_flow.client_job)

--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -117,11 +117,12 @@ class LinuxPerfMeasurement(BaseMeasurement):
 
             results.append(
                 LinuxPerfMeasurementResults(
-                    self,
-                    host,
-                    dst_filepath,
-                    self._start_timestamp,
-                    self._end_timestamp,
+                    measurement=self,
+                    measurement_success=job.passed,
+                    host=host,
+                    filename=dst_filepath,
+                    start_timestamp=self._start_timestamp,
+                    end_timestamp=self._end_timestamp,
                 )
             )
         return results

--- a/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/NeperFlowMeasurement.py
@@ -158,6 +158,9 @@ class NeperFlowMeasurement(BaseFlowMeasurement):
         for test_flow in test_flows:
             flow_results = NeperFlowMeasurementResults(
                     measurement=self,
+                    measurement_success=(
+                        test_flow.client_job.passed and test_flow.server_job.passed
+                    ),
                     flow=test_flow.flow,
                     warmup_duration=test_flow.flow.warmup_duration
             )

--- a/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
@@ -75,6 +75,9 @@ class RDMABandwidthMeasurement(BaseFlowMeasurement):
             duration = endpoint_test.flow.duration
             result = RDMABandwidthMeasurementResults(
                 measurement=self,
+                measurement_success=(
+                    endpoint_test.client_job.passed and endpoint_test.server_job.passed
+                ),
                 flow=endpoint_test.flow,
             )
             result.bandwidth = PerfInterval(

--- a/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/RDMABandwidthMeasurement.py
@@ -4,7 +4,7 @@ import logging
 
 from lnst.Controller.Job import Job
 from lnst.Controller.Recipe import BaseRecipe
-from lnst.Controller.RecipeResults import MeasurementResult
+from lnst.Controller.RecipeResults import MeasurementResult, ResultType
 from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import Flow, NetworkFlowTest
 from lnst.RecipeCommon.Perf.Results import PerfInterval
 from lnst.Tests.RDMABandwidth import RDMABandwidthServer, RDMABandwidthClient
@@ -159,6 +159,11 @@ class RDMABandwidthMeasurement(BaseFlowMeasurement):
         for aggregated_result in aggregated_results:
             measurement_result = MeasurementResult(
                 "rdma-bandwidth",
+                result=(
+                    ResultType.PASS
+                    if aggregated_result.measurement_success
+                    else ResultType.FAIL
+                ),
                 description=aggregated_result.describe(),
                 data={"bandwidth": aggregated_result.bandwidth}
             )

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedCPUMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedCPUMeasurementResults.py
@@ -5,8 +5,15 @@ from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementErro
 
 class AggregatedCPUMeasurementResults(CPUMeasurementResults):
     def __init__(self, measurement, host, cpu):
-        super(AggregatedCPUMeasurementResults, self).__init__(measurement, host, cpu)
+        super(AggregatedCPUMeasurementResults, self).__init__(measurement, True, host, cpu)
         self._individual_results = []
+
+    @property
+    def measurement_success(self) -> bool:
+        if self.individual_results:
+            return all(res.measurement_success for res in self.individual_results)
+        else:
+            return False
 
     @property
     def individual_results(self):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedFlowMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedFlowMeasurementResults.py
@@ -5,13 +5,20 @@ from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementErro
 
 class AggregatedFlowMeasurementResults(FlowMeasurementResults):
     def __init__(self, measurement, flow):
-        super(FlowMeasurementResults, self).__init__(measurement)
+        super(FlowMeasurementResults, self).__init__(measurement, True)
         self._flow = flow
         self._generator_results = SequentialPerfResult()
         self._generator_cpu_stats = SequentialPerfResult()
         self._receiver_results = SequentialPerfResult()
         self._receiver_cpu_stats = SequentialPerfResult()
         self._individual_results = []
+
+    @property
+    def measurement_success(self) -> bool:
+        if self.individual_results:
+            return all(res.measurement_success for res in self.individual_results)
+        else:
+            return False
 
     @property
     def individual_results(self):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedLinuxPerfMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedLinuxPerfMeasurementResults.py
@@ -12,6 +12,13 @@ class AggregatedLinuxPerfMeasurementResults(BaseMeasurementResults):
             self._individual_results = [result]
 
     @property
+    def measurement_success(self) -> bool:
+        if self.individual_results:
+            return all(res.measurement_success for res in self.individual_results)
+        else:
+            return False
+
+    @property
     def individual_results(self) -> list[LinuxPerfMeasurementResults]:
         return self._individual_results
 

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedRDMABandwidthMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedRDMABandwidthMeasurementResults.py
@@ -5,8 +5,15 @@ from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
 
 class AggregatedRDMABandwidthMeasurementResults(RDMABandwidthMeasurementResults):
     def __init__(self, measurement: BaseMeasurement, flow: "Flow"):
-        super().__init__(measurement, flow)
+        super().__init__(measurement, True, flow)
         self._individual_results = []
+
+    @property
+    def measurement_success(self) -> bool:
+        if self.individual_results:
+            return all(res.measurement_success for res in self.individual_results)
+        else:
+            return False
 
     @property
     def individual_results(self) -> list[RDMABandwidthMeasurementResults]:

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedTcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedTcRunMeasurementResults.py
@@ -15,9 +15,16 @@ class AggregatedTcRunMeasurementResults(TcRunMeasurementResults):
             device: Device,
             warmup_rules=0,
     ):
-        super().__init__(measurement, device, warmup_rules=warmup_rules)
+        super().__init__(measurement, True, device, warmup_rules=warmup_rules)
         self._individual_results: list[TcRunMeasurementResults] = []
         self._rule_install_rate: SequentialPerfResult = SequentialPerfResult()
+
+    @property
+    def measurement_success(self) -> bool:
+        if self.individual_results:
+            return all(res.measurement_success for res in self.individual_results)
+        else:
+            return False
 
     @property
     def rule_install_rate(self) -> SequentialPerfResult:

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedTcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedTcRunMeasurementResults.py
@@ -35,10 +35,6 @@ class AggregatedTcRunMeasurementResults(TcRunMeasurementResults):
         self._rule_install_rate = result
 
     @property
-    def run_success(self) -> bool:
-        return all((i.run_success for i in self.individual_results))
-
-    @property
     def individual_results(self) -> list[TcRunMeasurementResults]:
         return self._individual_results
 

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
@@ -6,10 +6,17 @@ from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
 
 
 class AggregatedXDPBenchMeasurementResults(XDPBenchMeasurementResults):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, measurement, flow):
+        super().__init__(measurement, True, flow)
         self._generator_results = SequentialPerfResult()
         self._receiver_results = SequentialPerfResult()
+
+    @property
+    def measurement_success(self) -> bool:
+        if self.individual_results:
+            return all(res.measurement_success for res in self.individual_results)
+        else:
+            return False
 
     def add_results(self, results):
         if results is None:

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
@@ -8,8 +8,13 @@ from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
 class AggregatedXDPBenchMeasurementResults(XDPBenchMeasurementResults):
     def __init__(self, measurement, flow):
         super().__init__(measurement, True, flow)
+        self._individual_results: list[TcRunMeasurementResults] = []
         self._generator_results = SequentialPerfResult()
         self._receiver_results = SequentialPerfResult()
+
+    @property
+    def individual_results(self) -> list[XDPBenchMeasurementResults]:
+        return self._individual_results
 
     @property
     def measurement_success(self) -> bool:
@@ -22,9 +27,11 @@ class AggregatedXDPBenchMeasurementResults(XDPBenchMeasurementResults):
         if results is None:
             return
         elif isinstance(results, AggregatedXDPBenchMeasurementResults):
+            self._individual_results.extend(results.individual_results)
             self.generator_results.extend(results.generator_results)
             self.receiver_results.extend(results.receiver_results)
         elif isinstance(results, XDPBenchMeasurementResults):
+            self._individual_results.append(results)
             self.generator_results.append(results.generator_results)
             self.receiver_results.append(results.receiver_results)
         else:

--- a/lnst/RecipeCommon/Perf/Measurements/Results/BaseMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/BaseMeasurementResults.py
@@ -2,13 +2,18 @@ from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
 
 
 class BaseMeasurementResults(object):
-    def __init__(self, measurement: BaseMeasurement, warmup=0):
+    def __init__(self, measurement: BaseMeasurement, measurement_success=True, warmup=0):
         self._measurement = measurement
+        self._measurement_success = measurement_success
         self._warmup_duration = warmup
 
     @property
     def measurement(self) -> BaseMeasurement:
         return self._measurement
+
+    @property
+    def measurement_success(self) -> bool:
+        return self._measurement_success
 
     @property
     def warmup_duration(self):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/CPUMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/CPUMeasurementResults.py
@@ -4,8 +4,8 @@ from lnst.RecipeCommon.Perf.Measurements.Results.BaseMeasurementResults import (
 
 
 class CPUMeasurementResults(BaseMeasurementResults):
-    def __init__(self, measurement, host, cpu):
-        super(CPUMeasurementResults, self).__init__(measurement)
+    def __init__(self, measurement, measurement_success, host, cpu):
+        super(CPUMeasurementResults, self).__init__(measurement, measurement_success)
         self._host = host
         self._cpu = cpu
         self._utilization = None

--- a/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
@@ -5,9 +5,9 @@ from lnst.RecipeCommon.Perf.Measurements.Results.BaseMeasurementResults import (
 
 
 class FlowMeasurementResults(BaseMeasurementResults):
-    def __init__(self, measurement, flow, warmup_duration=0):
+    def __init__(self, measurement, measurement_success, flow, warmup_duration=0):
         super(FlowMeasurementResults, self).__init__(
-            measurement, warmup_duration
+            measurement, measurement_success, warmup_duration
         )
         self._flow = flow
         self._generator_results = None
@@ -92,7 +92,7 @@ class FlowMeasurementResults(BaseMeasurementResults):
 
     def time_slice(self, start, end):
         result_copy = FlowMeasurementResults(
-            self.measurement, self.flow, warmup_duration=0
+            self.measurement, self.measurement_success, self.flow, warmup_duration=0
         )
 
         result_copy.generator_cpu_stats = self.generator_cpu_stats.time_slice(

--- a/lnst/RecipeCommon/Perf/Measurements/Results/LinuxPerfMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/LinuxPerfMeasurementResults.py
@@ -12,12 +12,13 @@ class LinuxPerfMeasurementResults(BaseMeasurementResults):
     def __init__(
         self,
         measurement,
+        measurement_success: bool,
         host: Host,
         filename: str,
         start_timestamp: float,
         end_timestamp: float,
     ):
-        super().__init__(measurement)
+        super().__init__(measurement, measurement_success)
         self._host = host
         self._filename = filename
         self._start_timestamp = start_timestamp

--- a/lnst/RecipeCommon/Perf/Measurements/Results/RDMABandwidthMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/RDMABandwidthMeasurementResults.py
@@ -4,8 +4,8 @@ from lnst.RecipeCommon.Perf.Results import PerfInterval, PerfResult
 
 
 class RDMABandwidthMeasurementResults(BaseMeasurementResults):
-    def __init__(self, measurement: BaseMeasurement, flow: "Flow"):
-        super().__init__(measurement)
+    def __init__(self, measurement: BaseMeasurement, measurement_success: bool, flow: "Flow"):
+        super().__init__(measurement, measurement_success)
 
         self._flow = flow
 
@@ -34,7 +34,7 @@ class RDMABandwidthMeasurementResults(BaseMeasurementResults):
         return self._bandwidth.end_timestamp
 
     def time_slice(self, start, end):
-        result_copy = RDMABandwidthMeasurementResults(self.measurement, self.flow)
+        result_copy = RDMABandwidthMeasurementResults(self.measurement, self.measurement_success, self.flow)
         result_copy.bandwidth = self.bandwidth.time_slice(start, end)
         return result_copy
 

--- a/lnst/RecipeCommon/Perf/Measurements/Results/StatCPUMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/StatCPUMeasurementResults.py
@@ -31,6 +31,7 @@ class StatCPUMeasurementResults(CPUMeasurementResults):
     def time_slice(self, start, end):
         result_copy = StatCPUMeasurementResults(
                 self.measurement,
+                self.measurement_success,
                 self.host,
                 self.cpu
                 )

--- a/lnst/RecipeCommon/Perf/Measurements/Results/StatCPUMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/StatCPUMeasurementResults.py
@@ -4,8 +4,8 @@ from lnst.RecipeCommon.Perf.Measurements.Results import CPUMeasurementResults
 
 
 class StatCPUMeasurementResults(CPUMeasurementResults):
-    def __init__(self, *args):
-        super(StatCPUMeasurementResults, self).__init__(*args)
+    def __init__(self, *args, **kwargs):
+        super(StatCPUMeasurementResults, self).__init__(*args, **kwargs)
         self._data = {}
 
     def update_intervals(self, intervals):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
@@ -10,10 +10,11 @@ class TcRunMeasurementResults(BaseMeasurementResults):
     def __init__(
             self,
             measurement: "TcRunMeasurement",
+            measurement_success: bool,
             device: Device,
             warmup_rules=0,
     ):
-        super().__init__(measurement, warmup_rules)
+        super().__init__(measurement, measurement_success, warmup_rules)
         self._device = device
         self._rule_install_rate: ParallelPerfResult = None
         self._run_success: bool = None

--- a/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
@@ -17,7 +17,6 @@ class TcRunMeasurementResults(BaseMeasurementResults):
         super().__init__(measurement, measurement_success, warmup_rules)
         self._device = device
         self._rule_install_rate: ParallelPerfResult = None
-        self._run_success: bool = None
 
     @property
     def metrics(self) -> list[str]:
@@ -38,14 +37,6 @@ class TcRunMeasurementResults(BaseMeasurementResults):
     @rule_install_rate.setter
     def rule_install_rate(self, result: ParallelPerfResult):
         self._rule_install_rate = result
-
-    @property
-    def run_success(self) -> bool:
-        return self._run_success
-
-    @run_success.setter
-    def run_success(self, v: bool):
-        self._run_success = v
 
     @property
     def description(self):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
@@ -6,8 +6,8 @@ from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementErro
 
 
 class XDPBenchMeasurementResults(BaseMeasurementResults):
-    def __init__(self, measurement, flow, warmup_duration=0):
-        super().__init__(measurement, warmup_duration)
+    def __init__(self, measurement, measurement_success, flow, warmup_duration=0):
+        super().__init__(measurement, measurement_success, warmup_duration)
 
         self._flow = flow
 
@@ -75,7 +75,7 @@ class XDPBenchMeasurementResults(BaseMeasurementResults):
 
     def time_slice(self, start, end) -> "XDPBenchMeasurementResults":
         result_copy = XDPBenchMeasurementResults(
-            self.measurement, self.flow, warmup_duration=0
+            self.measurement, self.measurement_success, self.flow, warmup_duration=0
         )
 
         result_copy.generator_results = self.generator_results.time_slice(start, end)

--- a/lnst/RecipeCommon/Perf/Measurements/StatCPUMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/StatCPUMeasurement.py
@@ -64,7 +64,12 @@ class StatCPUMeasurement(BaseCPUMeasurement):
 
             for cpu, cpu_intervals in list(parsed_sample.items()):
                 if cpu not in job_results:
-                    job_results[cpu] = StatCPUMeasurementResults(self, host, cpu)
+                    job_results[cpu] = StatCPUMeasurementResults(
+                        measurement=self,
+                        measurement_success=job.passed,
+                        host=host,
+                        cpu=cpu
+                    )
                 cpu_results = job_results[cpu]
                 cpu_results.update_intervals(cpu_intervals)
 

--- a/lnst/RecipeCommon/Perf/Measurements/TRexFlowMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TRexFlowMeasurement.py
@@ -164,7 +164,12 @@ class TRexFlowMeasurement(BaseFlowMeasurement):
         return result
 
     def _parse_results_by_port(self, job, port, flow):
-        results = FlowMeasurementResults(measurement=self, flow=flow, warmup_duration=flow.warmup_duration)
+        results = FlowMeasurementResults(
+            measurement=self,
+            measurement_success=job.passed,
+            flow=flow,
+            warmup_duration=flow.warmup_duration
+        )
         results.generator_results = SequentialPerfResult()
         results.generator_cpu_stats = SequentialPerfResult()
 

--- a/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
@@ -248,9 +248,10 @@ class TcRunMeasurement(BaseMeasurement):
 
     @classmethod
     def _report_result(cls,  recipe: BaseRecipe, result: TcRunMeasurementResults):
-        r_type = ResultType.PASS if result.run_success else ResultType.FAIL
+        r_type = ResultType.PASS if result.measurement_success else ResultType.FAIL
         measurement_result = MeasurementResult(
             "tc",
+            result=r_type,
             description=f"{r_type} {result.description}",
             data={"rule_install_rate": result.rule_install_rate},
         )

--- a/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
@@ -218,7 +218,6 @@ class TcRunMeasurement(BaseMeasurement):
         run_result.rule_install_rate = ParallelPerfResult(
             [self._get_instance_interval(d) for d in instance_data]
         )
-        run_result.run_success = job.passed
 
         return [run_result]
 

--- a/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
@@ -205,15 +205,16 @@ class TcRunMeasurement(BaseMeasurement):
         return configs
 
     def collect_results(self) -> list[TcRunMeasurementResults]:
-        run_result = TcRunMeasurementResults(
-            measurement=self,
-            device=self.device,
-        )
         if len(self._finished_jobs) > 1:
             raise MeasurementError("Too many jobs")
         job = self._finished_jobs[0]
         instance_data = job.result["data"]["instance_results"]
 
+        run_result = TcRunMeasurementResults(
+            measurement=self,
+            measurement_success=job.passed,
+            device=self.device,
+        )
         run_result.rule_install_rate = ParallelPerfResult(
             [self._get_instance_interval(d) for d in instance_data]
         )
@@ -224,6 +225,7 @@ class TcRunMeasurement(BaseMeasurement):
     def collect_simulated_results(self):
         run_result = TcRunMeasurementResults(
             measurement=self,
+            measurement_success=True,
             device=self.device,
         )
         run_result.rule_install_rate = ParallelPerfResult(

--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -145,6 +145,9 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
         for test_flow in test_flows:
             flow_results = XDPBenchMeasurementResults(
                 measurement=self,
+                measurement_success=(
+                    test_flow.client_job.passed and test_flow.server_job.passed
+                ),
                 flow=test_flow.flow,
                 warmup_duration=test_flow.flow.warmup_duration,
             )

--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -218,8 +218,8 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
 
             recipe_result = ResultType.PASS
             metrics = {"Generator": generator, "Receiver": receiver}
-            for name, result in metrics.items():
-                if cls._invalid_flow_duration(result):
+            for name, metric_result in metrics.items():
+                if cls._invalid_flow_duration(metric_result):
                     recipe_result = ResultType.FAIL
                     desc.append("{} has invalid duration!".format(name))
 

--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -22,7 +22,7 @@ from lnst.RecipeCommon.Perf.Results import (
 from lnst.Tests.PktGen import PktGen
 from lnst.Tests.XDPBench import XDPBench
 from lnst.Controller.Job import Job
-from lnst.Controller.RecipeResults import MeasurementResult
+from lnst.Controller.RecipeResults import MeasurementResult, ResultType
 from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import BaseFlowMeasurement
 
 
@@ -225,6 +225,11 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
 
             recipe_result = MeasurementResult(
                 "xdp-bench",
+                result=(
+                    ResultType.PASS
+                    if result.measurement_success
+                    else ResultType.FAIL
+                ),
                 description="\n".join(desc),
                 data={
                     "generator_results": generator,


### PR DESCRIPTION
### Description
This is necessary to detect situation when something went wrong with the measurement and we should disqualify the measurement results from being fully trustworthy, e.g. for setting baselines.

### Tests
Needs to be tested for all types of measurements, ideally with failures in the measurement process to see the changed results.

### Reviews
@Axonis @enhaut @jtluka 

Closes: #
