### PR TITLE
Move `deviation_percentage` to `PerfStatMixin`

### DIFF
--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPBenchMeasurementResults.py
@@ -8,7 +8,7 @@ from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
 class AggregatedXDPBenchMeasurementResults(XDPBenchMeasurementResults):
     def __init__(self, measurement, flow):
         super().__init__(measurement, True, flow)
-        self._individual_results: list[TcRunMeasurementResults] = []
+        self._individual_results: list[XDPBenchMeasurementResults] = []
         self._generator_results = SequentialPerfResult()
         self._receiver_results = SequentialPerfResult()
 

--- a/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/FlowMeasurementResults.py
@@ -122,7 +122,7 @@ class FlowMeasurementResults(BaseMeasurementResults):
             "Generator measured throughput (generator_results): {tput:.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second.".format(
                 tput=generator.average,
                 deviation=generator.std_deviation,
-                percentage=self._deviation_percentage(generator),
+                percentage=generator.deviation_percentage,
                 unit=generator.unit,
             )
         )
@@ -137,7 +137,7 @@ class FlowMeasurementResults(BaseMeasurementResults):
             "Receiver measured throughput (receiver_results): {tput:.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second.".format(
                 tput=receiver.average,
                 deviation=receiver.std_deviation,
-                percentage=self._deviation_percentage(receiver),
+                percentage=receiver.deviation_percentage,
                 unit=receiver.unit,
             )
         )
@@ -149,10 +149,3 @@ class FlowMeasurementResults(BaseMeasurementResults):
             )
         )
         return "\n".join(desc)
-
-    @staticmethod
-    def _deviation_percentage(result):
-        try:
-            return (result.std_deviation / result.average) * 100
-        except ZeroDivisionError:
-            return float("inf") if result.std_deviation >= 0 else float("-inf")

--- a/lnst/RecipeCommon/Perf/Measurements/Results/ForwardingMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/ForwardingMeasurementResults.py
@@ -175,7 +175,7 @@ class ForwardingMeasurementResults(BaseMeasurementResults):
                     "Generator generated (generator_results): {tput:_.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second.".format(
                         tput=gen_results.average,
                         deviation=gen_results.std_deviation,
-                        percentage=self._deviation_percentage(gen_results),
+                        percentage=gen_results.deviation_percentage,
                         unit=gen_results.unit,
                     ).replace("_", " ")
                 )
@@ -185,7 +185,7 @@ class ForwardingMeasurementResults(BaseMeasurementResults):
             "Generator generated (generator_results): {tput:_.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second.".format(
                 tput=generator.average,
                 deviation=generator.std_deviation,
-                percentage=self._deviation_percentage(generator),
+                percentage=generator.deviation_percentage,
                 unit=generator.unit,
             ).replace("_", " ")
         )
@@ -193,7 +193,7 @@ class ForwardingMeasurementResults(BaseMeasurementResults):
             "Receiver processed (receiver_results): {tput:_.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second.".format(
                 tput=receiver.average,
                 deviation=receiver.std_deviation,
-                percentage=self._deviation_percentage(receiver),
+                percentage=receiver.deviation_percentage,
                 unit=receiver.unit,
             ).replace("_", " ")
         )
@@ -201,7 +201,7 @@ class ForwardingMeasurementResults(BaseMeasurementResults):
             "Forwarder RX (forwarder_rx_results): {tput:_.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second.".format(
                 tput=self.forwarder_rx_results.average,
                 deviation=self.forwarder_rx_results.std_deviation,
-                percentage=self._deviation_percentage(self.forwarder_rx_results),
+                percentage=self.forwarder_rx_results.deviation_percentage,
                 unit=self.forwarder_rx_results.unit,
             ).replace("_", " ")
         )
@@ -209,19 +209,12 @@ class ForwardingMeasurementResults(BaseMeasurementResults):
             "Forwarder TX (forwarder_tx_results): {tput:_.2f} +-{deviation:.2f}({percentage:.2f}%) {unit} per second.".format(
                 tput=self.forwarder_tx_results.average,
                 deviation=self.forwarder_tx_results.std_deviation,
-                percentage=self._deviation_percentage(self.forwarder_tx_results),
+                percentage=self.forwarder_tx_results.deviation_percentage,
                 unit=self.forwarder_tx_results.unit,
             ).replace("_", " ")
         )
 
         return "\n".join(desc)
-
-    @staticmethod
-    def _deviation_percentage(result):
-        try:
-            return (result.std_deviation / result.average) * 100
-        except ZeroDivisionError:
-            return float("inf") if result.std_deviation >= 0 else float("-inf")
 
     @property
     def flow(self):

--- a/lnst/RecipeCommon/Perf/Measurements/Results/RDMABandwidthMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/RDMABandwidthMeasurementResults.py
@@ -1,6 +1,6 @@
 from lnst.RecipeCommon.Perf.Measurements.BaseMeasurement import BaseMeasurement
 from lnst.RecipeCommon.Perf.Measurements.Results.BaseMeasurementResults import BaseMeasurementResults
-from lnst.RecipeCommon.Perf.Results import PerfInterval, PerfResult
+from lnst.RecipeCommon.Perf.Results import PerfInterval
 
 
 class RDMABandwidthMeasurementResults(BaseMeasurementResults):
@@ -43,12 +43,5 @@ class RDMABandwidthMeasurementResults(BaseMeasurementResults):
         return "ib_send_bw measured bandwidth: {avg:.2f} +-{stddev:.2f}({percentage:.2f}%) MiB/s.".format(
             avg=bw.average,
             stddev=bw.std_deviation,
-            percentage=self._deviation_percentage(bw),
+            percentage=bw.deviation_percentage,
         )
-
-    @classmethod
-    def _deviation_percentage(cls, result: PerfResult) -> float:
-        try:
-            return (result.std_deviation/result.average) * 100
-        except ZeroDivisionError:
-            return float('inf') if result.std_deviation >= 0 else float("-inf")

--- a/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/XDPBenchMeasurementResults.py
@@ -90,13 +90,19 @@ class XDPBenchMeasurementResults(BaseMeasurementResults):
         desc = []
         desc.append(str(self.flow))
         desc.append(
-            "Generator generated (generator_results): {tput:,f} {unit} per second.".format(
-                tput=generator.average, unit=generator.unit
+            "Generator generated (generator_results): {tput:,f} +-{deviation:,f}({percentage:.2f}%) {unit} per second.".format(
+                tput=generator.average,
+                deviation=generator.std_deviation,
+                percentage=generator.deviation_percentage,
+                unit=generator.unit,
             )
         )
         desc.append(
-            "Receiver processed (receiver_results): {tput:,f} {unit} per second.".format(
-                tput=receiver.average, unit=receiver.unit
+            "Receiver processed (receiver_results): {tput:,f} +-{deviation:,f}({percentage:.2f}%) {unit} per second.".format(
+                tput=receiver.average,
+                deviation=receiver.std_deviation,
+                percentage=receiver.deviation_percentage,
+                unit=receiver.unit,
             )
         )
 

--- a/lnst/RecipeCommon/Perf/Results.py
+++ b/lnst/RecipeCommon/Perf/Results.py
@@ -16,6 +16,13 @@ class PerfStatMixin(object):
     def std_deviation(self):
         return std_deviation([i.average for i in self])
 
+    @property
+    def deviation_percentage(self):
+        try:
+            return (self.std_deviation / self.average) * 100
+        except ZeroDivisionError:
+            return float("inf") if self.std_deviation >= 0 else float("-inf")
+
 class PerfResult(PerfStatMixin):
     @property
     def value(self):


### PR DESCRIPTION
### Description

- Individual result classes often reimplemented `deviation_percentage` method, moved to common `PerfStatMixin`.
- Added stddev print to `XDPBenchMeasurementResults.describe()`:
```
        Generator generated (generator_results): 37,171,086.771299 +-24,195.113819(0.07%) packets per second.
        Receiver processed (receiver_results): 34,839,102.606929 +-346,301.588501(0.99%) packets per second.
```

### Tests
J:12597703