### PR TITLE
Virt linuxperf

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/LinuxPerfMeasurement.py
@@ -111,9 +111,11 @@ class LinuxPerfMeasurement(BaseMeasurement):
             logging.debug(f"perf-record data copied from agent to {dst_filepath}")
 
             # copy debug symbols to controller
-            archive_filepath = job.result.get("archive_filename")
-            host.copy_file_from_machine(archive_filepath, f"{dst_filepath}.tar.bz2")
-            logging.debug(f"perf-record debug symbols copied from agent to {dst_filepath}.tar.bz2")
+            if archive_filepath := job.result.get("archive_filename"):
+                host.copy_file_from_machine(archive_filepath, f"{dst_filepath}.tar.bz2")
+                logging.debug(f"perf-record debug symbols copied from agent to {dst_filepath}.tar.bz2")
+            else:
+                logging.debug(f"perf-record debug symbols not available")
 
             results.append(
                 LinuxPerfMeasurementResults(

--- a/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/LinuxPerfMeasurementGenerator.py
@@ -6,10 +6,15 @@ from lnst.Recipes.ENRT.MeasurementGenerators.BaseMeasurementGenerator import (
 from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
 from lnst.RecipeCommon.Perf.Measurements import LinuxPerfMeasurement
 from lnst.Common.Parameters import BoolParam
+from lnst.Controller.Host import Host
 
 
 class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
     do_linuxperf_measurement = BoolParam(default=False)
+
+    @property
+    def linuxperf_hosts(self) -> list[Host]:
+        return self.matched
 
     def generate_perf_measurements_combinations(self, config):
         combinations = super().generate_perf_measurements_combinations(config)
@@ -29,7 +34,7 @@ class LinuxPerfMeasurementGenerator(BaseMeasurementGenerator):
 
         for combination in combinations:
             measurement: BaseMeasurement = LinuxPerfMeasurement(
-                hosts=self.matched,
+                hosts=self.linuxperf_hosts,
                 data_folder=linuxperf_data_folder,
                 recipe_conf=config,
             )

--- a/lnst/Recipes/ENRT/VirtualEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/VirtualEnrtRecipe.py
@@ -13,6 +13,8 @@ from lnst.Recipes.ENRT.MeasurementGenerators.FlowMeasurementGenerator import (
 from lnst.Recipes.ENRT.MeasurementGenerators.HypervisorsStatCPUMeasurementGenerator import (
     HypervisorsStatCPUMeasurementGenerator,
 )
+from lnst.Recipes.ENRT.MeasurementGenerators.LinuxPerfMeasurementGenerator import LinuxPerfMeasurementGenerator
+from lnst.Controller.Host import Host
 
 
 class VirtualEnrtRecipe(
@@ -20,6 +22,7 @@ class VirtualEnrtRecipe(
     DisableTurboboostMixin,
     DisableIdleStatesMixin,
     HypervisorsStatCPUMeasurementGenerator,
+    LinuxPerfMeasurementGenerator,
     FlowMeasurementGenerator,
     BaseEnrtRecipe,
 ):
@@ -49,4 +52,8 @@ class VirtualEnrtRecipe(
         :any:`DisableTurboboostMixin` and
         :any:`DisableTurboboostMixin.disable_turboboost_host_list`.
         """
+        return self.hypervisor_hosts
+
+    @property
+    def linuxperf_hosts(self) -> list[Host]:
         return self.hypervisor_hosts

--- a/lnst/Tests/LinuxPerf.py
+++ b/lnst/Tests/LinuxPerf.py
@@ -5,7 +5,7 @@ import os
 from lnst.Tests.BaseTestModule import BaseTestModule
 from lnst.Common.Parameters import StrParam, IntParam, ListParam
 from lnst.Common.Utils import is_installed
-from lnst.Common.ExecCmd import exec_cmd, log_output
+from lnst.Common.ExecCmd import exec_cmd, log_output, ExecCmdFail
 
 class LinuxPerf(BaseTestModule):
     output_file = StrParam(mandatory=True)
@@ -40,8 +40,11 @@ class LinuxPerf(BaseTestModule):
 
         self._res_data["filename"] = os.path.abspath(self.params.output_file)
 
-        exec_cmd(f"HOME=/root perf archive {self._res_data['filename']}")
-        self._res_data["archive_filename"] = self._res_data["filename"] + ".tar.bz2"
+        try:
+            exec_cmd(f"HOME=/root perf archive {self._res_data['filename']}")
+            self._res_data["archive_filename"] = self._res_data["filename"] + ".tar.bz2"
+        except ExecCmdFail:
+            logging.error(f"Could not generate perf archive for {self._res_data['filename']}")
 
         return process.returncode == -2
 


### PR DESCRIPTION
### Description

This enables LinuxPerfMeasurement in virtual recipes.

This also fix an issue when perf archive fails - it is a potential issue noticed in RHEL9.6, however unsuccesful archiving currently results in exception. Missing archived data still can be installed through appropriate debuginfo rpm.

### Tests

J:10794035

### Reviews

@olichtne 