### PR TITLE
pyproject.toml: add includes into wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,11 @@ packages = [
     { include = "lnst"}
 ]
 
-include = ["schema-am.rng", "install/*", "lnst-ctl.conf"]
+include = [
+    { path="schema-am.rng", format=["sdist", "wheel"]},
+    { path="install/*", format=["sdist", "wheel"]},
+    { path="lnst-ctl.conf", format=["sdist", "wheel"]},
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
### Description
After poetry-core update the default of the includes changed so that they're only in the sdist by default and this breaks our lnst installation as the schema file is used during runtime.

### Tests
(Please provide a list of tests that prove that the pull
request doesn't break the stable state of the master branch. This should
include test runs with valid results for all of critical workflows.)

### Reviews
(Please add a list of reviewers that should check the validity and sanity of
this merge request before it's accepted. Use the `@username` syntax. If you
don't know who to mention just link `@all`.)

Closes: #
