### PR TITLE
Extend NftablesRuleScaleRecipe parameterization

### DIFF
--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -97,7 +97,7 @@ for recipe_name in dir(enrt_recipes):
                 "add chain {family} {tablename} otherchain",
                 "add rule {family} {tablename} {chainname} counter"
         ]
-        params["rule"] = "accept"
+        params["rule"] = ["jump otherchain", "accept"]
         params["scale"] = 1
 
     if issubclass(recipe, OffloadSubConfigMixin):

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -93,6 +93,10 @@ for recipe_name in dir(enrt_recipes):
         params["family"] = "ip"
         params["tablename"] = "mytable"
         params["chainname"] = "mychain"
+        params["extras"] = [
+                "add chain {family} {tablename} otherchain",
+                "add rule {family} {tablename} {chainname} counter"
+        ]
         params["rule"] = "accept"
         params["scale"] = 1
 

--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -90,6 +90,9 @@ for recipe_name in dir(enrt_recipes):
         params["perf_tool_cpu"] = [0]
 
     if recipe_name == "NftablesRuleScaleRecipe":
+        params["family"] = "ip"
+        params["tablename"] = "mytable"
+        params["chainname"] = "mychain"
         params["rule"] = "accept"
         params["scale"] = 1
 

--- a/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
+++ b/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
@@ -12,6 +12,18 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
     :any:`chainspec` parameter) which routes test traffic between host1 and a
     local netns.
 
+    :param family:
+        The family to use for the tested ruleset.
+    :type family: :any:`StrParam` (default "inet")
+
+    :param tablename:
+        The name to use for the tested ruleset's table.
+    :type tablename: :any:`StrParam` (default "t")
+
+    :param chainname:
+        The name to use for the tested ruleset's chain.
+    :type chainname: :any:`StrParam` (default "c")
+
     :param chainspec:
         The hook spec of the chain to add rules to.
     :type chainspec: :any:`StrParam` (default "type filter hook forward priority filter")
@@ -31,6 +43,9 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
         'established' and adding the flow.
     :type flowtable: :any:`BoolParam` (default False)
     """
+    family = StrParam(mandatory=False, default="inet")
+    tablename = StrParam(mandatory=False, default="t")
+    chainname = StrParam(mandatory=False, default="c")
     chainspec = StrParam(mandatory=False,
                          default="type filter hook forward priority filter")
     rule = StrParam(mandatory=True)
@@ -39,28 +54,36 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
 
     @property
     def firewall_rulesets_generator(self):
+        family = self.params.get('family')
+        tablename = self.params.get('tablename')
+        chainname = self.params.get('chainname')
         chainspec = self.params.get('chainspec')
         rule = self.params.get('rule')
         scale = self.params.get('scale')
+        f_t_c = f"{family} {tablename} {chainname}"
         ruleset = [
             "flush ruleset",
-            "add table inet t",
-            f"add chain inet t c {{ {chainspec}; }}",
-        ] + [f"add rule inet t c {rule}"] * scale
+            f"add table {family} {tablename}",
+            f"add chain {f_t_c} {{ {chainspec}; }}"
+        ] + [f"add rule {f_t_c} {rule}"] * scale
         if self.params.get('flowtable'):
             devs = f"{self.matched.host2.eth0.name}, {self.matched.host2.pn0.name}"
             ftspec = f"hook ingress priority filter; devices = {{ {devs} }};"
-            ruleset.append(f"add flowtable inet t ft {{ {ftspec} }}")
-            ruleset.append("add rule inet t c ct state established flow add @ft")
+            ruleset.append(f"add flowtable {family} {tablename} ft {{ {ftspec} }}")
+            ruleset.append(f"add rule {f_t_c} ct state established flow add @ft")
         yield { self.matched.host2: "\n".join(ruleset) }
 
     def generate_sub_configuration_description(self, config):
+        family = self.params.get('family')
+        tablename = self.params.get('tablename')
+        chainname = self.params.get('chainname')
         chainspec = self.params.get('chainspec')
         rule = self.params.get('rule')
         scale = self.params.get('scale')
         desc = super().generate_sub_configuration_description(config)
         msg = f"NftablesScale: Ruleset with {scale} times '{rule}'"
-        msg += f" in a chain of '{chainspec}'"
+        msg += f" in a table named '{tablename}' and chain named '{chainname}'"
+        msg += f" with '{chainspec}' in family '{family}'"
         if self.params.get('flowtable'):
             msg += " and a flowtable"
         desc.append(msg)

--- a/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
+++ b/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
@@ -1,6 +1,6 @@
 from lnst.Recipes.ENRT.SimpleNetnsRouterRecipe import SimpleNetnsRouterRecipe
 from lnst.Recipes.ENRT.ConfigMixins.FirewallMixin import NftablesMixin
-from lnst.Common.Parameters import StrParam, IntParam, BoolParam
+from lnst.Common.Parameters import StrParam, ListParam, IntParam, BoolParam
 
 class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
     """
@@ -28,6 +28,12 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
         The hook spec of the chain to add rules to.
     :type chainspec: :any:`StrParam` (default "type filter hook forward priority filter")
 
+    :param extras:
+        Extra nftables commands to run after table and chain creation and
+        before generating the list of rules to test. Use `{family}`, `{tablename}`
+        and `{chainname}` to refer to ruleset elements.
+    :type extras: :any:`ListParam` (default empty)
+
     :param rule:
         The actual rule to insert repeatedly into the router's chain.
     :type rule: :any:`StrParam` representing the nftables rule.
@@ -48,6 +54,7 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
     chainname = StrParam(mandatory=False, default="c")
     chainspec = StrParam(mandatory=False,
                          default="type filter hook forward priority filter")
+    extras = ListParam(mandatory=False, default=[])
     rule = StrParam(mandatory=True)
     scale = IntParam(mandatory=True)
     flowtable = BoolParam(mandatory=False, default=False)
@@ -58,6 +65,7 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
         tablename = self.params.get('tablename')
         chainname = self.params.get('chainname')
         chainspec = self.params.get('chainspec')
+        extras = self.params.get('extras')
         rule = self.params.get('rule')
         scale = self.params.get('scale')
         f_t_c = f"{family} {tablename} {chainname}"
@@ -65,6 +73,9 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
             "flush ruleset",
             f"add table {family} {tablename}",
             f"add chain {f_t_c} {{ {chainspec}; }}"
+        ] + [
+            e.format(family=family, tablename=tablename, chainname=chainname)
+            for e in extras
         ] + [f"add rule {f_t_c} {rule}"] * scale
         if self.params.get('flowtable'):
             devs = f"{self.matched.host2.eth0.name}, {self.matched.host2.pn0.name}"
@@ -78,10 +89,14 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
         tablename = self.params.get('tablename')
         chainname = self.params.get('chainname')
         chainspec = self.params.get('chainspec')
+        extras = self.params.get('extras')
         rule = self.params.get('rule')
         scale = self.params.get('scale')
         desc = super().generate_sub_configuration_description(config)
-        msg = f"NftablesScale: Ruleset with {scale} times '{rule}'"
+        msg = "NftablesScale: Ruleset with"
+        if extras:
+            msg += f" extra commands '{extras}' and"
+        msg += f" {scale} times '{rule}'"
         msg += f" in a table named '{tablename}' and chain named '{chainname}'"
         msg += f" with '{chainspec}' in family '{family}'"
         if self.params.get('flowtable'):

--- a/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
+++ b/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
@@ -8,16 +8,16 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
     routing throughput impact of specific nftables rules. To generate
     meaningful results, the rule is simply repeated multiple times, thereby
     amplifying the impact.
-    Rules are added to host2's forwarding hook which routes test traffic
-    between host1 and a local netns.
+    Rules are added to host2's forwarding hook by default (defined by
+    :any:`chainspec` parameter) which routes test traffic between host1 and a
+    local netns.
 
     :param chainspec:
         The hook spec of the chain to add rules to.
     :type chainspec: :any:`StrParam` (default "type filter hook forward priority filter")
 
     :param rule:
-        The actual rule to insert repeatedly into the router's forwarding
-        chain.
+        The actual rule to insert repeatedly into the router's chain.
     :type rule: :any:`StrParam` representing the nftables rule.
 
     :param scale:

--- a/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
+++ b/lnst/Recipes/ENRT/NftablesRuleScaleRecipe.py
@@ -6,8 +6,8 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
     """
     This recipe combines SimpleNetnsRouterRecipe and NftablesMixin for testing
     routing throughput impact of specific nftables rules. To generate
-    meaningful results, the rule is simply repeated multiple times, thereby
-    amplifying the impact.
+    meaningful results, the list of rules is simply repeated multiple times,
+    thereby amplifying the impact.
     Rules are added to host2's forwarding hook by default (defined by
     :any:`chainspec` parameter) which routes test traffic between host1 and a
     local netns.
@@ -35,8 +35,9 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
     :type extras: :any:`ListParam` (default empty)
 
     :param rule:
-        The actual rule to insert repeatedly into the router's chain.
-    :type rule: :any:`StrParam` representing the nftables rule.
+        The actual list of rules to insert repeatedly into the
+        router's chain.
+    :type rule: :any:`ListParam` representing the nftables rules.
 
     :param scale:
         The number of times to insert :any:`rule` into the ruleset.
@@ -55,7 +56,7 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
     chainspec = StrParam(mandatory=False,
                          default="type filter hook forward priority filter")
     extras = ListParam(mandatory=False, default=[])
-    rule = StrParam(mandatory=True)
+    rule = ListParam(mandatory=True)
     scale = IntParam(mandatory=True)
     flowtable = BoolParam(mandatory=False, default=False)
 
@@ -76,7 +77,7 @@ class NftablesRuleScaleRecipe(SimpleNetnsRouterRecipe, NftablesMixin):
         ] + [
             e.format(family=family, tablename=tablename, chainname=chainname)
             for e in extras
-        ] + [f"add rule {f_t_c} {rule}"] * scale
+        ] + [f"add rule {f_t_c} {r}" for r in rule] * scale
         if self.params.get('flowtable'):
             devs = f"{self.matched.host2.eth0.name}, {self.matched.host2.pn0.name}"
             ftspec = f"hook ingress priority filter; devices = {{ {devs} }};"


### PR DESCRIPTION
Most crucial change is in the last commit which changes 'rule' parameter into ListParam. This allows users to specify multiple rules which are added repeatedly.

The next best thing is in commit three which opens the possibility to add arbitrary ruleset elements, e.g. to test chain jumps with a rule like 'jump mychain'. This requires for that chain to exist and passing 'extras=["add chain {family} {tablename} mychain"]' makes it happen.

To add a bit of convenience to that new 'extras' parameter, parameterize family, table and chain names in commit 2 (not really necessary but a low hanging fruit if one wants to support format strings in 'extras'.

Finally, the first commit fixes up docs after the 'chainspec' enhancement.