### PR TITLE
Tests/CPUStatMonitor.py: save only relevant lines from /cpu/stat

### DIFF
--- a/lnst/Tests/CPUStatMonitor.py
+++ b/lnst/Tests/CPUStatMonitor.py
@@ -23,7 +23,9 @@ class CPUStatMonitor(BaseTestModule):
                 while True:
                     stat.seek(0)
                     timestamp = time.time()
-                    stat_lines = "".join(stat.readlines())
+                    stat_lines = "".join(
+                        [l for l in stat.readlines() if l.startswith('cpu')]
+                    )
                     raw_samples.append({
                         "timestamp": timestamp,
                         "stat": stat_lines


### PR DESCRIPTION
### Description
Since the only lines processed by the CPUStatMonitor need to start with 'cpu' string, there's no need to save the whole content of the file.

This also resolve issues caused by https://issues.redhat.com/browse/RHEL-114221

### Tests

J:11701353

### Reviews

@olichtne 