### PR TITLE
pyproject.toml: add pyroute2 version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ include = [
 python = "^3.9"
 lxml = "*"
 ethtool = "*"
-pyroute2 = "*"
+pyroute2 = "<0.9.0"
 
 libvirt-python = {version = "*", optional = true }
 podman = {version = "*", optional = true }


### PR DESCRIPTION
### Description

Starting from version 0.9.1 pyroute2 will use asyncio-based core, and even if the project continues to provide the synchronous API, there might be some incompatible things.

So until we prepare and discuss a PR to align the code with the current pyroute2 master branch, restrict the version to avoid occasional failures when pyroute2 0.9.1 will be released.

### Tests

This PR only fixes the current state, no additional functionality is added.

### Reviews

@jtluka 
@olichtne 
