### PR TITLE
docs/installation: add -c10 to ping command

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -99,7 +99,7 @@ A minimal "hello world" example of an executable test script looks like this:
             self.matched.machine2.nic1.ip_add("192.168.1.2/24")
             self.matched.machine2.nic1.up()
 
-            self.matched.machine1.run("ping 192.168.1.2")
+            self.matched.machine1.run("ping 192.168.1.2 -c 10")
 
     ctl = Controller()
     recipe_instance = HelloWorldRecipe()


### PR DESCRIPTION
### Description
Without this the ping command runs forever meaning that it will timeout and be killed from the machine.run command.

This can be confusing for new users.

### Tests
ci is enough