### PR TITLE
Recipes/ConfigMixins/DisableIdleStatesMixin.py: fix reset condition

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/DisableIdleStatesMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/DisableIdleStatesMixin.py
@@ -52,7 +52,7 @@ class DisableIdleStatesMixin(BaseSubConfigMixin):
 
     def remove_sub_configuration(self, config):
         for host in self.disable_idlestates_host_list:
-            if getattr(self.params, "minimal_idlestates_latency", None):
+            if getattr(self.params, "minimal_idlestates_latency", None) is not None:
                 host.run("cpupower idle-set -E")
 
         return super().remove_sub_configuration(config)


### PR DESCRIPTION
### Description

The value of the parameter can be 0, which means user completely disables idle states and there should be a step to restore the configuration in deconfigure.

Fixes commit 8c16c21cd5dbeccbcb5138a12fd175652bcb432e

### Tests

J:11351754

### Reviews

@enhaut 