### PR TITLE
Recipes/ENRT/BaseTunnelRecipe.py: print device namespace

### DIFF
--- a/lnst/Recipes/ENRT/BaseTunnelRecipe.py
+++ b/lnst/Recipes/ENRT/BaseTunnelRecipe.py
@@ -103,7 +103,7 @@ class BaseTunnelRecipe(
         """
         desc = super().generate_test_wide_description(config)
         desc += [
-            "Configured {}.{}.ips = {}".format(dev.host.hostid, dev.name, dev.ips)
+            "Configured {}{}.{}.ips = {}".format(dev.host.hostid, f".{dev.netns.name}" if dev.netns.name else "", dev.name, dev.ips)
             for dev in config.configured_devices
         ]
         desc += [


### PR DESCRIPTION
### Description

Includes a network namespace in the test wide description. This is useful for some tests that have multiple devices configured in different namespaces.

For example GeneveOvsNetnsTunnelRecipe:
* before
```
    Testwide configuration for recipe GeneveOvsNetnsTunnelRecipe description:
    Configured host1.ens5f0np0.ips = [Ip4Address(192.168.80.1/24), Ip6Address(fe80::9a03:9bff:fec6:d2a0/64)]
    Configured host2.ens5f0np0.ips = [Ip4Address(192.168.80.2/24), Ip6Address(fe80::9a03:9bff:fec6:d2a4/64)]
    Configured host1.peer_lveth0.ips = [Ip6Address(fe80::b0b5:e3ff:fe66:2178/64), Ip4Address(172.16.10.1/32), Ip6Address(fc00:a::1/128)]
    Configured host2.peer_lveth0.ips = [Ip6Address(fe80::2c3d:18ff:fecb:c72f/64), Ip4Address(172.16.20.1/32), Ip6Address(fc00:b::1/128)]
    Configured host1.peer_lveth0.ips = [Ip6Address(fe80::a815:60ff:fe30:54ad/64), Ip4Address(172.16.10.2/32), Ip6Address(fc00:a::2/128)]
    Configured host2.peer_lveth0.ips = [Ip6Address(fe80::acaf:d8ff:fe7c:7dea/64), Ip4Address(172.16.20.2/32), Ip6Address(fc00:b::2/128)]
```
* after
```
    Testwide configuration for recipe GeneveOvsNetnsTunnelRecipe description:
    Configured host1.enp8s0.ips = [Ip4Address(192.168.101.1/24)]
    Configured host2.enp8s0.ips = [Ip4Address(192.168.101.2/24)]
    Configured host1.subnet0.peer_lveth0.ips = [Ip6Address(fe80::6c01:48ff:fe24:41d7/64), Ip4Address(172.16.10.1/32), Ip6Address(fc00:a::1/128)]
    Configured host2.subnet0.peer_lveth0.ips = [Ip6Address(fe80::cc4:77ff:fe16:5bd3/64), Ip4Address(172.16.20.1/32), Ip6Address(fc00:b::1/128)]
    Configured host1.subnet1.peer_lveth0.ips = [Ip4Address(172.16.10.2/32), Ip6Address(fe80::c46d:8eff:fe5b:f2f3/64), Ip6Address(fc00:a::2/128)]
    Configured host2.subnet1.peer_lveth0.ips = [Ip4Address(172.16.20.2/32), Ip6Address(fc00:b::2/128), Ip6Address(fe80::802:6ff:fe68:1aaa/64)]
```

### Tests

Tested locally with a tunnel test using namespaces and a test without namespaces. CI should cover this.

### Reviews

@olichtne 
