### PR TITLE
Better XDP error handling

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -190,6 +190,17 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
         )  # just a placeholder to keep data structure same as other Measurements
         results = SequentialPerfResult()  # single instance of xdp-bench
 
+        if not job.passed:
+            if "exception" in job.result:
+                logging.error(f"Exception from receiver job: {job.result['exception']}")
+            elif job.result == "Job killed":
+                # when job was killed, .result is replaced by "Job killed",
+                # so there are no results to process bellow
+                logging.error("Receiver job killed")
+
+            results.append(PerfInterval(0, 1, "packets", time.time()))
+            return results
+
         for sample in job.result:
             results.append(
                 PerfInterval(

--- a/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPBenchMeasurement.py
@@ -164,6 +164,12 @@ class XDPBenchMeasurement(BaseFlowMeasurement):
     def _parse_generator_results(self, job: Job):
         results = ParallelPerfResult()  # container for multiple instances of pktgen
 
+        if not job.passed and "exception" in job.result:
+            logging.error(f"Exception from generator job: {job.result['exception']}")
+
+            results.append(PerfInterval(0, 1, "packets", time.time()))
+            return results
+
         for _, raw_results in job.result.items():
             instance_results = SequentialPerfResult()  # instance (device) of pktgen
             for raw_result in raw_results:


### PR DESCRIPTION
### Description

XDP's test modules might raise an exception when running on agent
machine. Currently these are not propagated to conroller, so it treats
incomplete/wrong results as a valid ones and so, controller crashes
on weird issues because of that.


### Tests
- no crash test (just to be sure everything works as expected) `J:10515937`
- crash test (to test added code) `J:10515938`
