### PR TITLE
RecipeCommon/Ping/Recipe.py: estimate the ping duration based on interval and count

### DIFF
--- a/lnst/RecipeCommon/Ping/Recipe.py
+++ b/lnst/RecipeCommon/Ping/Recipe.py
@@ -6,7 +6,7 @@ class PingConf(object):
     def __init__(self,
                  client, client_bind,
                  destination, destination_address,
-                 count=None, interval=None, size=None):
+                 count=None, interval=None, size=None, reachable=True,):
         self._client = client
         self._client_bind = client_bind
         self._destination = destination
@@ -15,6 +15,7 @@ class PingConf(object):
         self._interval = interval
         self._size = size
         self._evaluators = list()
+        self._reachable = reachable
 
     @property
     def client(self):
@@ -47,6 +48,10 @@ class PingConf(object):
     @size.setter
     def size(self, value):
         self._size = value
+
+    @property
+    def reachable(self):
+        return self._reachable
 
     @property
     def evaluators(self):

--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -388,6 +388,7 @@ class BaseEnrtRecipe(
                                      count = self.params.ping_count,
                                      interval = self.params.ping_interval,
                                      size = self.params.ping_psize,
+                                     reachable = endpoints.reachable,
                                      )
 
                     ping_evaluators = self.generate_ping_evaluators(


### PR DESCRIPTION
### Description

Negative ping test with count=100 and interval 0.2 can take significantly more that the default timeout of 60 seconds that leads to termination of the ping test and reporting exception.

The patch set fixes this by calculating estimation based on the count and interval parameter. For positive test, the estimate is `(count*interval + 10)` seconds, for negative `(2*count)` seconds.

### Tests

Tested in  beaker job 11332804 

### Reviews

@olichtne 