### PR TITLE
lnst/Common/Logs.py: reset export logger between set/unset_recipe

### DIFF
--- a/lnst/Common/Logs.py
+++ b/lnst/Common/Logs.py
@@ -101,7 +101,7 @@ class LoggingCtl:
     agents = {}
     transmit_handler = None
     _id_seq = 0
-    log_list = {}
+    log_list = None
 
     def __init__(self, debug=False, log_dir=None, log_subdir="", colours=True):
         #clear any previously set handlers
@@ -130,11 +130,6 @@ class LoggingCtl:
         self.display_handler = logging.StreamHandler(sys.stdout)
         self.display_handler.setFormatter(MultilineFormatter(colours))
 
-        # the export_handler will add log messages to lists, so it could be exported to .lrc file
-        self.log_list["controller"] = []
-        self.export_handler = self._create_export_handler(self.log_list["controller"], colours)
-        self.export_handler.setLevel(logging.DEBUG)
-
         if not debug:
             self.display_handler.setLevel(logging.INFO)
         else:
@@ -146,7 +141,6 @@ class LoggingCtl:
         logger = logging.getLogger()
         logger.setLevel(logging.NOTSET)
         logger.addHandler(self.display_handler)
-        logger.addHandler(self.export_handler)
 
     def unset_formatter(self):
         self.display_handler.setFormatter(None)
@@ -182,11 +176,21 @@ class LoggingCtl:
         logger.addHandler(recipe_info)
         logger.addHandler(recipe_debug)
 
+        # set the export_handler
+        self.log_list = {}
+        self.log_list["controller"] = []
+        self.export_handler = self._create_export_handler(self.log_list["controller"])
+        self.export_handler.setLevel(logging.DEBUG)
+        logger.addHandler(self.export_handler)
+
     def unset_recipe(self):
         logger = logging.getLogger()
         logger.removeHandler(self.recipe_handlers[0])
         logger.removeHandler(self.recipe_handlers[1])
         self.recipe_handlers = (None, None)
+        logger.removeHandler(self.export_handler)
+        self.export_handler = None
+        self.log_list = None
 
     def add_agent(self, agent_id):
         agent_log_path = os.path.join(self.recipe_log_path, agent_id)

--- a/lnst/Controller/Controller.py
+++ b/lnst/Controller/Controller.py
@@ -179,6 +179,7 @@ class Controller(object):
                     raise
                 finally:
                     self._cleanup_agents()
+                    self._log_ctl.unset_recipe()
         finally:
             if isinstance(self._pools, ContainerPoolManager):
                 self._pools.cleanup()


### PR DESCRIPTION
### Description

Without this the export_handler logger handler would append all recipes executed by a single Controller instance into a shared list.

The export_handler initialization/teardown is moved to set_recipe() and unset_recipe() methods to avoid that.

### Tests

Tested locally with attached script: [test-containers.py](https://github.com/user-attachments/files/27626144/test-containers.py)
```
uv run  ./test-containers.py
```

And then inspecting the log files with another script: [dump-lrc-log.py](https://github.com/user-attachments/files/27626164/dump-lrc-log.py)
```
uv run ./dump-lrc-log.py /tmp/lnst_container_recipe1_run.lrc controller| less
uv run ./dump-lrc-log.py /tmp/lnst_container_recipe2_run.lrc controller| less
```

In the dumped logs, check for `Summary of used Recipe parameters` ... the second dump will include also run from previous recipe (ipv6 AND ipv4).
### Reviews

@olichtne @enhaut @Axonis 