### PR TITLE
Fix XDP cpu eval filter

### DIFF
--- a/lnst/Recipes/ENRT/BaseEnrtRecipe.py
+++ b/lnst/Recipes/ENRT/BaseEnrtRecipe.py
@@ -502,6 +502,16 @@ class BaseEnrtRecipe(
         return evaluators
 
     @property
+    def cpu_perf_evaluation_hosts(self):
+        """Hosts to include in CPU performance evaluation.
+
+        Override to limit CPU evaluation to specific hosts, e.g. only the
+        receiver in an XDP drop test where the generator's aggregate CPU
+        is irrelevant.
+        """
+        return list(self.matched)
+
+    @property
     def cpu_perf_evaluators(self):
         """CPU measurement evaluators
 

--- a/lnst/Recipes/ENRT/XDPDropRecipe.py
+++ b/lnst/Recipes/ENRT/XDPDropRecipe.py
@@ -15,3 +15,7 @@ class XDPDropRecipe(
     # NOTE: Receiver's IRQs needs to be pinned to single CPU (due to test stability)
     # Generator needs to reach line rate, therefore its' IRQ CPUs should not be limited.
     # Simply use `multi_dev_interrupt_config` with single host.
+
+    @property
+    def cpu_perf_evaluation_hosts(self):
+        return [self.matched.host2]

--- a/lnst/Recipes/ENRT/XDPTxRecipe.py
+++ b/lnst/Recipes/ENRT/XDPTxRecipe.py
@@ -15,3 +15,7 @@ class XDPTxRecipe(
     # NOTE: Receiver's IRQs needs to be pinned to single CPU (due to test stability)
     # Generator needs to reach line rate, therefore its' IRQ CPUs should not be limited.
     # Simply use `multi_dev_interrupt_config` with single host.
+
+    @property
+    def cpu_perf_evaluation_hosts(self):
+        return [self.matched.host2]


### PR DESCRIPTION
### Description

XDP recipes (drop, tx) evaluate aggregate CPU utilization on both test hosts. The generator host only pushes traffic toward the receiver - it does not run the XDP program. Because the generator spreads packet transmission across multiple cores while the receiver pins IRQs to a single CPU, their aggregate CPU profiles are very different.

When machines rotate between generator and receiver roles across pipeline runs, the rolling baseline for a given host absorbs values from both roles. This makes the baseline unstable and causes false positive CPU eval detections that have nothing to do with actual XDP performance.

#### Changes

- Add an overridable `cpu_perf_evaluation_hosts` property to `BaseEnrtRecipe` that controls which hosts are included in CPU baseline evaluation. Defaults to all matched hosts, so existing recipes are unaffected.
- Override it in `XDPDropRecipe` and `XDPTxRecipe` to only evaluate CPU on host2 (the receiver), where the XDP workload actually runs.

CPU data is still collected and saved on both hosts - only the evaluation step is scoped to the receiver.


### Tests
TODO - run XDP

### Reviews
@olichtne @enhaut @jtluka 

Closes: #
