### PR TITLE
Recipes/ENRT/LinuxBridgeRecipe.py: add vf_trust_dev_list property

### DIFF
--- a/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
@@ -151,3 +151,7 @@ class LinuxBridgeRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin, SimpleNet
     @property
     def parallel_stream_qdisc_hw_config_dev_list(self):
         return [self.matched.host1.eth0, self.matched.host2.eth0]
+
+    @property
+    def vf_trust_dev_list(self):
+        return [self.matched.host1.eth0, self.matched.host2.eth0]


### PR DESCRIPTION
This is required for `use_vfs=True` + `vf_trust='on'`