### PR TITLE
Recipes: added XDPRedirectCPU recipe

### DIFF
--- a/.github/runner_all_enrt.py
+++ b/.github/runner_all_enrt.py
@@ -82,7 +82,7 @@ for recipe_name in dir(enrt_recipes):
     if recipe_name == "SoftwareRDMARecipe":
         params["software_rdma_type"] = "rxe"
 
-    if recipe_name in ["XDPDropRecipe", "XDPTxRecipe"]:
+    if recipe_name in ["XDPDropRecipe", "XDPTxRecipe", "XDPRedirectCPURecipe"]:
         params["multi_dev_interrupt_config"] = {
             "host1": {"eth0": {"cpus": [0], "cpu_policy": "round-robin"}},
             "host2": {"eth0": {"cpus": [0], "cpu_policy": "round-robin"}},

--- a/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
+++ b/lnst/Controller/RunSummaryFormatters/JsonRunSummaryFormatter.py
@@ -129,6 +129,12 @@ class JsonRunSummaryFormatter(RunSummaryFormatter):
                     "generator_results": result.data["generator_results"].average,
                     "receiver_results": result.data["receiver_results"].average,
                 }
+            elif result.measurement_type == "xdp-redirect-cpu":
+                measurement_data = {
+                    "generator_results": result.data["generator_results"].average,
+                    "receiver_results": result.data["receiver_results"].average,
+                    "forwarded_results": result.data["forwarded_results"].average,
+                }
             elif result.measurement_type == "forwarding":
                 measurement_data = {
                     "generator_results": result.data["generator_results"].average,

--- a/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPRedirectCPUMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/AggregatedXDPRedirectCPUMeasurementResults.py
@@ -1,0 +1,40 @@
+from lnst.RecipeCommon.Perf.Results import SequentialPerfResult
+from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
+from lnst.RecipeCommon.Perf.Measurements.Results.XDPRedirectCPUMeasurementResults import (
+    XDPRedirectCPUMeasurementResults,
+)
+
+
+class AggregatedXDPRedirectCPUMeasurementResults(XDPRedirectCPUMeasurementResults):
+    def __init__(self, measurement, flows):
+        super().__init__(measurement, True, flows)
+        self._individual_results: list[XDPRedirectCPUMeasurementResults] = []
+        self._generator_results = SequentialPerfResult()
+        self._receiver_results = SequentialPerfResult()
+        self._forwarded_results = SequentialPerfResult()
+
+    @property
+    def individual_results(self) -> list[XDPRedirectCPUMeasurementResults]:
+        return self._individual_results
+
+    @property
+    def measurement_success(self) -> bool:
+        if self._individual_results:
+            return all(res.measurement_success for res in self._individual_results)
+        return False
+
+    def add_results(self, results):
+        if results is None:
+            return
+        elif isinstance(results, AggregatedXDPRedirectCPUMeasurementResults):
+            self._individual_results.extend(results.individual_results)
+            self.generator_results.extend(results.generator_results)
+            self.receiver_results.extend(results.receiver_results)
+            self.forwarded_results.extend(results.forwarded_results)
+        elif isinstance(results, XDPRedirectCPUMeasurementResults):
+            self._individual_results.append(results)
+            self.generator_results.append(results.generator_results)
+            self.receiver_results.append(results.receiver_results)
+            self.forwarded_results.append(results.forwarded_results)
+        else:
+            raise MeasurementError("Adding incorrect results.")

--- a/lnst/RecipeCommon/Perf/Measurements/Results/XDPRedirectCPUMeasurementResults.py
+++ b/lnst/RecipeCommon/Perf/Measurements/Results/XDPRedirectCPUMeasurementResults.py
@@ -1,0 +1,147 @@
+from itertools import chain
+
+from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import Flow
+from lnst.RecipeCommon.Perf.Results import ParallelPerfResult
+from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
+from lnst.RecipeCommon.Perf.Measurements.Results.XDPBenchMeasurementResults import (
+    XDPBenchMeasurementResults,
+)
+
+
+class XDPRedirectCPUMeasurementResults(XDPBenchMeasurementResults):
+    """
+    Results container for XDP redirect-cpu measurements.
+
+    Extends :class:`XDPBenchMeasurementResults` with per-CPU receiver stats.
+
+    Metrics:
+
+    - ``generator_results``: :class:`ParallelPerfResult` — pktgen per-flow stats
+    - ``receiver_results``: :class:`ParallelPerfResult` — one
+      :class:`SequentialPerfResult` per target CPU, from xdp-bench
+      ``kthread cpu:N pkt/s`` (packets dequeued by each target CPU's kthread)
+    - ``forwarded_results``: :class:`ParallelPerfResult` — single
+      :class:`SequentialPerfResult` inside, from xdp-bench
+      ``receive total pkt/s`` (packets received and forwarded by the IRQ CPU)
+
+    :param flows: list of individual :class:`Flow` objects covered by this
+        result (one per pktgen instance)
+    """
+
+    def __init__(self, measurement, measurement_success, flows, warmup_duration=0):
+        super().__init__(measurement, measurement_success, None, warmup_duration)
+        self._flows = flows
+        self._forwarded_results = ParallelPerfResult()
+
+    @property
+    def flows(self):
+        return self._flows
+
+    @property
+    def flow(self):
+        first_flow = self._flows[0]
+        generator_cpupins = list(
+            chain.from_iterable(flow.generator_cpupin for flow in self._flows)
+        )
+        receiver_cpupins = list(
+            chain.from_iterable(
+                flow.receiver_cpupin
+                for flow in self._flows
+                if flow.receiver_cpupin
+            )
+        )
+        return Flow(
+            type=first_flow.type,
+            generator=first_flow.generator,
+            generator_bind=first_flow.generator_bind,
+            generator_nic=first_flow.generator_nic,
+            receiver=first_flow.receiver,
+            receiver_bind=None,
+            receiver_nic=first_flow.receiver_nic,
+            receiver_port=None,
+            msg_size=first_flow.msg_size,
+            duration=first_flow.duration,
+            parallel_streams=len(self._flows),
+            generator_cpupin=generator_cpupins,
+            receiver_cpupin=receiver_cpupins or None,
+            aggregated_flow=True,
+            warmup_duration=first_flow.warmup_duration,
+        )
+
+    @property
+    def metrics(self) -> list[str]:
+        return super().metrics + ["forwarded_results"]
+
+    @property
+    def forwarded_results(self) -> ParallelPerfResult:
+        return self._forwarded_results
+
+    @forwarded_results.setter
+    def forwarded_results(self, value: ParallelPerfResult):
+        self._forwarded_results = value
+
+    @property
+    def start_timestamp(self):
+        timestamps = [super().start_timestamp]
+        if self._forwarded_results:
+            timestamps.append(self._forwarded_results.start_timestamp)
+        return min(timestamps)
+
+    @property
+    def end_timestamp(self):
+        timestamps = [super().end_timestamp]
+        if self._forwarded_results:
+            timestamps.append(self._forwarded_results.end_timestamp)
+        return max(timestamps)
+
+    def time_slice(self, start, end) -> "XDPRedirectCPUMeasurementResults":
+        result_copy = XDPRedirectCPUMeasurementResults(
+            self.measurement, self.measurement_success, self._flows, warmup_duration=0
+        )
+        result_copy.generator_results = self.generator_results.time_slice(start, end)
+        result_copy.receiver_results = self.receiver_results.time_slice(start, end)
+        result_copy.forwarded_results = self.forwarded_results.time_slice(start, end)
+        return result_copy
+
+    def add_results(self, results):
+        if results is None:
+            return
+        if isinstance(results, XDPRedirectCPUMeasurementResults):
+            super().add_results(results)
+            self.forwarded_results.extend(results.forwarded_results)
+        else:
+            raise MeasurementError("Adding incorrect results.")
+
+    def describe(self) -> str:
+        generator = self.generator_results
+        receiver = self.receiver_results
+        forwarded = self.forwarded_results
+
+        desc = [str(self.flow)]
+        desc.append(
+            "Generator generated (generator_results): {tput:,f} +-{deviation:,f}({percentage:.2f}%) {unit} per second.".format(
+                tput=generator.average,
+                deviation=generator.std_deviation,
+                percentage=generator.deviation_percentage,
+                unit=generator.unit,
+            )
+        )
+        if forwarded:
+            desc.append(
+                "IRQ CPU forwarded (forwarded_results): {tput:,f} +-{deviation:,f}({percentage:.2f}%) {unit} per second.".format(
+                    tput=forwarded.average,
+                    deviation=forwarded.std_deviation,
+                    percentage=forwarded.deviation_percentage,
+                    unit=forwarded.unit,
+                )
+            )
+        if receiver:
+            desc.append(
+                "Per-CPU received (receiver_results): {tput:,f} +-{deviation:,f}({percentage:.2f}%) {unit} per second.".format(
+                    tput=receiver.average,
+                    deviation=receiver.std_deviation,
+                    percentage=receiver.deviation_percentage,
+                    unit=receiver.unit,
+                )
+            )
+        return "\n".join(desc)

--- a/lnst/RecipeCommon/Perf/Measurements/XDPRedirectCPUMeasurement.py
+++ b/lnst/RecipeCommon/Perf/Measurements/XDPRedirectCPUMeasurement.py
@@ -1,0 +1,307 @@
+import logging
+
+from lnst.Tests.XDPBenchRedirectCpu import XDPBenchRedirectCpu
+from lnst.Tests.PktGen import PktgenController
+from lnst.RecipeCommon.Perf.Results import (
+    PerfInterval,
+    ParallelPerfResult,
+    SequentialPerfResult,
+)
+from lnst.RecipeCommon.Perf.Measurements.BaseFlowMeasurement import (
+    BaseFlowMeasurement,
+    NetworkFlowTest,
+)
+from lnst.RecipeCommon.Perf.Measurements.MeasurementError import MeasurementError
+from lnst.RecipeCommon.Perf.Measurements.Results.XDPRedirectCPUMeasurementResults import (
+    XDPRedirectCPUMeasurementResults,
+)
+from lnst.RecipeCommon.Perf.Measurements.Results.AggregatedXDPRedirectCPUMeasurementResults import (
+    AggregatedXDPRedirectCPUMeasurementResults,
+)
+from lnst.Controller.RecipeResults import MeasurementResult, ResultType
+
+
+class XDPRedirectCPUMeasurement(BaseFlowMeasurement):
+    """
+    Measurement for ``xdp-bench redirect-cpu``.
+
+    Starts a single ``xdp-bench redirect-cpu`` instance on the receiver with
+    all target CPUs as ``-c`` flags, and a multi-flow pktgen instance on the
+    generator.
+
+    One aggregated :class:`XDPRedirectCPUMeasurementResults` is returned per
+    measurement run, covering all flows.
+
+    :param flows: list of :class:`Flow` objects, one per pktgen instance
+    :param cpus: target CPU IDs on the receiver for cpumap redirect
+    :param xdp_program: ``-p`` flag for xdp-bench. Supported: ``l4-dport``
+        (default) and ``l4-sport``. LNST creates multiple flows distinguished
+        by src/dst port, so only port-based programs distribute flows across
+        CPUs correctly.
+    :param xdp_remote_action: ``-r`` flag for xdp-bench (default ``drop``)
+    :param backlog_size: ``-q`` flag, cpumap queue depth per CPU (default 512)
+    :param ratep: pktgen rate limit in pkt/s, -1 for unlimited (default -1)
+    :param burst: pktgen burst size (default 1)
+    """
+
+    def __init__(
+        self,
+        flows,
+        cpus: list[int] = None,
+        xdp_program: str = "l4-dport",
+        xdp_remote_action: str = "drop",
+        backlog_size: int = 512,
+        ratep=-1,
+        burst=1,
+        recipe_conf=None,
+    ):
+        super().__init__(recipe_conf=recipe_conf)
+        _SUPPORTED_PROGRAMS = {"l4-dport", "l4-sport"}
+        if xdp_program not in _SUPPORTED_PROGRAMS:
+            raise MeasurementError(
+                f"xdp_program={xdp_program!r} is not supported. "
+                f"Supported: {sorted(_SUPPORTED_PROGRAMS)}. "
+                "LNST distinguishes flows by src/dst port; only port-based "
+                "programs distribute them across CPUs correctly."
+            )
+        self._flows = flows
+        self._cpus = cpus or []
+        self._xdp_program = xdp_program
+        self._xdp_remote_action = xdp_remote_action
+        self._backlog_size = backlog_size
+        self._ratep = ratep
+        self._burst = burst
+
+        self._generator_job = None
+        self._receiver_job = None
+        self._finished_generator_job = None
+        self._finished_receiver_job = None
+        self._net_flows = []
+
+    @property
+    def flows(self):
+        return self._flows
+
+    def start(self):
+        if not all(
+            flow.receiver_nic == self.flows[0].receiver_nic for flow in self.flows
+        ):
+            raise MeasurementError("All flows must have the same receiver_nic")
+        if not all(flow.generator == self.flows[0].generator for flow in self.flows):
+            raise MeasurementError("Multiple generators are not supported")
+        if not all(flow.duration == self.flows[0].duration for flow in self.flows):
+            raise MeasurementError("All flows must have the same duration")
+        if not all(
+            flow.warmup_duration == self.flows[0].warmup_duration
+            for flow in self.flows
+        ):
+            raise MeasurementError("All flows must have the same warmup duration")
+
+        self._generator_job = self._prepare_client()
+        self._receiver_job = self._prepare_receiver()
+
+        for flow in self.flows:
+            self._net_flows.append(
+                NetworkFlowTest(flow, self._receiver_job, self._generator_job)
+            )
+
+        self._receiver_job.start(bg=True)
+        self._generator_job.start(bg=True)
+
+    def _prepare_receiver(self):
+        sample_flow = self.flows[0]
+        bench = XDPBenchRedirectCpu(
+            interface=sample_flow.receiver_nic,
+            cpus=self._cpus,
+            program=self._xdp_program,
+            remote_action=self._xdp_remote_action,
+            qsize=self._backlog_size,
+            duration=sample_flow.duration + sample_flow.warmup_duration * 2,
+        )
+        return sample_flow.receiver.prepare_job(bench)
+
+    def _prepare_client(self):
+        config = []
+        for flow in self.flows:
+            cpu = flow.generator_cpupin[0] if flow.generator_cpupin else None
+            ratep = (
+                int(self._ratep / self._burst) if self._ratep >= 0 else self._ratep
+            )
+            config.append(
+                {
+                    "src_if": flow.generator_nic,
+                    "dst_mac": flow.receiver_nic.hwaddr,
+                    "src_ip": flow.generator_bind,
+                    "dst_ip": flow.receiver_bind,
+                    "cpu": cpu,
+                    "pkt_size": flow.msg_size,
+                    "duration": flow.duration + flow.warmup_duration * 2,
+                    "src_port": flow.generator_port,
+                    "dst_port": flow.receiver_port,
+                    "ratep": ratep,
+                    "burst": self._burst,
+                }
+            )
+        pktgen = PktgenController(config=config)
+        return self.flows[0].generator.prepare_job(pktgen)
+
+    def finish(self):
+        try:
+            self._generator_job.wait(
+                timeout=self._generator_job.what.runtime_estimate()
+            )
+            self._receiver_job.wait(
+                timeout=self._receiver_job.what.runtime_estimate()
+            )
+        finally:
+            self._generator_job.kill()
+            self._receiver_job.kill()
+
+        self._finished_generator_job = self._generator_job
+        self._finished_receiver_job = self._receiver_job
+        self._generator_job = None
+        self._receiver_job = None
+
+    def collect_results(self):
+        generator_results = self._parse_generator_results()
+        receiver_results, forwarded_results = self._parse_receiver_results()
+
+        flows = [net_flow.flow for net_flow in self._net_flows]
+        warmup_duration = flows[0].warmup_duration if flows else 0
+
+        result = XDPRedirectCPUMeasurementResults(
+            measurement=self,
+            measurement_success=(
+                bool(generator_results)
+                and self._finished_receiver_job is not None
+                and self._finished_receiver_job.passed
+            ),
+            flows=flows,
+            warmup_duration=warmup_duration,
+        )
+        result.generator_results = generator_results
+        result.receiver_results = receiver_results
+        result.forwarded_results = forwarded_results
+
+        self._net_flows = []
+        return [result]
+
+    def _parse_generator_results(self) -> ParallelPerfResult:
+        if not self._finished_generator_job.passed:
+            return ParallelPerfResult()
+
+        results = ParallelPerfResult()
+        for _, raw_results in self._finished_generator_job.result.items():
+            instance_results = SequentialPerfResult()
+            for raw_result in raw_results:
+                instance_results.append(
+                    PerfInterval(
+                        raw_result["packets"],
+                        raw_result["duration"],
+                        "packets",
+                        raw_result["timestamp"],
+                    )
+                )
+            results.append(instance_results)
+        return results
+
+    def _parse_receiver_results(self):
+        """
+        Returns ``(receiver_results, forwarded_results)``:
+
+        - ``receiver_results``: :class:`ParallelPerfResult` with one
+          :class:`SequentialPerfResult` per target CPU (kthread cpu:N pkt/s)
+        - ``forwarded_results``: :class:`ParallelPerfResult` with a single
+          :class:`SequentialPerfResult` (receive total pkt/s, IRQ CPU)
+        """
+        receiver_results = ParallelPerfResult()
+        forwarded_results = ParallelPerfResult()
+
+        if not self._finished_receiver_job or not self._finished_receiver_job.passed:
+            return receiver_results, forwarded_results
+
+        for _ in self._cpus:
+            receiver_results.append(SequentialPerfResult())
+
+        irq_total = SequentialPerfResult()
+
+        for sample in self._finished_receiver_job.result:
+            irq_total.append(
+                PerfInterval(
+                    sample["received"],
+                    sample["duration"],
+                    "packets",
+                    sample["timestamp"],
+                )
+            )
+            for cpu, pkts in sample["forwarded_per_cpu"].items():
+                try:
+                    flow_idx = self._map_cpu_to_flow_id(cpu)
+                except ValueError:
+                    logging.warning(f"Unexpected CPU {cpu} in xdp-bench output, skipping")
+                    continue
+                receiver_results[flow_idx].append(
+                    PerfInterval(
+                        pkts,
+                        sample["duration"],
+                        "packets",
+                        sample["timestamp"],
+                    )
+                )
+
+        forwarded_results.append(irq_total)
+        return receiver_results, forwarded_results
+
+    def _map_cpu_to_flow_id(self, cpu: int) -> int:
+        return self._cpus.index(cpu)
+
+    def _aggregate_flows(self, old_flow, new_flow):
+        if old_flow is None:
+            return new_flow
+
+        if isinstance(old_flow, AggregatedXDPRedirectCPUMeasurementResults):
+            old_flow.add_results(new_flow)
+            return old_flow
+
+        aggregated = AggregatedXDPRedirectCPUMeasurementResults(
+            measurement=self, flows=new_flow.flows
+        )
+        aggregated.add_results(old_flow)
+        aggregated.add_results(new_flow)
+        return aggregated
+
+    @classmethod
+    def report_results(cls, recipe, results):
+        for result in results:
+            generator = result.generator_results
+            receiver = result.receiver_results
+            forwarded = result.forwarded_results
+
+            desc = [result.describe()]
+            recipe_result = ResultType.PASS
+
+            for name, metric in [
+                ("Generator", generator),
+                ("Receiver", receiver),
+                ("Forwarded", forwarded),
+            ]:
+                if cls._invalid_flow_duration(metric):
+                    recipe_result = ResultType.FAIL
+                    desc.append(f"{name} has invalid duration!")
+
+            recipe.add_custom_result(
+                MeasurementResult(
+                    "xdp-redirect-cpu",
+                    result=(
+                        ResultType.PASS
+                        if result.measurement_success and recipe_result == ResultType.PASS
+                        else ResultType.FAIL
+                    ),
+                    description="\n".join(desc),
+                    data={
+                        "generator_results": generator,
+                        "receiver_results": receiver,
+                        "forwarded_results": forwarded,
+                    },
+                )
+            )

--- a/lnst/Recipes/ENRT/MeasurementGenerators/XDPRedirectCPUMeasurementGenerator.py
+++ b/lnst/Recipes/ENRT/MeasurementGenerators/XDPRedirectCPUMeasurementGenerator.py
@@ -1,0 +1,71 @@
+from lnst.Common.Parameters import IntParam, ListParam, StrParam
+from lnst.Recipes.ENRT.MeasurementGenerators.BaseFlowMeasurementGenerator import (
+    BaseFlowMeasurementGenerator,
+)
+from lnst.RecipeCommon.Perf.Measurements.XDPRedirectCPUMeasurement import (
+    XDPRedirectCPUMeasurement,
+)
+
+
+class XDPRedirectCPUMeasurementGenerator(BaseFlowMeasurementGenerator):
+    """
+    Measurement generator mixin for XDP redirect-cpu recipes.
+
+    :param perf_tool_cpu: target CPU IDs on the receiver host for cpumap
+        redirect (mandatory). Also used to pin pktgen threads on the generator
+        host (round-robin). The IRQ CPU must not appear in this list.
+    :type perf_tool_cpu: :any:`ListParam`
+
+    :param ratep: pktgen rate limit in pkt/s, -1 for unlimited (default -1)
+    :type ratep: :any:`IntParam`
+
+    :param burst: pktgen burst size (default 1)
+    :type burst: :any:`IntParam`
+
+    :param backlog_size: cpumap queue depth per CPU, passed as ``-q`` to
+        xdp-bench (default 512)
+    :type backlog_size: :any:`IntParam`
+
+    :param xdp_redirect_program: XDP program variant, passed as ``-p`` to
+        xdp-bench. Supported: ``l4-dport`` (default), ``l4-sport``.
+    :type xdp_redirect_program: :any:`StrParam`
+
+    :param xdp_redirect_remote_action: action after cpumap, passed as ``-r``
+        to xdp-bench (default ``drop``)
+    :type xdp_redirect_remote_action: :any:`StrParam`
+    """
+
+    perf_tool_cpu = ListParam(mandatory=True)
+    ratep = IntParam(default=-1)
+    burst = IntParam(default=1)
+    backlog_size = IntParam(default=512)
+    xdp_redirect_program = StrParam(default="l4-dport")
+    xdp_redirect_remote_action = StrParam(default="drop")
+
+    @property
+    def net_perf_tool_class(self):
+        """
+        Partial application - same pattern as :class:`XDPFlowMeasurementGenerator`.
+        Needed to inject extra params into XDPRedirectCPUMeasurement since
+        BaseFlowMeasurementGenerator calls net_perf_tool_class with a fixed
+        signature. See https://github.com/LNST-project/lnst/pull/310#discussion_r1305763175
+        """
+
+        def _factory(*args, **kwargs):
+            return XDPRedirectCPUMeasurement(
+                *args,
+                cpus=self.params.perf_tool_cpu,
+                xdp_program=self.params.xdp_redirect_program,
+                xdp_remote_action=self.params.xdp_redirect_remote_action,
+                backlog_size=self.params.backlog_size,
+                ratep=self.params.ratep,
+                burst=self.params.burst,
+                **kwargs,
+            )
+
+        return _factory
+
+    def generator_cpupin(self, flow_id: int) -> list[int]:
+        return self._cpupin_based_on_policy(
+            flow_id, self.params.perf_tool_cpu, "round-robin"
+        )

--- a/lnst/Recipes/ENRT/XDPRedirectCPURecipe.py
+++ b/lnst/Recipes/ENRT/XDPRedirectCPURecipe.py
@@ -1,0 +1,101 @@
+import re
+import logging
+
+from lnst.Recipes.ENRT.ConfigMixins.MultiDevInterruptHWConfigMixin import (
+    MultiDevInterruptHWConfigMixin,
+)
+from lnst.Recipes.ENRT.MeasurementGenerators.XDPRedirectCPUMeasurementGenerator import (
+    XDPRedirectCPUMeasurementGenerator,
+)
+from lnst.Recipes.ENRT.SimpleNetworkRecipe import SimpleNetworkRecipe
+from lnst.Recipes.ENRT.BaseEnrtRecipe import EnrtConfiguration
+
+
+class XDPRedirectCPURecipe(
+    MultiDevInterruptHWConfigMixin,
+    XDPRedirectCPUMeasurementGenerator,
+    SimpleNetworkRecipe,
+):
+    """
+    ENRT recipe measuring per-CPU packet throughput via ``xdp-bench
+    redirect-cpu``.
+
+    .. code-block:: none
+
+        +--------+              +--------+
+        | host1  |              | host2  |
+        |  eth0 -+-- switch  ---+- eth0  |
+        | pktgen |              | xdp-bench redirect-cpu |
+        +--------+              +--------+
+
+    host1 sends pktgen flows to host2. host2 runs ``xdp-bench redirect-cpu``
+    with all target CPUs via ``-c`` flags using the ``round-robin`` program,
+    which distributes packets evenly by packet count regardless of flow tuple.
+
+    **host2 configuration applied before traffic:**
+
+    - RSS hash key zeroed via ``ethtool -X`` so the NIC does not spread
+      packets across hardware queues (all IRQs go to one CPU).
+    - ``rxhash`` offload disabled.
+    - NIC IRQs pinned to a single dedicated CPU via
+      ``multi_dev_interrupt_config``. This CPU must not appear in
+      ``perf_tool_cpu``.
+
+    **Recommended parameter setup:**
+
+    - ``perf_tool_cpu``: list of target CPUs on host2, e.g. ``[2, 4, 6]``
+    - ``multi_dev_interrupt_config``: pin host2.eth0 IRQs to one CPU not in
+      ``perf_tool_cpu``
+    """
+
+    def test_wide_configuration(self, config: EnrtConfiguration) -> EnrtConfiguration:
+        config = super().test_wide_configuration(config)
+
+        host2 = self.matched.host2
+        dev = host2.eth0
+
+        self._zero_rss_hash_key(host2, dev, config)
+        host2.run(f"ethtool -K {dev.name} rxhash off")
+
+        return config
+
+    def test_wide_deconfiguration(self, config: EnrtConfiguration):
+        host2 = self.matched.host2
+        dev = host2.eth0
+
+        self._restore_rss_hash_key(host2, dev, config)
+        host2.run(f"ethtool -K {dev.name} rxhash on")
+
+        super().test_wide_deconfiguration(config)
+        return config
+
+    def _zero_rss_hash_key(self, host, dev, config):
+        result = host.run(f"ethtool -x {dev.name}")
+        output = result.stdout
+
+        key_match = re.search(r"RSS hash key:\s*\n((?:[0-9a-fA-F]{2}:?)+)", output)
+        if key_match:
+            original_key = key_match.group(1).strip()
+            key_bytes = original_key.split(":")
+            key_length = len(key_bytes)
+
+            config.rss_original_hash_key = original_key
+
+            zero_key = ":".join(["00"] * key_length)
+            host.run(f"ethtool -X {dev.name} hkey {zero_key}")
+            logging.info(
+                f"Zeroed RSS hash key on {dev.name} (original length: {key_length} bytes)"
+            )
+        else:
+            logging.warning(f"Could not parse RSS hash key from ethtool -x output")
+            config.rss_original_hash_key = None
+
+    def _restore_rss_hash_key(self, host, dev, config):
+        original_key = getattr(config, "rss_original_hash_key", None)
+        if original_key:
+            host.run(f"ethtool -X {dev.name} hkey {original_key}")
+            logging.info(f"Restored RSS hash key on {dev.name}")
+
+    @property
+    def offload_nics(self):
+        return [self.matched.host1.eth0, self.matched.host2.eth0]

--- a/lnst/Recipes/ENRT/__init__.py
+++ b/lnst/Recipes/ENRT/__init__.py
@@ -146,3 +146,4 @@ from lnst.Recipes.ENRT.SimpleNetnsRouterRecipe import SimpleNetnsRouterRecipe
 from lnst.Recipes.ENRT.NftablesRuleScaleRecipe import NftablesRuleScaleRecipe
 from .ForwardingRecipe import ForwardingRecipe
 from .XDPForwardingRecipe import XDPForwardingRecipe
+from .XDPRedirectCPURecipe import XDPRedirectCPURecipe

--- a/lnst/Tests/XDPBench.py
+++ b/lnst/Tests/XDPBench.py
@@ -80,7 +80,6 @@ XDP_BENCH_COMMANDS = (
     "drop",
     "tx",
     "redirect",
-    "redirect-cpu",
     "redirect-map",
     "redirect-multi",
 )
@@ -168,3 +167,4 @@ class XDPBench(BaseTestModule):
 
     def runtime_estimate(self):
         return self.params.duration + 2
+

--- a/lnst/Tests/XDPBench.py
+++ b/lnst/Tests/XDPBench.py
@@ -167,4 +167,3 @@ class XDPBench(BaseTestModule):
 
     def runtime_estimate(self):
         return self.params.duration + 2
-

--- a/lnst/Tests/XDPBenchRedirectCpu.py
+++ b/lnst/Tests/XDPBenchRedirectCpu.py
@@ -1,0 +1,192 @@
+import re
+import time
+import signal
+import logging
+from subprocess import Popen, PIPE
+from threading import Thread
+
+from lnst.Tests.BaseTestModule import BaseTestModule, TestModuleError
+from lnst.Common.Parameters import StrParam, IntParam, DeviceParam, ListParam
+
+
+class XDPBenchRedirectCpuOutputParser:
+    def __init__(self, process: Popen):
+        self._process = process
+        self._raw_samples = []
+        self._capturing_start = 0
+
+    def start_sampling(self):
+        thread = Thread(target=self._capture_output)
+        thread.start()
+        self._capturing_start = time.time()
+
+    def _capture_output(self):
+        try:
+            for sample in iter(self._process.stdout.readline, ""):
+                self._raw_samples.append((time.time(), sample.decode()))
+        except ValueError:
+            pass  # .readline raises when the xdp-bench subprocess is killed
+
+    def parse_output(self) -> list[dict]:
+        _, stderr = self._process.communicate()
+
+        if stderr:
+            logging.error(
+                "xdp-bench redirect-cpu stderr:\n%s",
+                stderr.decode(errors="replace"),
+            )
+
+        results = []
+        blocks = self._split_into_blocks()
+
+        for block_timestamp, block_lines in blocks:
+            try:
+                received, forwarded_per_cpu = self._parse_block(block_lines)
+            except ValueError:
+                logging.error(f"Could not parse block: {block_lines}")
+                continue
+
+            if results:
+                duration = block_timestamp - (
+                    results[-1]["timestamp"] + results[-1]["duration"]
+                )
+            else:
+                duration = block_timestamp - self._capturing_start
+
+            results.append(
+                {
+                    "received": received,
+                    "forwarded_per_cpu": forwarded_per_cpu,
+                    "duration": duration,
+                    "timestamp": block_timestamp - duration,
+                }
+            )
+
+        if not results:
+            raise TestModuleError("Could not get xdp-bench redirect-cpu output")
+
+        return results
+
+    def _split_into_blocks(self) -> list[tuple[float, list[str]]]:
+        blocks = []
+        current_block = []
+        current_timestamp = self._capturing_start
+
+        for timestamp, line in self._raw_samples:
+            if re.match(r"^\S+->", line):
+                if current_block:
+                    blocks.append((current_timestamp, current_block))
+                current_block = [line]
+                current_timestamp = timestamp
+            else:
+                current_block.append(line)
+
+        if current_block:
+            blocks.append((current_timestamp, current_block))
+
+        return blocks
+
+    def _parse_block(self, lines: list[str]) -> tuple[int, dict[int, int]]:
+        """
+        Parse one interval block for receive total and per-CPU kthread counts.
+
+        Returns ``(received, forwarded_per_cpu)`` where ``forwarded_per_cpu``
+        maps ``cpu_id -> pkt/s``.
+
+        Example kthread section::
+
+            kthread total         4,334,231 pkt/s ...
+              cpu:4               2,162,754 pkt/s ...
+              cpu:6               2,171,476 pkt/s ...
+        """
+        received = None
+        forwarded_per_cpu = {}
+        in_kthread_section = False
+
+        for line in lines:
+            if received is None:
+                match = re.search(r"receive\s+total\s+([\d,]+)\s+pkt/s", line)
+                if match:
+                    received = int(match.group(1).replace(",", ""))
+
+            if re.search(r"kthread\s+total\s+[\d,]+\s+pkt/s", line):
+                in_kthread_section = True
+                continue
+
+            if in_kthread_section:
+                cpu_match = re.match(r"\s+cpu:(\d+)\s+([\d,]+)\s+pkt/s", line)
+                if cpu_match:
+                    cpu_id = int(cpu_match.group(1))
+                    pkt_s = int(cpu_match.group(2).replace(",", ""))
+                    forwarded_per_cpu[cpu_id] = pkt_s
+                else:
+                    in_kthread_section = False
+
+        if received is None or not forwarded_per_cpu:
+            raise ValueError("Could not parse received/forwarded from block")
+
+        return received, forwarded_per_cpu
+
+
+class XDPBenchRedirectCpu(BaseTestModule):
+    """
+    ``xdp-bench redirect-cpu`` test module.
+
+    Runs ``xdp-bench redirect-cpu`` on the given interface, redirecting packets
+    to cpumap queues on the specified target CPUs.
+
+    xdp-bench must be shut down with SIGINT — SIGKILL leaves the XDP program
+    attached to the NIC.
+
+    :param interface: NIC to attach XDP program to
+    :param cpus: target CPU IDs for cpumap redirect (mandatory)
+    :param program: ``-p`` flag — supported: ``l4-dport`` (default),
+        ``l4-sport``
+    :param qsize: ``-q`` flag, cpumap queue depth per CPU (default 512)
+    :param remote_action: ``-r`` flag (default ``drop``)
+    :param interval: stats reporting interval in seconds (default 1)
+    :param duration: how long to run in seconds (default 60)
+    """
+
+    interface = DeviceParam(mandatory=True)
+    cpus = ListParam(mandatory=True)
+    program = StrParam(default="l4-dport")
+    qsize = IntParam(default=512)
+    remote_action = StrParam(default="drop")
+    interval = IntParam(default=1)
+    duration = IntParam(default=60, mandatory=True)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._res_data = []
+
+    def run(self):
+        command = self._prepare_command()
+        logging.debug(f"Starting xdp-bench redirect-cpu: `{command}`")
+
+        bench = Popen(command, stdout=PIPE, stderr=PIPE)
+        output_parser = XDPBenchRedirectCpuOutputParser(bench)
+        output_parser.start_sampling()
+        time.sleep(self.params.duration)
+
+        bench.send_signal(signal.SIGINT)  # must be SIGINT to detach XDP program
+
+        self._res_data = output_parser.parse_output()
+        return True
+
+    def _prepare_command(self):
+        args = ["xdp-bench", "redirect-cpu", self.params.interface.name]
+
+        for cpu in self.params.cpus:
+            args.extend(["-c", str(cpu)])
+
+        args.extend(["-p", self.params.program])
+        args.extend(["-r", self.params.remote_action])
+        args.extend(["-i", str(self.params.interval)])
+        args.extend(["-q", str(self.params.qsize)])
+        args.append("-e")  # extended stats required for per-CPU kthread output
+
+        return args
+
+    def runtime_estimate(self):
+        return self.params.duration + 2


### PR DESCRIPTION
### Description
Adding `XDPRedirectCPU` recipe that benchmarks redirecting packets between CPUs using XDP. We only support `l4-dhash` because we need to spread packets to separate cpus. LNST generates multiple flows with the same IP but src/dst port differs and only `l4-{s,d}port` program supports src/dst port hashing and so, spreading between cpus.


This also extends `XDPBench.py` but we need to have separate classes handling `xdp-bench redirect-cpu`, it uses a completely different output format...


#### Results structure
`XDPRedirectCpuMeasurement` returns **single** result object with following structure. It's similar to what forwarding recipes return. It cannot return multiple results - one per flow (the same way as iperf measurements does) as `xdp-bench` returns stats aggregated per receiver cpu. It actually spreads flows to separate cpus but this solely depends on `xdp-bench` so we don't know what cpu is handling what flow. Therefore, it returns single, aggregated result.
```
generator_results:
SequentialPerfResult (5 runs)         # iterations
    ParallelPerfResult (4 streams)    # pktgen threads
        SequentialPerfResult               # intervals
            PerfInterval (60)

receiver_results:
SequentialPerfResult (5 runs)         # iterations
    ParallelPerfResult (4 CPUs)        # one per target CPU in cpumap
        SequentialPerfResult               # intervals
            PerfInterval (60)

forwarded_results:
SequentialPerfResult (5 runs)         # iterations
    ParallelPerfResult (1)                   # single receive IRQ CPU
        SequentialPerfResult               # intervals
            PerfInterval (60)
```


### Tests
`J:13005666`
