### PR TITLE
HOTFIX: DevNfcRxFlowHashConfigMixin: delete xfrm_original only if defined

### DIFF
--- a/lnst/Recipes/ENRT/ConfigMixins/DevNfcRxFlowHashConfigMixin.py
+++ b/lnst/Recipes/ENRT/ConfigMixins/DevNfcRxFlowHashConfigMixin.py
@@ -78,7 +78,8 @@ class DevNfcRxFlowHashConfigMixin(BaseHWConfigMixin):
                  )
             )
 
-        del config.hw_config["xfrm_original"]
+        if xfrm_original_config:
+            del config.hw_config["xfrm_original"]
 
         super().hw_deconfig(config)
 


### PR DESCRIPTION
### Description
If the dictionary key isn't defined the deletion here would fail with a traceback.

### Tests
CI should be enough.

internal beaker job: `J:11524005`

### Reviews
@jtluka 

Closes: #
