### PR TITLE
pyproject.toml: losen restriction on urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ pyyaml = {version = "*", optional = true}
 psutil = "^5.9.4"
 requests = "^2.30.0"
 
-urllib3 = "<2"
 wheel = "^0.45.1"
 
 [tool.poetry.extras]


### PR DESCRIPTION
Check if this is still relevant. This blocks integration with other projects that require higher urllib version.