### PR TITLE
Enhance ci

### DIFF
--- a/.github/lnst_setup.sh
+++ b/.github/lnst_setup.sh
@@ -32,5 +32,5 @@ git \
 libnl-3-dev
 uv sync --extra containers
 
-#echo Build LNST agents image
-#sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile
+echo Build LNST agents image
+sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile

--- a/.github/lnst_setup.sh
+++ b/.github/lnst_setup.sh
@@ -32,5 +32,5 @@ git \
 libnl-3-dev
 uv sync --extra containers
 
-echo Build LNST agents image
-sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile
+#echo Build LNST agents image
+#sudo -E XDG_RUNTIME_DIR= podman build . -t lnst -f container_files/agent/Dockerfile

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -31,22 +31,29 @@ def get_changed_files():
         # GitHub Actions environment variables
         base_ref = os.environ.get('GITHUB_BASE_REF')  # Set for pull_request events
         event_name = os.environ.get('GITHUB_EVENT_NAME', '')
+        github_workspace = os.environ.get('GITHUB_WORKSPACE')
 
         if base_ref and event_name == 'pull_request':
             # Pull request - compare against base branch
             # Use three-dot diff to compare merge-base with HEAD
             logging.info(f"Detected pull request, comparing with base branch: {base_ref}")
-            result = subprocess.run(
-                ['git', 'diff', '--name-only', f'origin/{base_ref}...HEAD'],
-                capture_output=True,
-                text=True,
-                check=True
-            )
+            try:
+                result = subprocess.run(
+                    ['git', '-C', f'{github_workspace}', 'diff', '--name-only', f'origin/{base_ref}...HEAD'],
+                    capture_output=True,
+                    text=True,
+                    check=True
+                )
+            except subprocess.CalledProcessError as e:
+                logging.info(e.stdout)
+                logging.info(e.stderr)
+                raise
+
         elif event_name == 'push':
             # Push to master - compare with previous commit
             logging.info("Detected push event, comparing with previous commit")
             result = subprocess.run(
-                ['git', 'diff', '--name-only', 'HEAD^', 'HEAD'],
+                ['git', '-C', f'{github_workspace}', 'diff', '--name-only', 'HEAD^', 'HEAD'],
                 capture_output=True,
                 text=True,
                 check=True
@@ -56,14 +63,14 @@ def get_changed_files():
             # Check if HEAD^ exists (at least 2 commits)
             logging.info(f"fallback ... {base_ref} {event_name}")
             check_result = subprocess.run(
-                ['git', 'rev-parse', '--verify', 'HEAD^'],
+                ['git', '-C', f'{github_workspace}', 'rev-parse', '--verify', 'HEAD^'],
                 capture_output=True,
                 check=False
             )
             if check_result.returncode == 0:
                 logging.info("Fallback: comparing with previous commit")
                 result = subprocess.run(
-                    ['git', 'diff', '--name-only', 'HEAD^', 'HEAD'],
+                    ['git', '-C', f'{github_workspace}', 'diff', '--name-only', 'HEAD^', 'HEAD'],
                     capture_output=True,
                     text=True,
                     check=True

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -61,7 +61,6 @@ def get_changed_files():
         else:
             # Fallback: try to detect if we're in a PR or push
             # Check if HEAD^ exists (at least 2 commits)
-            logging.info(f"fallback ... {base_ref} {event_name}")
             check_result = subprocess.run(
                 ['git', '-C', f'{github_workspace}', 'rev-parse', '--verify', 'HEAD^'],
                 capture_output=True,

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -1,5 +1,9 @@
 import inspect
 import logging
+import subprocess
+import sys
+import os
+from pathlib import Path
 
 from lnst.Controller import Controller
 from lnst.Controller.ContainerPoolManager import ContainerPoolManager
@@ -10,6 +14,144 @@ from lnst.Recipes.ENRT.BaseSRIOVNetnsTcRecipe import BaseSRIOVNetnsTcRecipe
 from lnst.Recipes.ENRT.ConfigMixins.OffloadSubConfigMixin import OffloadSubConfigMixin
 
 import lnst.Recipes.ENRT as enrt_recipes
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s'
+)
+
+
+def get_changed_files():
+    """
+    Get list of changed files in the PR or commit.
+    Returns None if detection fails (will run all recipes - conservative approach).
+    """
+    try:
+        # GitHub Actions environment variables
+        base_ref = os.environ.get('GITHUB_BASE_REF')  # Set for pull_request events
+        event_name = os.environ.get('GITHUB_EVENT_NAME', '')
+
+        if base_ref and event_name == 'pull_request':
+            # Pull request - compare against base branch
+            # Use three-dot diff to compare merge-base with HEAD
+            logging.info(f"Detected pull request, comparing with base branch: {base_ref}")
+            result = subprocess.run(
+                ['git', 'diff', '--name-only', f'origin/{base_ref}...HEAD'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+        elif event_name == 'push':
+            # Push to master - compare with previous commit
+            logging.info("Detected push event, comparing with previous commit")
+            result = subprocess.run(
+                ['git', 'diff', '--name-only', 'HEAD^', 'HEAD'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+        else:
+            # Fallback: try to detect if we're in a PR or push
+            # Check if HEAD^ exists (at least 2 commits)
+            check_result = subprocess.run(
+                ['git', 'rev-parse', '--verify', 'HEAD^'],
+                capture_output=True,
+                check=False
+            )
+            if check_result.returncode == 0:
+                logging.info("Fallback: comparing with previous commit")
+                result = subprocess.run(
+                    ['git', 'diff', '--name-only', 'HEAD^', 'HEAD'],
+                    capture_output=True,
+                    text=True,
+                    check=True
+                )
+            else:
+                logging.warning("Could not determine comparison strategy. Running all recipes.")
+                return None
+
+        changed_files = [f.strip() for f in result.stdout.split('\n') if f.strip()]
+
+        if not changed_files:
+            logging.info("No changed files detected")
+
+        return changed_files
+    except Exception as e:
+        logging.warning(f"Could not detect changed files: {e}. Running all recipes.")
+        return None
+
+
+def get_recipe_module_path(recipe_class):
+    """Get the file path of a recipe class relative to repository root."""
+    try:
+        module = inspect.getmodule(recipe_class)
+        if module and hasattr(module, '__file__'):
+            # Convert absolute path to relative path from repo root
+            abs_path = Path(module.__file__).resolve()
+            repo_root = Path(__file__).resolve().parent.parent
+            return str(abs_path.relative_to(repo_root))
+    except Exception:
+        pass
+    return None
+
+
+def get_recipe_dependencies(recipe_class):
+    """
+    Get all classes that this recipe depends on (base classes and mixins).
+    Returns their module paths.
+    """
+    dependencies = set()
+
+    # Get all base classes (MRO - Method Resolution Order)
+    for base in inspect.getmro(recipe_class):
+        if base == object:
+            continue
+        dep_path = get_recipe_module_path(base)
+        if dep_path:
+            dependencies.add(dep_path)
+
+    return dependencies
+
+
+def should_run_recipe(recipe_class, changed_files):
+    """
+    Determine if a recipe should be run based on changed files.
+
+    Returns True if:
+    - changed_files is None (couldn't detect changes, run all)
+    - The recipe's own file was changed
+    - Any of the recipe's dependencies (base classes, mixins) were changed
+    - Core infrastructure was changed (conservative approach)
+    """
+    if changed_files is None:
+        return True
+
+    # Check if any core infrastructure changed (run all tests)
+    core_paths = [
+        'lnst/Controller/',
+        'lnst/Common/',
+        'lnst/RecipeCommon/',
+        'lnst/Devices/',
+        'lnst/Tests/',
+    ]
+
+    for changed_file in changed_files:
+        for core_path in core_paths:
+            if changed_file.startswith(core_path):
+                logging.info(f"Core infrastructure changed ({changed_file}), running all recipes")
+                return True
+
+    # Get all files this recipe depends on
+    recipe_deps = get_recipe_dependencies(recipe_class)
+
+    # Check if any of the recipe's dependencies were changed
+    for changed_file in changed_files:
+        if changed_file in recipe_deps:
+            return True
+
+    return False
+
 
 podman_uri = "unix:///run/podman/podman.sock"
 image_name = "lnst"
@@ -23,8 +165,26 @@ params_base = dict(
     perf_test_simulation=True,
 )
 
+# Check if we should run all recipes regardless of changes
+run_all = '--all' in sys.argv or '--force-all' in sys.argv
+
+# Detect changed files to determine which recipes to run
+if run_all:
+    logging.info("Running all recipes (--all flag specified)")
+    changed_files = None
+else:
+    changed_files = get_changed_files()
+    if changed_files:
+        logging.info(f"Detected {len(changed_files)} changed files")
+        for f in changed_files:
+            logging.info(f"  - {f}")
+    else:
+        logging.info("Running all recipes (could not detect changes)")
+
 i = 0
 recipe_results = {}
+skipped_recipes = []
+
 for recipe_name in dir(enrt_recipes):
     if recipe_name in ["BaseEnrtRecipe", "BaseTunnelRecipe", "BaseLACPRecipe", "DellLACPRecipe", "BaseSRIOVNetnsTcRecipe"]:
         continue
@@ -51,6 +211,12 @@ for recipe_name in dir(enrt_recipes):
         continue
     elif issubclass(recipe, BaseSRIOVNetnsTcRecipe):
         # veth doesn't support sriov
+        continue
+
+    # Check if this recipe should run based on changed files
+    if not should_run_recipe(recipe, changed_files):
+        logging.info(f"Skipping {recipe_name} (not impacted by changes)")
+        skipped_recipes.append(recipe_name)
         continue
 
     i += 1
@@ -116,8 +282,19 @@ for recipe_name in dir(enrt_recipes):
         logging.exception(f"Recipe {recipe_name} crashed with exception.")
         recipe_results[recipe_name] = f"EXCEPTION: {e}"
 
-print("Recipe run results:")
+print("\n" + "="*80)
+print("SUMMARY")
+print("="*80)
+
+if skipped_recipes:
+    print(f"\nSkipped {len(skipped_recipes)} recipes (not impacted by changes):")
+    for recipe_name in sorted(skipped_recipes):
+        print(f"  - {recipe_name}")
+
+print(f"\nRan {len(recipe_results)} recipes:")
 for recipe_name, result in recipe_results.items():
-    print(recipe_name, result)
+    print(f"  {recipe_name}: {result}")
+
+print("="*80)
 
 exit(any(result.startswith("EXCEPTION") for result in recipe_results.values()))

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -54,6 +54,7 @@ def get_changed_files():
         else:
             # Fallback: try to detect if we're in a PR or push
             # Check if HEAD^ exists (at least 2 commits)
+            logging.info(f"fallback ... {base_ref} {event_name}")
             check_result = subprocess.run(
                 ['git', 'rev-parse', '--verify', 'HEAD^'],
                 capture_output=True,

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -39,7 +39,7 @@ def get_changed_files():
             logging.info(f"Detected pull request, comparing with base branch: {base_ref}")
             try:
                 result = subprocess.run(
-                    ['git', '-C', f'{github_workspace}', 'diff', '--name-only', f'origin/{base_ref}...HEAD'],
+                    ['git', '-C', f'{github_workspace}', 'diff', '--name-only', f'origin/{base_ref}..HEAD'],
                     capture_output=True,
                     text=True,
                     check=True

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,6 +43,11 @@ jobs:
     - name: Source branch checkout
       uses: actions/checkout@v4
 
+    - name: Fetch base branch
+      if: github.event_name == 'pull_request'
+      run: |
+        git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: SimpleNetworkRecipe ping test
       run: |
-        sudo env "PATH=$PATH" uv run .github/runner.py
+        sudo -E env "PATH=$PATH" uv run .github/runner.py
 
   ENRT_All_Test:
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
 
     - name: Run all ENRT recipes
       run: |
-        sudo env "PATH=$PATH" uv run .github/runner_all_enrt.py
+        sudo -E env "PATH=$PATH" uv run .github/runner_all_enrt.py
 
   ENRT_PingFlood:
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
 
     - name: Run PingFlood
       run: |
-        sudo env "PATH=$PATH" uv run .github/runner_ping_flood.py
+        sudo -E env "PATH=$PATH" uv run .github/runner_ping_flood.py
 
   ImportsCheck:
     runs-on: ubuntu-latest

--- a/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
+++ b/lnst/Recipes/ENRT/LinuxBridgeRecipe.py
@@ -151,3 +151,7 @@ class LinuxBridgeRecipe(CommonHWSubConfigMixin, OffloadSubConfigMixin, SimpleNet
     @property
     def parallel_stream_qdisc_hw_config_dev_list(self):
         return [self.matched.host1.eth0, self.matched.host2.eth0]
+
+    @property
+    def vf_trust_dev_list(self):
+        return [self.matched.host1.eth0, self.matched.host2.eth0]


### PR DESCRIPTION
Note, this was generated with AI, just checking whether it actually works.

The GitHub Actions CI has been enhanced to run only ENRT recipe tests that are directly impacted by code changes in pull requests and commits. This significantly reduces CI execution time while maintaining comprehensive test coverage.
                                                                                
## Problem Statement                                                            
                                                                                
Previously, the `ENRT_All_Test` job in `.github/workflows/ci-test.yml` ran all ~50+ ENRT recipe tests on every PR and push to master, regardless of what files were changed.                          
