### PR TITLE
Eliminate some harmless Error: lines from output

### DIFF
--- a/lnst/Common/ExecCmd.py
+++ b/lnst/Common/ExecCmd.py
@@ -77,7 +77,6 @@ def exec_cmd(cmd, die_on_err=True, log_outputs=True, report_stderr=False, json=F
             log_output(logging.debug, "Stderr", data_stderr)
     if subp.returncode and die_on_err:
         err = ExecCmdFail(cmd, subp.returncode, [data_stdout, data_stderr], report_stderr)
-        logging.error(err)
         raise err
 
     if json:

--- a/lnst/Common/Parameters.py
+++ b/lnst/Common/Parameters.py
@@ -26,8 +26,8 @@ class ParamError(LnstError):
 class Param(object):
     """Base Parameter class
 
-    Can beused to define your own specific parameter type. Param derived classes
-    serve as *type checkers* to enable earlier failure of the recipe.
+    Can be used to define your own specific parameter type. Param derived
+    classes serve as *type checkers* to enable earlier failure of the recipe.
 
     :param mandatory: if `True`, marks the parameter as mandatory
     :type mandatory: bool

--- a/lnst/Devices/Device.py
+++ b/lnst/Devices/Device.py
@@ -1085,9 +1085,11 @@ class Device(object, metaclass=DeviceMeta):
 
     def _get_vf_count(self):
         # TODO: create sysfs api for Device, then run self.[get|set]_sysfs("device/sriov_numvfs")
-        stdout, _ = exec_cmd(f"cat /sys/class/net/{self.name}/device/sriov_numvfs")
-
-        return int(stdout)
+        try:
+            stdout, _ = exec_cmd(f"cat /sys/class/net/{self.name}/device/sriov_numvfs")
+            return int(stdout)
+        except ExecCmdFail:
+            raise DeviceFeatureNotSupported(f"Device {self.name} not SR-IOV capable")
 
     def _get_vf_representor(self, vf_index: int):
         pf_number = int(self.phys_port_name[1:])


### PR DESCRIPTION
Some commands are expected to fail especially with virtual NICs like VETH or loopback. Make sure `exec_cmd()` respects `log_outputs` parameter and pass that as `False` when probing for NIC features. Setters intentionally left untouched so failing deliberate action is not washed away.

The first commit is entirely unrelated, but too trivial to justify a separate PR.