### PR TITLE
DevNfcRxFlowHashConfigMixin: disable symmetric hashing

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/DevNfcRxFlowHashConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/DevNfcRxFlowHashConfigMixin.py
@@ -1,3 +1,5 @@
+import logging
+
 from lnst.Common.Parameters import DictParam
 from lnst.Recipes.ENRT.ConfigMixins.BaseHWConfigMixin import BaseHWConfigMixin
 
@@ -25,6 +27,14 @@ class DevNfcRxFlowHashConfigMixin(BaseHWConfigMixin):
                 nfc_config[device][protocol] = {
                     "original": original_flow_hash,
                 }
+
+                if protocol_setting not in {"sd", "fn", "sdfn"}:
+                    logging.info(
+                        f"Selected protocol setting {protocol_setting} requires disabling symmetric hashing: setting xfrm none"
+                    )
+                    device.host.run(
+                        f"ethtool -X {device.name} xfrm none"
+                    )
 
                 device.host.run(
                     f"ethtool -N {device.name} rx-flow-hash {protocol} {protocol_setting}"


### PR DESCRIPTION
### Description
If we're requesting any of the "non-symmetric" hash options we should disable symmetric hashing, otherwise the configuration is considered invalid and may error out.

This is based on an internal discussion investigating a potential regression, it turns out that when symmetric hashing is enabled configuring the `rx-flow-hash` option to use only one of src or dst fields is invalid and not supported.

This is explained in: https://elixir.bootlin.com/linux/v6.16-rc4/source/net/ethtool/ioctl.c#L1021

### Tests
tested via internal beaker job: `J:11347282`

### Reviews
@jtluka 

Closes: #
