### PR TITLE
Common/ExecCmd.py: handle gracefully terminated commands

### DIFF
--- a/lnst/Common/ExecCmd.py
+++ b/lnst/Common/ExecCmd.py
@@ -62,7 +62,12 @@ def exec_cmd(cmd, die_on_err=True, log_outputs=True, report_stderr=False, json=F
     subp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, stdin=subprocess.PIPE,
                             close_fds=True)
-    (data_stdout, data_stderr) = subp.communicate(input = stdin)
+    try:
+        (data_stdout, data_stderr) = subp.communicate(input = stdin)
+    except KeyboardInterrupt:
+        data_stdout = subp.stdout.read()
+        data_stderr = subp.stderr.read()
+
     data_stdout = data_stdout.decode()
     data_stderr = data_stderr.decode()
 


### PR DESCRIPTION
Resolves the following recipe case:
```
dump = m1.run("tcpdump -i eth0", bg=True)
ctl.wait(2)
dump.kill(signal.SIGINT)
```

The agent would silently discard following error and will not cleanup the Job reference from its state.
```
Process Process-45:
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/lnst/Agent/Job.py", line 107, in _run
    self._job_cls.run()
  File "/usr/local/lib/python3.9/site-packages/lnst/Agent/Job.py", line 238, in run
    stdout, stderr = exec_cmd(self._what["command"], json=self._what["json"])
  File "/usr/local/lib/python3.9/site-packages/lnst/Common/ExecCmd.py", line 65, in exec_cmd
    (data_stdout, data_stderr) = subp.communicate(input = stdin)
  File "/usr/lib64/python3.9/subprocess.py", line 1134, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib64/python3.9/subprocess.py", line 1995, in _communicate
    ready = selector.select(timeout)
  File "/usr/lib64/python3.9/selectors.py", line 416, in select
    fd_event_list = self._selector.poll(timeout)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib64/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.9/site-packages/lnst/Agent/Job.py", line 119, in _run
    result["result"] = job_result
UnboundLocalError: local variable 'job_result' referenced before assignment
```

Controller would report following in cleanup phase:
```
2026-04-21 13:20:49           (host1)        -   ERROR: [Errno 3] No such process
```

The code does not intentionally raise an exception as the keyboard interrupt is typically intentional and graceful termination. So, the stdout and stderr is collected and raising an exception is based on returncode check that is done further in the code.

### Description
(Please provide an overall description of what your Merge request is trying to
do.)

### Tests

J:12626902