### PR TITLE
TcRunMeasurementResults: rename description to describe

### DIFF
--- a/lnst/RecipeCommon/Perf/Evaluators/MaxTimeTakenEvaluator.py
+++ b/lnst/RecipeCommon/Perf/Evaluators/MaxTimeTakenEvaluator.py
@@ -26,7 +26,7 @@ class MaxTimeTakenEvaluator(BaseResultEvaluator):
         for timed_run in results:
             result_text = [
                 f"MaxTimeTaken evaluation of timed run, max_time={self._max_time}s",
-                timed_run.description,
+                timed_run.describe(),
             ]
             rtype = self._check_interval(timed_run)
 

--- a/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/TcRunMeasurementResults.py
@@ -38,8 +38,7 @@ class TcRunMeasurementResults(BaseMeasurementResults):
     def rule_install_rate(self, result: ParallelPerfResult):
         self._rule_install_rate = result
 
-    @property
-    def description(self):
+    def describe(self):
         return f"{self.device.host.hostid}.{self.device.name}" \
                f" tc run with {self.rule_install_rate.value} rules" \
                f" num_instances={self.measurement.num_instances}" \

--- a/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/TcRunMeasurement.py
@@ -252,7 +252,7 @@ class TcRunMeasurement(BaseMeasurement):
         measurement_result = MeasurementResult(
             "tc",
             result=r_type,
-            description=f"{r_type} {result.description}",
+            description=f"{r_type} {result.describe()}",
             data={"rule_install_rate": result.rule_install_rate},
         )
         recipe.add_custom_result(measurement_result)


### PR DESCRIPTION
### Description
This is for consistency with other MeasurementResults, this should be a method called describe not a property called description. Not sure why it ended up this way...

### Tests
(Please provide a list of tests that prove that the pull
request doesn't break the stable state of the master branch. This should
include test runs with valid results for all of critical workflows.)

### Reviews
(Please add a list of reviewers that should check the validity and sanity of
this merge request before it's accepted. Use the `@username` syntax. If you
don't know who to mention just link `@all`.)

Closes: #
